### PR TITLE
Fix layer2 not arping when IP changes

### DIFF
--- a/speaker/main.go
+++ b/speaker/main.go
@@ -31,7 +31,7 @@ import (
 	"go.universe.tf/metallb/internal/layer2"
 	"go.universe.tf/metallb/internal/logging"
 	"go.universe.tf/metallb/internal/version"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	gokitlog "github.com/go-kit/kit/log"
 	"github.com/hashicorp/memberlist"
@@ -303,6 +303,12 @@ func (c *controller) SetBalancer(l gokitlog.Logger, name string, svc *v1.Service
 
 	if proto, ok := c.announced[name]; ok && proto != pool.Protocol {
 		if st := c.deleteBalancer(l, name, "protocolChanged"); st == k8s.SyncStateError {
+			return st
+		}
+	}
+
+	if svcIP, ok := c.svcIP[name]; ok && !lbIP.Equal(svcIP) {
+		if st := c.deleteBalancer(l, name, "loadBalancerIPChanged"); st == k8s.SyncStateError {
 			return st
 		}
 	}


### PR DESCRIPTION
Fixed https://github.com/metallb/metallb/issues/471

I noticed that SetBalancer in Announcer.go essentially short circuits if the load balancer is already set. I also saw that it was cached in main.go of the speaker for the service.

So to fix this, I just deleted the existing balancer for the service and allowed it to fall through and create a new one with the new IP.