### PR TITLE
Allow pools dedicated to k8s namespaces in the controller

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ type selectorRequirements struct {
 type addressPool struct {
 	Protocol          Proto
 	Name              string
+	Namespace         string
 	Addresses         []string
 	AvoidBuggyIPs     bool               `yaml:"avoid-buggy-ips"`
 	AutoAssign        *bool              `yaml:"auto-assign"`
@@ -129,6 +130,9 @@ type Pool struct {
 	// If false, prevents IP addresses to be automatically assigned
 	// from this pool.
 	AutoAssign bool
+	// If not empty IP addresses from this pool will only be assigned
+	// to services with this namespace.
+	Namespace string
 	// When an IP is allocated from this pool, how should it be
 	// translated into BGP announcements?
 	BGPAdvertisements []*BGPAdvertisement
@@ -311,6 +315,7 @@ func parseAddressPool(p addressPool, bgpCommunities map[string]uint32) (*Pool, e
 		Protocol:      p.Protocol,
 		AvoidBuggyIPs: p.AvoidBuggyIPs,
 		AutoAssign:    true,
+		Namespace:     p.Namespace,
 	}
 
 	if p.AutoAssign != nil {


### PR DESCRIPTION
This PR partially implements https://github.com/danderson/metallb/issues/383. Only loadBalancer address allocation is considered, i.e only "controller" code is affected.

The configuration now allows a new "namespace" parameter for pools;
```
  config: |
    address-pools:
    - name: app001
      namespace: app001
      protocol: layer2
      addresses:
      - 1000::1:0/124
      - 10.0.1.0/28
    - name: default
      protocol: layer2
      addresses:
      - 1000::/124
      - 10.0.0.0/28
```
In the example services in the "app001" namespace will *only* get addresses from the "app001" (even if free addresses are available in the "default" pool).

Services in namespaces without any dedicated pool will get addresses from the "default" pool (never from the "app001" pool).

The `Allocator` has a new "nspools" field;
```go
type Allocator struct {
	pools map[string]*config.Pool

	allocated       map[string]*alloc          // svc -> alloc
	sharingKeyForIP map[string]*key            // ip.String() -> assigned sharing key
	portsInUse      map[string]map[Port]string // ip.String() -> Port -> svc
	servicesOnIP    map[string]map[string]bool // ip.String() -> svc -> allocated?
	poolIPsInUse    map[string]map[string]int  // poolName -> ip.String() -> number of users
	poolServices    map[string]int             // poolName -> #services
	nspools         map[string][]string        // namespace -> poolNames
}
```
Pools with the "namespace" attribute set are added to this map. The lenght of the map is used as "feature-gate" in the code;
```
    if len(nspools) > 0 {
        // Do namespace related stuff...
    }
```
This ensures that existing setups not using this new feature are not affected.

The `nspools` maps to a slice of pool-names but this list is currently not used, only the existence of pools dedicated to a namespace is checked.