### PR TITLE
Implement MP-BGP for IPv6 announcements

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -418,13 +418,6 @@ func (s *Session) Set(advs ...*Advertisement) error {
 
 	newAdvs := map[string]*Advertisement{}
 	for _, adv := range advs {
-		if adv.Prefix.IP.To4() == nil {
-			return fmt.Errorf("cannot advertise non-v4 prefix %q", adv.Prefix)
-		}
-
-		if adv.NextHop != nil && adv.NextHop.To4() == nil {
-			return fmt.Errorf("next-hop must be IPv4, got %q", adv.NextHop)
-		}
 		if len(adv.Communities) > 63 {
 			return fmt.Errorf("max supported communities is 63, got %d", len(adv.Communities))
 		}

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -210,7 +210,11 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 func (c *bgpController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool *config.Pool) error {
 	c.svcAds[name] = nil
 	for _, adCfg := range pool.BGPAdvertisements {
-		m := net.CIDRMask(adCfg.AggregationLength, 32)
+		m := net.CIDRMask(128, 128)
+		isIPv6 := lbIP.To4() == nil
+		if !isIPv6 {
+			m = net.CIDRMask(adCfg.AggregationLength, 32)
+		}
 		ad := &bgp.Advertisement{
 			Prefix: &net.IPNet{
 				IP:   lbIP.Mask(m),


### PR DESCRIPTION
A basic implementation of MP-BGP for just IPv6 announcements. This allows IPv6 service addresses to be announced using BGP.

I've tried to keep the implementation as simple as possible and have only done MP-BGP for IPv6. I tried to avoid touching the IPv4 codepath.

Todo:
- [ ] IPv6 withdraw