### PR TITLE
Address Pool with node selector filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ e2etest/initrd.img
 e2etest/*.qcow2
 e2etest/e2etest
 e2etest-cached-universe
+.idea

--- a/e2etest/manifests/mirror-server.yaml
+++ b/e2etest/manifests/mirror-server.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: default

--- a/manifests/example-layer2-filter.yaml
+++ b/manifests/example-layer2-filter.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: my-ip-space
+      protocol: layer2
+      addresses:
+      - 192.168.5.240/28
+      node-selectors:
+      - match-labels:
+          metallb.universe.tf/rack: test1
+    - name: my-ip-space2
+      protocol: layer2
+      addresses:
+      - 192.168.5.224/28
+      node-selectors:
+      - match-labels:
+          metallb.universe.tf/rack: test2


### PR DESCRIPTION
In our infrastructure it will be two networks (internal and public), only some nodes will have access to the public network and this scenario was not covered by metallb.

I have implemented such using node-selectors in address pools.
In some complex scenario I think this would be useful for the community.

I have added an example in manifests/example-layer2-filter.yaml
```apiVersion: v1
kind: ConfigMap
metadata:
  namespace: metallb-system
  name: config
data:
  config: |
    address-pools:
    - name: my-ip-space
      protocol: layer2
      addresses:
      - 192.168.5.240/28
      node-selectors:
      - match-labels:
          metallb.universe.tf/rack: test1
    - name: my-ip-space2
      protocol: layer2
      addresses:
      - 192.168.5.224/28
      node-selectors:
      - match-labels:
          metallb.universe.tf/rack: test2
```
This implementation is practically identical to the BGP node-selectors.
