### PR TITLE
modify kustomization.yaml

### DIFF
--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - metallb.yaml
+  - namespace.yaml

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app: metallb
-  name: metallb-system
----
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
Metallb is now using `kustomize` to generate Kubernetes resource files since [v0.8.3](https://metallb.universe.tf/release-notes/#version-0-8-3)

I noticed that in the manifest directory both `namespace.yaml` and `metallb.yaml` contain the same namespace resource, but `metallb.yaml` does not need the namespace resource if `kustomization.yaml` merge both files.

It does not only reduce codes but also beneficial for the users who want to use `metallb` resources in a different namespace. 
(They do not need to edit the upsteam yaml file and only need to edit `kustomization.yaml`)

Therefore, this pull request made the following changes.
- delete namespace resource from `metallb.yaml`
- modify `kustomization.yaml` to  merge `metallb.yaml` and `namespace.yaml`
 
