### PR TITLE
update Installation by manifest script

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -45,6 +45,7 @@ Note, you don't need this if you're using kube-router as service-proxy because i
 To install MetalLB, apply the manifest:
 
 ```shell
+kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/namespace.yaml
 kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/metallb.yaml
 # On first install only
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"


### PR DESCRIPTION
since v9.0 because of kustomize "metallb.yaml" doesn't have namespace spec
before apply metallb.yaml should apply namespace.yaml first
Installation page is for new user and someone just copy and paste tutorial
before v9.0 tutorial works fine
after v9.0 user will see namespace not found error
please check my PR