### PR TITLE
Update repository urls

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Thanks for sending a pull request! A few things before we get started:
 
 1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
 2. For non-trivial pull requests, please [file an
-   issue](https://github.com/google/metallb/issues/new) first, and get
+   issue](https://github.com/metallb/metallb/issues/new) first, and get
    agreement that the change is a good idea, and a general guideline
    for how it should be implemented, before sending code. Large PRs
    that weren't first discussed and agreed upon in an issue won't be

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MetalLB is a load-balancer implementation for bare
 metal [Kubernetes](https://kubernetes.io) clusters, using standard
 routing protocols.
 
-[![Project maturity: beta](https://img.shields.io/badge/maturity-beta-orange.svg)](https://metallb.universe.tf/concepts/maturity/) [![license](https://img.shields.io/github/license/google/metallb.svg?maxAge=2592000)](https://github.com/google/metallb/blob/main/LICENSE) [![CircleCI](https://img.shields.io/circleci/project/github/google/metallb.svg)](https://circleci.com/gh/google/metallb) [![Containers](https://img.shields.io/badge/containers-ready-green.svg)](https://hub.docker.com/u/metallb) [![Go report card](https://goreportcard.com/badge/github.com/google/metallb)](https://goreportcard.com/report/github.com/google/metallb)
+[![Project maturity: beta](https://img.shields.io/badge/maturity-beta-orange.svg)](https://metallb.universe.tf/concepts/maturity/) [![license](https://img.shields.io/github/license/metallb/metallb.svg?maxAge=2592000)](https://github.com/metallb/metallb/blob/main/LICENSE) [![CircleCI](https://img.shields.io/circleci/project/github/metallb/metallb.svg)](https://circleci.com/gh/metallb/metallb) [![Containers](https://img.shields.io/badge/containers-ready-green.svg)](https://hub.docker.com/u/metallb) [![Go report card](https://goreportcard.com/badge/github.com/metallb/metallb)](https://goreportcard.com/report/github.com/metallb/metallb)
 
 Check out [MetalLB's website](https://metallb.universe.tf) for more
 information.
@@ -21,7 +21,7 @@ a [code of conduct](https://metallb.universe.tf/community/code-of-conduct/).
 
 One lightweight way you can contribute is
 to
-[tell us that you're using MetalLB](https://github.com/google/metallb/issues/5),
+[tell us that you're using MetalLB](https://github.com/metallb/metallb/issues/5),
 which will give us warm fuzzy feelings :).
 
 # Reporting security issues

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -224,7 +224,7 @@ type controllerConfig struct {
 	MList  *memberlist.Memberlist
 
 	// For testing only, and will be removed in a future release.
-	// See: https://github.com/google/metallb/issues/152.
+	// See: https://github.com/metallb/metallb/issues/152.
 	DisableLayer2 bool
 }
 

--- a/tasks.py
+++ b/tasks.py
@@ -305,9 +305,9 @@ def release(ctx, version, skip_release_notes=False):
         newpat = pattern.format("v{}").format(version)
         run("perl -pi -e 's#{}#{}#g' website/content/*.md website/content/*/*.md".format(oldpat, newpat),
             echo=True)
-    _replace("/google/metallb/{}")
-    _replace("/google/metallb/tree/{}")
-    _replace("/google/metallb/blob/{}")
+    _replace("/metallb/metallb/{}")
+    _replace("/metallb/metallb/tree/{}")
+    _replace("/metallb/metallb/blob/{}")
 
     # Update the version listed on the website sidebar
     run("perl -pi -e 's/MetalLB .*/MetalLB v{}/g' website/content/_header.md".format(version), echo=True)

--- a/website/config.toml
+++ b/website/config.toml
@@ -7,7 +7,7 @@ theme = "docdock"
 
 [params]
 	# General information
-    editURL = "https://github.com/google/metallb/edit/main/website/content/"
+    editURL = "https://github.com/metallb/metallb/edit/main/website/content/"
 	description = "MetalLB, bare metal load-balancer for Kubernetes"
     disableNavChevron = true
 
@@ -17,7 +17,7 @@ home = ["HTML", "RSS", "JSON"]
 [[menu.shortcuts]]
 pre = "<hr>"
 name = "<i class='fa fa-github'></i> Github repo"
-url = "https://github.com/google/metallb"
+url = "https://github.com/metallb/metallb"
 weight = 10
 
 [[menu.shortcuts]]
@@ -32,5 +32,5 @@ weight = 30
 
 [[menu.shortcuts]]
 name = "<i class='fa fa-copyright'></i> License"
-url = "https://github.com/google/metallb/blob/main/LICENSE"
+url = "https://github.com/metallb/metallb/blob/main/LICENSE"
 weight = 40

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -67,5 +67,5 @@ information.
 
 One lightweight way you can contribute is
 to
-[tell us that you're using MetalLB](https://github.com/google/metallb/issues/5),
+[tell us that you're using MetalLB](https://github.com/metallb/metallb/issues/5),
 which will give us warm fuzzy feelings :).

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -30,7 +30,7 @@ if you don't already have an IRC client.
 ## Issue Tracker
 
 Use the [GitHub issue
-tracker](https://github.com/google/metallb/issues) to file bugs and
+tracker](https://github.com/metallb/metallb/issues) to file bugs and
 features request. If you need support, please send your questions to
 the metallb-users mailing list rather than filing a GitHub issue.
 
@@ -116,7 +116,7 @@ To develop MetalLB, you'll need a couple of pieces of software:
 ## Building the code
 
 Start by fetching the MetalLB repository, with `git clone
-https://github.com/danderson/metallb`.
+https://github.com/metallb/metallb`.
 
 From there, you can use Invoke to build Docker images, push them to
 registries, and so forth. `inv -l` lists the available tasks.
@@ -125,7 +125,7 @@ To build and deploy MetalLB to a local development environment using a kind
 cluster, run `inv dev-env`.
 
 For development, fork
-the [github repository](https://github.com/google/metallb), and add
+the [github repository](https://github.com/metallb/metallb), and add
 your fork as a remote in `$GOPATH/src/go.universe.tf/metallb`, with
 `git remote add fork git@github.com:<your-github-user>/metallb.git`.
 

--- a/website/content/concepts/layer2.md
+++ b/website/content/concepts/layer2.md
@@ -62,7 +62,7 @@ During an unplanned failover, the service IPs will be unreachable until the
 buggy clients refresh their cache entries.
 
 If you encounter a situation where layer 2 mode failover is slow (more than
-about 10s), please [file a bug](https://github.com/google/metallb/issues/new)!
+about 10s), please [file a bug](https://github.com/metallb/metallb/issues/new)!
 We can help you investigate and determine if the issue is with the client, or a
 bug in MetalLB.
 

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -8,7 +8,7 @@ creating and deploying a configmap into the same namespace
 (metallb-system) as the deployment.
 
 There is an example configmap in
-[`manifests/example-config.yaml`](https://raw.githubusercontent.com/google/metallb/main/manifests/example-config.yaml),
+[`manifests/example-config.yaml`](https://raw.githubusercontent.com/metallb/metallb/main/manifests/example-config.yaml),
 annotated with explanatory comments.
 
 If you've named the configmap `config.yaml`, you can deploy the manifest with `kubectl apply -f config.yaml`.

--- a/website/content/configuration/calico.md
+++ b/website/content/configuration/calico.md
@@ -206,7 +206,7 @@ graph BT
 While this should theoretically work, it hasn't been demonstrated, and
 setting it up varies wildly based on which routing software/hardware
 you are interfacing with. If you get this working,
-please [let us know](https://github.com/google/metallb/issues/new),
+please [let us know](https://github.com/metallb/metallb/issues/new),
 especially if you have tips on how to make this work best!
 
 ## Ideas wanted!
@@ -217,4 +217,4 @@ acrobatics to integrate the two.
 
 If you have an idea for another workaround that would enable Calico
 and MetalLB to coexist nicely,
-please [tell us](https://github.com/google/metallb/issues/new) !
+please [tell us](https://github.com/metallb/metallb/issues/new) !

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -26,4 +26,4 @@ Yes but by default, OpenStack has anti-spoofing protection enabled which prevent
 
 ## Can I update one pool at a time?
 
-Not yet.  The whole configuration for MetalLB is stored in a ConfigMap called `config` in the metallb-system namespace. We anticipate converting to Custom Resources at some point as described in [Issue 196](https://github.com/google/metallb/issues/196).  Contributions Welcome! 
+Not yet.  The whole configuration for MetalLB is stored in a ConfigMap called `config` in the metallb-system namespace. We anticipate converting to Custom Resources at some point as described in [Issue 196](https://github.com/metallb/metallb/issues/196).  Contributions Welcome! 

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -45,8 +45,8 @@ Note, you don't need this if you're using kube-router as service-proxy because i
 To install MetalLB, apply the manifest:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/metallb.yaml
 # On first install only
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 ```
@@ -80,7 +80,7 @@ on the remote kustomization fle :
 namespace: metallb-system
 
 resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
+  - github.com/metallb/metallb//manifests?ref=v0.8.2
   - configmap.yml 
   - secret.yml
 ```
@@ -97,7 +97,7 @@ the configMap, as MetalLB is waiting for a configMap named `config`
 namespace: metallb-system
 
 resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
+  - github.com/metallb/metallb//manifests?ref=v0.8.2
 
 configMapGenerator:
 - name: config

--- a/website/content/installation/clouds.md
+++ b/website/content/installation/clouds.md
@@ -153,5 +153,5 @@ willing to pay for the resources (servers, IPs, ...) required to test
 the integration, then we could *potentially* add support to MetalLB.
 
 If you think you can help with getting resources for testing, [file a
-bug](https://github.com/danderson/metallb/issues/new) and we can talk
+bug](https://github.com/metallb/metallb/issues/new) and we can talk
 about it!

--- a/website/content/installation/network-addons.md
+++ b/website/content/installation/network-addons.md
@@ -32,4 +32,4 @@ efficient "IPVS mode", in addition to the default "iptables mode."
 MetalLB **might** work with IPVS mode in kube-proxy, in Kubernetes
 1.13 or later. However, it is not explicitly tested yet, so it's at
 your own risk. See our [tracking
-bug](https://github.com/google/metallb/issues/153) for details.
+bug](https://github.com/metallb/metallb/issues/153) for details.

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -10,7 +10,7 @@ Bugfixes:
 
 - Fix manifests to use container image version `v0.9.3` instead of `main`. Users
   of `v0.9.2` are encouraged to upgrade, as [manifests included in that
-  release](https://raw.githubusercontent.com/google/metallb/v0.9.2/manifests/metallb.yaml)
+  release](https://raw.githubusercontent.com/metallb/metallb/v0.9.2/manifests/metallb.yaml)
   use an incorrect container image version. Those two images happen to match
   now but, as development continues on `main` branch, they will differ.
 
@@ -84,7 +84,7 @@ Action required:
 
 Bugfixes:
 
-- Fix layer2 node selection when healthy and unhealthy replicas are colocated on a single node. ([#474](https://github.com/danderson/metallb/issues/474))
+- Fix layer2 node selection when healthy and unhealthy replicas are colocated on a single node. ([#474](https://github.com/metallb/metallb/issues/474))
 
 This release includes contributions from David Anderson and Gary Richards.
 
@@ -94,10 +94,10 @@ This release includes contributions from David Anderson and Gary Richards.
 
 Bugfixes:
 
-- Fix the apiGroup for PodSecurityPolicy, for compatibility with Kubernetes 1.16. ([#458](https://github.com/google/metallb/issues/458)).
-- Fix speaker posting events with an empty string as the announcing node name. ([#456](https://github.com/google/metallb/issues/456)).
+- Fix the apiGroup for PodSecurityPolicy, for compatibility with Kubernetes 1.16. ([#458](https://github.com/metallb/metallb/issues/458)).
+- Fix speaker posting events with an empty string as the announcing node name. ([#456](https://github.com/metallb/metallb/issues/456)).
 - Fix RBAC permissions on speaker, to allow it to post events to all
-  namespaces. ([#455](https://github.com/google/metallb/issues/455)).
+  namespaces. ([#455](https://github.com/metallb/metallb/issues/455)).
 
 This release includes contributions from David Anderson.
 
@@ -136,7 +136,7 @@ New features:
 - MetalLB withdraws BGP announcements entirely for services with no
   healthy pods. This enables anycast geo-redundancy by advertising the
   same IP from multiple Kubernetes
-  clusters. ([#312](https://github.com/google/metallb/issues/312))
+  clusters. ([#312](https://github.com/metallb/metallb/issues/312))
 - The speaker only exposes its Prometheus metrics port on the node IP
   registered with Kubernetes, rather than on all interfaces. This
   should reduce the risk of exposure for clusters where nodes have
@@ -150,7 +150,7 @@ New features:
 - MetalLB now publishes a Kubernetes event to a service, indicating
   which nodes are announcing that service. This makes it much easier
   to determine how traffic is
-  flowing. ([#430](https://github.com/google/metallb/issues/430))
+  flowing. ([#430](https://github.com/metallb/metallb/issues/430))
 - The manifest and Helm chart now use the `apps/v1` version of
   `Deployment` and `DaemonSet`, rather than the obsolete
   `extensions/v1beta1`.
@@ -160,25 +160,25 @@ Bugfixes:
 - Fix address allocation in cases where no addresses were available at
   service creation, but the deletion of another service subsequently
   makes one
-  available. ([#413](https://github.com/google/metallb/issues/413))
+  available. ([#413](https://github.com/metallb/metallb/issues/413))
 - Fix allocation not updating when the address pool annotation
-  changes. ([#448](https://github.com/google/metallb/issues/448)).
+  changes. ([#448](https://github.com/metallb/metallb/issues/448)).
 - Fix periodic crashes due to `glog` trying to write to disk despite
   explicit instructions to the
-  contrary. ([#427](https://github.com/google/metallb/issues/427))
+  contrary. ([#427](https://github.com/metallb/metallb/issues/427))
 - Fix `spec.loadBalancerIP` validation on IPv6 clusters.
-  ([#301](https://github.com/google/metallb/issues/301))
+  ([#301](https://github.com/metallb/metallb/issues/301))
 - Fix BGP Router ID selection on v6 BGP sessions.
 - Fix handling of IPv6 addresses in the BGP connection establishment
   logic.
 - Generate deterministically pseudorandom BGP router IDs in IPv6-only
   clusters.
 - Fix incorrect ARP/NDP responses on bonded interfaces.
-  ([#349](https://github.com/google/metallb/issues/349))
+  ([#349](https://github.com/metallb/metallb/issues/349))
 - Fix ARP/NDP responses sent on interfaces with the NOARP flag.
-  ([#351](https://github.com/google/metallb/issues/351))
+  ([#351](https://github.com/metallb/metallb/issues/351))
 - Update MetalLB logs on the website to the new structured
-  format. ([#275](https://github.com/google/metallb/issues/301))
+  format. ([#275](https://github.com/metallb/metallb/issues/301))
 
 This release includes contributions from Alex Lovell-Troy, Antonio
 Ojea, aojeagarcia, Ashley Dumaine, Brian, Brian Topping, David
@@ -195,7 +195,7 @@ stokbaek and till. Thanks to all of them for making MetalLB better!
 Bugfixes:
 
 - Fix BGP announcement refcounting when using shared
-  IPs. ([#295](https://github.com/google/metallb/issues/295))
+  IPs. ([#295](https://github.com/metallb/metallb/issues/295))
 
 ## Version 0.7.2
 
@@ -204,9 +204,9 @@ Bugfixes:
 Bugfixes:
 
 - Fix gratuitous ARP and NDP announcements on IP
-  failover. ([#291](https://github.com/google/metallb/issues/291))
+  failover. ([#291](https://github.com/metallb/metallb/issues/291))
 - Fix BGP dialing on Arm64, by using `x/sys/unix` instead of the
-  `syscall` package. ([#289](https://github.com/google/metallb/issues/289))
+  `syscall` package. ([#289](https://github.com/metallb/metallb/issues/289))
 
 ## Version 0.7.1
 
@@ -215,7 +215,7 @@ Bugfixes:
 Bugfixes:
 
 - Actually allow layer2 mode to use the Local traffic
-  policy. Oops. ([#279](https://github.com/google/metallb/issues/279))
+  policy. Oops. ([#279](https://github.com/metallb/metallb/issues/279))
 
 ## Version 0.7.0
 
@@ -236,11 +236,11 @@ New features:
 
 - Layer2 mode now supports `externalTrafficPolicy=Local`, meaning layer2
   services can see the true client source
-  IP. ([#257](https://github.com/google/metallb/issues/257))
+  IP. ([#257](https://github.com/metallb/metallb/issues/257))
 - Layer2 mode now selects leader nodes on a per-service level, instead of using
   a single leader node for all services in the cluster. If you have many
   services, this change spreads the load of handling incoming traffic across
-  more than one machine. ([#195](https://github.com/google/metallb/issues/195))
+  more than one machine. ([#195](https://github.com/metallb/metallb/issues/195))
 - MetalLB's maturity has upgraded from _alpha_ to _beta_! Mostly this
   just reflects the increased confidence in the code from the larger
   userbase, and adds some guarantees around graceful upgrades from one
@@ -249,7 +249,7 @@ New features:
 Bugfixes:
 
 - Speaker no longer sends localpref over eBGP sessions
-  ([#266](https://github.com/google/metallb/issues/266))
+  ([#266](https://github.com/metallb/metallb/issues/266))
 
 This release includes contributions from Baul, David Anderson, Ryan
 Roemmich, Sanjeev Rampal, and Steve Sloka. Thanks to all of them for
@@ -261,7 +261,7 @@ making MetalLB better!
 
 Bugfixes:
 
-- Fix nil pointer deref crash on BGP peers that reject MetalLB's OPEN message too promptly ([#250](https://github.com/google/metallb/issues/250))
+- Fix nil pointer deref crash on BGP peers that reject MetalLB's OPEN message too promptly ([#250](https://github.com/metallb/metallb/issues/250))
 
 ## Version 0.6.1
 
@@ -271,7 +271,7 @@ Bugfixes:
 
 - Speaker no longer goes into a tight CPU-burning loop when pods are
   deleted on the
-  node. ([#246](https://github.com/google/metallb/issues/246))
+  node. ([#246](https://github.com/metallb/metallb/issues/246))
 
 ## Version 0.6.0
 
@@ -292,25 +292,25 @@ New features:
   annotations on the Service objects. See
   the
   [IP sharing documentation]({{% relref "usage/_index.md" %}}#ip-address-sharing) for
-  instructions and caveats. ([#121](https://github.com/google/metallb/issues/121))
+  instructions and caveats. ([#121](https://github.com/metallb/metallb/issues/121))
 - Layer 2 mode now listens on all interfaces for ARP and NDP requests,
   not just the interface used for communication by Kubernetes
-  components. ([#165](https://github.com/google/metallb/issues/165))
+  components. ([#165](https://github.com/metallb/metallb/issues/165))
 - MetalLB now uses structured logging instead of Google's glog
   package. Logging events are written to standard output as a series
   of JSON objects suitable for collection by centralized logging
-  systems. ([#189](https://github.com/google/metallb/issues/189))
+  systems. ([#189](https://github.com/metallb/metallb/issues/189))
 - BGP connections can now specify a password for TCP MD5 secured BGP
-  sessions. ([#215](https://github.com/google/metallb/issues/215))
+  sessions. ([#215](https://github.com/metallb/metallb/issues/215))
 - MetalLB is now available as a Helm package in the "stable" Helm
   repository. Note that, due to code review delay, it may take several
   days after a release before the Helm package is
-  updated. ([#177](https://github.com/google/metallb/issues/177))
+  updated. ([#177](https://github.com/metallb/metallb/issues/177))
 
 Bugfixes:
 
 - Correctly use AS_SEQUENCE in eBGP session messages, rather than
-  AS_SET ([#225](https://github.com/google/metallb/issues/225))
+  AS_SET ([#225](https://github.com/metallb/metallb/issues/225))
 
 This release includes contributions from David Anderson, ghorofamike,
 Serguei Bezverkhi, and Zsombor Welker. Thanks to all of them for making
@@ -355,7 +355,7 @@ New features:
   makes it much easier to allocate IP ranges that don't fall cleanly
   on CIDR prefix boundaries.
 - BGP mode supports nodes with multiple interfaces and IP addresses
-  ([#182](https://github.com/google/metallb/issues/182)). Previously,
+  ([#182](https://github.com/metallb/metallb/issues/182)). Previously,
   MetalLB could only establish working BGP sessions on the node's
   "primary" interface, i.e. the one that owned the IP that Kubernetes
   uses to identify the node. Now, peerings may be established via any
@@ -366,7 +366,7 @@ Bugfixes:
 
 - The NDP
   handler
-  [refcounts its sollicited multicast group memberships](https://github.com/google/metallb/issues/184),
+  [refcounts its sollicited multicast group memberships](https://github.com/metallb/metallb/issues/184),
   to avoid extremely rare cases where it might stop responding for a
   service IP.
 
@@ -376,7 +376,7 @@ Bugfixes:
 
 Bugfixes:
 
-- [Remove the --config-ns flag](https://github.com/google/metallb/issues/193)
+- [Remove the --config-ns flag](https://github.com/metallb/metallb/issues/193)
 
 ## Version 0.4.5
 
@@ -384,7 +384,7 @@ Bugfixes:
 
 Bugfixes:
 
-- [Controller doesn't clean up balancers that change their type away from LoadBalancer](https://github.com/google/metallb/issues/190)
+- [Controller doesn't clean up balancers that change their type away from LoadBalancer](https://github.com/metallb/metallb/issues/190)
 
 ## Version 0.4.4
 
@@ -408,7 +408,7 @@ Changes:
 
 Bugfixes:
 
-- [Speaker doesn't readvertise existing services on sessions added by node label changes](https://github.com/google/metallb/issues/181).
+- [Speaker doesn't readvertise existing services on sessions added by node label changes](https://github.com/metallb/metallb/issues/181).
 
 ## Version 0.4.1
 
@@ -416,7 +416,7 @@ Bugfixes:
 
 Bugfixes:
 
-- [Make speaker not crash on machines with IPv6 disabled](https://github.com/google/metallb/issues/180).
+- [Make speaker not crash on machines with IPv6 disabled](https://github.com/metallb/metallb/issues/180).
 
 ## Version 0.4.0
 
@@ -445,7 +445,7 @@ New features:
   [Neighbor Discovery Protocol](https://en.wikipedia.org/wiki/Neighbor_Discovery_Protocol),
   IPv6's analog to ARP. If you have an IPv6 Kubernetes cluster, please
   try it out
-  and [file bugs](https://github.com/google/metallb/issues/new)!
+  and [file bugs](https://github.com/metallb/metallb/issues/new)!
 - BGP peers now have
   a
   [node selector]({{% relref "configuration/_index.md" %}}#limiting-peers-to-certain-nodes). You
@@ -453,7 +453,7 @@ New features:
   topologies.
 - MetalLB now has
   a
-  [Helm chart](https://github.com/google/metallb/tree/main/helm/metallb). If
+  [Helm chart](https://github.com/metallb/metallb/tree/main/helm/metallb). If
   you use [Helm](https://helm.sh) on your cluster, this should make it
   easier to track and manage your MetalLB installation. The chart will
   be submitted for inclusion in the main Helm stable repository
@@ -464,11 +464,11 @@ Other improvements:
 
 - MetalLB
   now
-  [backs off on failing BGP connections](https://github.com/google/metallb/issues/84),
+  [backs off on failing BGP connections](https://github.com/metallb/metallb/issues/84),
   to avoid flooding logs with failures
 - ARP mode should be a little
   more
-  [interoperable with clients](https://github.com/google/metallb/issues/172),
+  [interoperable with clients](https://github.com/metallb/metallb/issues/172),
   and failover should be a little faster, thanks to tweaks to its
   advertisement logic.
 - ARP and NDP modes export [Prometheus](https://prometheus.io) metrics
@@ -487,7 +487,7 @@ all of them for making MetalLB better!
 [Documentation for this release](https://v0-3-1--metallb.netlify.com)
 
 Fixes a couple
-of [embarrassing bugs](https://github.com/google/metallb/issues/142)
+of [embarrassing bugs](https://github.com/metallb/metallb/issues/142)
 that sneaked into 0.3.
 
 Bugfixes:
@@ -511,7 +511,7 @@ Action required if upgrading from 0.2.x:
   ds/bgp-speaker`. This will take down your load-balancers until you
   deploy the new DaemonSet.
 - The
-  [configuration file format](https://raw.githubusercontent.com/google/metallb/main/manifests/example-config.yaml) has
+  [configuration file format](https://raw.githubusercontent.com/metallb/metallb/main/manifests/example-config.yaml) has
   changed in a few backwards-incompatible ways. You need to update
   your ConfigMap by hand:
   - Each `address-pool` must now have a `protocol` field, to select
@@ -570,7 +570,7 @@ Notable fixes:
 
 - MetalLB unable to start because Kubernetes cannot verify that
   "nobody" is a non-root
-  user ([#85](https://github.com/google/metallb/issues/85))
+  user ([#85](https://github.com/metallb/metallb/issues/85))
 
 ## Version 0.2.0
 
@@ -609,7 +609,7 @@ Notable fixes:
 
 ## Version 0.1.0
 
-[Documentation for this release](https://github.com/google/metallb/tree/v0.1)
+[Documentation for this release](https://github.com/metallb/metallb/tree/v0.1)
 
 This was the first tagged version of MetalLB. Its changelog is
 effectively "MetalLB now exists, where previously it did not."

--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -146,7 +146,7 @@ In future, MetalLB might be able to overcome the downsides of the
 `Local` traffic policy, in which case it would be unconditionally the
 best mode to use with BGP
 announcements. See
-[issue 1](https://github.com/google/metallb/issues/1) for more
+[issue 1](https://github.com/metallb/metallb/issues/1) for more
 information.
 
 ## IP address sharing


### PR DESCRIPTION
This repository used to be located at google/metallb and danderson/metallb. Redirects still work, but this just brings it in line with the current repository location.

---

Fixes #567