### PR TITLE
Update dev environment

### DIFF
--- a/e2etest/manifests/mirror-server.yaml
+++ b/e2etest/manifests/mirror-server.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: default

--- a/e2etest/manifests/mirror-server.yaml
+++ b/e2etest/manifests/mirror-server.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mirror
-        image: metallb/mirror-server:master
+        image: metallb/mirror-server:main
         env:
         - name: NODE_NAME
           valueFrom:

--- a/tasks.py
+++ b/tasks.py
@@ -211,7 +211,22 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None):
             f.write(manifest)
             f.flush()
 
+        # Create memberlist secret.
+        secret = """---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: memberlist
+  namespace: metallb-system
+stringData:
+  secretkey: verysecurelol"""
+
+        with open(tmpdir + "/secret.yaml", "w") as f:
+            f.write(secret)
+            f.flush()
+
         run("kubectl apply -f {}/namespace.yaml".format(tmpdir), echo=True)
+        run("kubectl apply -f {}/secret.yaml".format(tmpdir), echo=True)
         run("kubectl apply -f {}/metallb.yaml".format(tmpdir), echo=True)
 
     with open("e2etest/manifests/mirror-server.yaml") as f:

--- a/tasks.py
+++ b/tasks.py
@@ -187,10 +187,8 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None):
             tmp.flush()
             run("kind create cluster --name={} --config={}".format(name, tmp.name), pty=True, echo=True)
 
-    config = run("kind get kubeconfig-path --name={}".format(name), hide=True).stdout.strip()
-    env = {"KUBECONFIG": config}
     if mk_cluster and cni:
-        run("kubectl apply -f e2etest/manifests/{}.yaml".format(cni), echo=True, env=env)
+        run("kubectl apply -f e2etest/manifests/{}.yaml".format(cni), echo=True)
 
     build(ctx, binaries=["controller", "speaker", "mirror-server"], architectures=[architecture])
     run("kind load docker-image --name={} metallb/controller:dev-{}".format(name, architecture), echo=True)
@@ -205,7 +203,7 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None):
     with tempfile.NamedTemporaryFile() as tmp:
         tmp.write(manifest.encode("utf-8"))
         tmp.flush()
-        run("kubectl apply -f {}".format(tmp.name), echo=True, env=env)
+        run("kubectl apply -f {}".format(tmp.name), echo=True)
 
     with open("e2etest/manifests/mirror-server.yaml") as f:
         manifest = f.read()
@@ -213,14 +211,7 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None):
     with tempfile.NamedTemporaryFile() as tmp:
         tmp.write(manifest.encode("utf-8"))
         tmp.flush()
-        run("kubectl apply -f {}".format(tmp.name), echo=True, env=env)
-
-    print("""
-
-To access the cluster:
-
-export KUBECONFIG={}
-""".format(config))
+        run("kubectl apply -f {}".format(tmp.name), echo=True)
 
 @task
 def test_cni_manifests(ctx):

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -105,8 +105,13 @@ To develop MetalLB, you'll need a couple of pieces of software:
   tool)
 - [Docker](https://www.docker.com/docker-community), the container
   running system
+- [kind](https://github.com/kubernetes-sigs/kind), a lightweight Kubernetes cluster running in Docker
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/), the Kubernetes commandline interface
 - [Invoke](https://www.pyinvoke.org) to drive the build system
+
+>NOTE: The development environment was tested with **kind `v0.7.0`**. Older
+>versions may not work since there have been breaking changes between minor
+>versions.
 
 ## Building the code
 
@@ -115,6 +120,9 @@ https://github.com/danderson/metallb`.
 
 From there, you can use Invoke to build Docker images, push them to
 registries, and so forth. `inv -l` lists the available tasks.
+
+To build and deploy MetalLB to a local development environment using a kind
+cluster, run `inv dev-env`.
 
 For development, fork
 the [github repository](https://github.com/google/metallb), and add


### PR DESCRIPTION
Fixes https://github.com/metallb/metallb/issues/552.

This PR updates the dev environment following recent changes to the MetalLB code and k8s manifests. It also updates `tasks.yaml` for kind `v0.7.0`.

To test the PR, ensure you have kind `v0.7.0` installed, then run `inv dev-env`.

P.S. Should we mention the kind dependency in the docs somewhere? I had to guess the required version in order to get `inv dev-env` to work...