### PR TITLE
Add support for MP BGP encoding for IPv4 and IPv6

### DIFF
--- a/internal/bgp/messages.go
+++ b/internal/bgp/messages.go
@@ -10,6 +10,14 @@ import (
 	"time"
 )
 
+const (
+	mpReachNLRI          = 14
+	mpUnreachNLRI        = 15
+	AFIv4         uint16 = 1
+	AFIv6         uint16 = 2
+	SAFIUnicast   uint8  = 1
+)
+
 func sendOpen(w io.Writer, asn uint32, routerID net.IP, holdTime time.Duration) error {
 	if routerID.To4() == nil {
 		panic("non-ipv4 address used as RouterID")
@@ -283,7 +291,7 @@ func readCapabilities(r io.Reader, ret *openResult) error {
 	}
 }
 
-func sendUpdate(w io.Writer, asn uint32, ibgp, fbasn bool, defaultNextHop net.IP, adv *Advertisement) error {
+func sendUpdate(w io.Writer, asn uint32, ibgp, fbasn bool, mpBGP bool, adv *Advertisement) error {
 	var b bytes.Buffer
 
 	hdr := struct {
@@ -301,11 +309,13 @@ func sendUpdate(w io.Writer, asn uint32, ibgp, fbasn bool, defaultNextHop net.IP
 		return err
 	}
 	l := b.Len()
-	if err := encodePathAttrs(&b, asn, ibgp, fbasn, defaultNextHop, adv); err != nil {
+	if err := encodePathAttrs(&b, asn, ibgp, fbasn, mpBGP, adv); err != nil {
 		return err
 	}
 	binary.BigEndian.PutUint16(b.Bytes()[21:23], uint16(b.Len()-l))
-	encodePrefixes(&b, []*net.IPNet{adv.Prefix})
+	if !mpBGP {
+		encodePrefixes(&b, []*net.IPNet{adv.Prefix})
+	}
 	binary.BigEndian.PutUint16(b.Bytes()[16:18], uint16(b.Len()))
 
 	if _, err := io.Copy(w, &b); err != nil {
@@ -318,7 +328,11 @@ func encodePrefixes(b *bytes.Buffer, pfxs []*net.IPNet) {
 	for _, pfx := range pfxs {
 		o, _ := pfx.Mask.Size()
 		b.WriteByte(byte(o))
-		b.Write(pfx.IP.To4()[:bytesForBits(o)])
+		val := pfx.IP.To4()
+		if val == nil {
+			val = pfx.IP.To16()
+		}
+		b.Write(val[:bytesForBits(o)])
 	}
 }
 
@@ -329,7 +343,8 @@ func bytesForBits(n int) int {
 	return ((n + 7) &^ 7) / 8
 }
 
-func encodePathAttrs(b *bytes.Buffer, asn uint32, ibgp, fbasn bool, defaultNextHop net.IP, adv *Advertisement) error {
+func encodePathAttrs(b *bytes.Buffer, asn uint32, ibgp, fbasn, mpBGP bool, adv *Advertisement) error {
+
 	b.Write([]byte{
 		0x40, 1, // mandatory, origin
 		1, // len
@@ -360,15 +375,21 @@ func encodePathAttrs(b *bytes.Buffer, asn uint32, ibgp, fbasn bool, defaultNextH
 			}
 		}
 	}
-	b.Write([]byte{
-		0x40, 3, // mandatory, next-hop
-		4, // len
-	})
-	if adv.NextHop != nil {
+	// mp bgp message should not include NEXT_HOP path attribute
+	if !mpBGP {
+		b.Write([]byte{
+			0x40, 3, // mandatory, next-hop
+			4, // len
+		})
 		b.Write(adv.NextHop.To4())
-	} else {
-		b.Write(defaultNextHop)
 	}
+
+	if mpBGP {
+		if err := encodeMPReachNLRI(b, adv); err != nil {
+			return err
+		}
+	}
+
 	if ibgp {
 		b.Write([]byte{
 			0x40, 5, // well-known, localpref
@@ -396,7 +417,122 @@ func encodePathAttrs(b *bytes.Buffer, asn uint32, ibgp, fbasn bool, defaultNextH
 	return nil
 }
 
-func sendWithdraw(w io.Writer, prefixes []*net.IPNet) error {
+func encodeMPReachNLRI(b *bytes.Buffer, adv *Advertisement) error {
+	b.Write([]byte{
+		0x80,
+		mpReachNLRI,
+		0,
+	})
+	lenPos := b.Len() - 1
+	var isIPv6 bool
+
+	if adv.Prefix.IP.To4() == nil {
+		isIPv6 = true
+	}
+	afi := AFIv4
+	if isIPv6 {
+		afi = AFIv6
+	}
+	if err := binary.Write(b, binary.BigEndian, afi); err != nil {
+		return err
+	}
+	if err := binary.Write(b, binary.BigEndian, SAFIUnicast); err != nil {
+		return err
+	}
+	if isIPv6 {
+		b.WriteByte(16)
+		b.Write(adv.NextHop.To16())
+	} else {
+		b.WriteByte(4)
+		b.Write(adv.NextHop.To4())
+	}
+	b.WriteByte(0)
+	encodePrefixes(b, []*net.IPNet{adv.Prefix})
+	b.Bytes()[lenPos] = byte(b.Len() - lenPos - 1)
+	return nil
+}
+
+func sendWithdraw(w io.Writer, mpForV4 bool, prefixes []*net.IPNet) error {
+	var v4prefixes []*net.IPNet
+	var v6prefixes []*net.IPNet
+
+	for _, p := range prefixes {
+		if p.IP.To4() != nil {
+			v4prefixes = append(v4prefixes, p)
+			continue
+		}
+		v6prefixes = append(v6prefixes, p)
+	}
+
+	if mpForV4 {
+		if err := mpWithdraw(w, v4prefixes); err != nil {
+			return err
+		}
+	} else {
+		if err := legacyWithdraw(w, v4prefixes); err != nil {
+			return err
+		}
+	}
+	return mpWithdraw(w, v6prefixes)
+}
+
+func mpWithdraw(w io.Writer, prefixes []*net.IPNet) error {
+	if len(prefixes) == 0 {
+		return nil
+	}
+	isIPv6 := prefixes[0].IP.To4() == nil
+
+	var b bytes.Buffer
+
+	hdr := struct {
+		M1, M2  uint64
+		Len     uint16
+		Type    uint8
+		WdrLen  uint16
+		AttrLen uint16
+	}{
+		M1:   uint64(0xffffffffffffffff),
+		M2:   uint64(0xffffffffffffffff),
+		Type: 2,
+	}
+	if err := binary.Write(&b, binary.BigEndian, hdr); err != nil {
+		return err
+	}
+	hdrLen := b.Len()
+
+	b.Write([]byte{
+		0x80,
+		mpUnreachNLRI,
+		0, // Path attr len
+	})
+	afi := AFIv4
+	if isIPv6 {
+		afi = AFIv6
+	}
+	if err := binary.Write(&b, binary.BigEndian, afi); err != nil {
+		return err
+	}
+	if err := binary.Write(&b, binary.BigEndian, SAFIUnicast); err != nil {
+		return err
+	}
+	encodePrefixes(&b, prefixes)
+	b.Bytes()[hdrLen+2] = byte(b.Len() - hdrLen - 3)
+
+	// attr len
+	binary.BigEndian.PutUint16(b.Bytes()[21:23], uint16(b.Len()-hdrLen))
+	// msg len
+	binary.BigEndian.PutUint16(b.Bytes()[16:18], uint16(b.Len()))
+	if _, err := io.Copy(w, &b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func legacyWithdraw(w io.Writer, prefixes []*net.IPNet) error {
+	if len(prefixes) == 0 {
+		return nil
+	}
+
 	var b bytes.Buffer
 
 	hdr := struct {
@@ -409,17 +545,17 @@ func sendWithdraw(w io.Writer, prefixes []*net.IPNet) error {
 		M2:   uint64(0xffffffffffffffff),
 		Type: 2,
 	}
+
 	if err := binary.Write(&b, binary.BigEndian, hdr); err != nil {
 		return err
 	}
-	l := b.Len()
+	hdrLen := b.Len()
 	encodePrefixes(&b, prefixes)
-	binary.BigEndian.PutUint16(b.Bytes()[19:21], uint16(b.Len()-l))
+	binary.BigEndian.PutUint16(b.Bytes()[19:21], uint16(b.Len()-hdrLen))
 	if err := binary.Write(&b, binary.BigEndian, uint16(0)); err != nil {
 		return err
 	}
 	binary.BigEndian.PutUint16(b.Bytes()[16:18], uint16(b.Len()))
-
 	if _, err := io.Copy(w, &b); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,10 @@ type addressPool struct {
 }
 
 type bgpAdvertisement struct {
-	AggregationLength *int `yaml:"aggregation-length"`
-	LocalPref         *uint32
-	Communities       []string
+	AggregationLength   *int `yaml:"aggregation-length"`
+	AggregationLengthV6 *int `yaml:"aggregation-length-v6"`
+	LocalPref           *uint32
+	Communities         []string
 }
 
 // Config is a parsed MetalLB configuration.
@@ -140,6 +141,9 @@ type BGPAdvertisement struct {
 	// length. Optional, defaults to 32 (i.e. no aggregation) if not
 	// specified.
 	AggregationLength int
+	// Optional, defaults to 128 (i.e. no aggregation) if not
+	// specified.
+	AggregationLengthV6 int
 	// Value of the LOCAL_PREF BGP path attribute. Used only when
 	// advertising to IBGP peers (i.e. Peer.MyASN == Peer.ASN).
 	LocalPref uint32
@@ -352,9 +356,10 @@ func parseBGPAdvertisements(ads []bgpAdvertisement, cidrs []*net.IPNet, communit
 	if len(ads) == 0 {
 		return []*BGPAdvertisement{
 			{
-				AggregationLength: 32,
-				LocalPref:         0,
-				Communities:       map[uint32]bool{},
+				AggregationLength:   32,
+				AggregationLengthV6: 128,
+				LocalPref:           0,
+				Communities:         map[uint32]bool{},
 			},
 		}, nil
 	}
@@ -362,21 +367,35 @@ func parseBGPAdvertisements(ads []bgpAdvertisement, cidrs []*net.IPNet, communit
 	var ret []*BGPAdvertisement
 	for _, rawAd := range ads {
 		ad := &BGPAdvertisement{
-			AggregationLength: 32,
-			LocalPref:         0,
-			Communities:       map[uint32]bool{},
+			AggregationLength:   32,
+			AggregationLengthV6: 128,
+			LocalPref:           0,
+			Communities:         map[uint32]bool{},
 		}
 
 		if rawAd.AggregationLength != nil {
 			ad.AggregationLength = *rawAd.AggregationLength
 		}
 		if ad.AggregationLength > 32 {
-			return nil, fmt.Errorf("invalid aggregation length %q", ad.AggregationLength)
+			return nil, fmt.Errorf("invalid aggregation length for IPv4 %q", ad.AggregationLength)
 		}
+
+		if rawAd.AggregationLengthV6 != nil {
+			ad.AggregationLengthV6 = *rawAd.AggregationLengthV6
+		}
+		if ad.AggregationLengthV6 > 128 {
+			return nil, fmt.Errorf("invalid aggregation length for IPv6 %q", ad.AggregationLengthV6)
+		}
+
 		for _, cidr := range cidrs {
 			o, _ := cidr.Mask.Size()
-			if ad.AggregationLength < o {
-				return nil, fmt.Errorf("invalid aggregation length %d: prefix %q in this pool is more specific than the aggregation length", ad.AggregationLength, cidr)
+			maxLength := ad.AggregationLength
+			if cidr.IP.To4() == nil {
+				maxLength = ad.AggregationLengthV6
+			}
+			if maxLength < o {
+				return nil, fmt.Errorf("invalid aggregation length %d: prefix %q in "+
+					"this pool is more specific than the aggregation length", ad.AggregationLength, cidr)
 			}
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,7 @@ address-pools:
   auto-assign: false
   bgp-advertisements:
   - aggregation-length: 32
+    aggregation-length-v6: 64
     localpref: 100
     communities: ["bar", "1234:2345"]
   - aggregation-length: 24
@@ -120,16 +121,18 @@ address-pools:
 						AutoAssign:    false,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								LocalPref:         100,
+								AggregationLength:   32,
+								AggregationLengthV6: 64,
+								LocalPref:           100,
 								Communities: map[uint32]bool{
 									0xfc0004d2: true,
 									0x04D20929: true,
 								},
 							},
 							{
-								AggregationLength: 24,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   24,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -139,8 +142,9 @@ address-pools:
 						AutoAssign: true,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -417,8 +421,9 @@ address-pools:
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -442,8 +447,9 @@ address-pools:
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -211,6 +211,10 @@ func (c *bgpController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 	c.svcAds[name] = nil
 	for _, adCfg := range pool.BGPAdvertisements {
 		m := net.CIDRMask(adCfg.AggregationLength, 32)
+		isIPv6 := lbIP.To4() == nil
+		if isIPv6 {
+			m = net.CIDRMask(adCfg.AggregationLengthV6, 128)
+		}
 		ad := &bgp.Advertisement{
 			Prefix: &net.IPNet{
 				IP:   lbIP.Mask(m),

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -92,7 +92,7 @@ data:
 
 By default, BGP mode advertises each allocated IP to the configured
 peers with no additional BGP attributes. The peer router(s) will
-receive one `/32` route for each service IP, with the BGP localpref
+receive one `/32` (`/128` for IPv6) route for each service IP, with the BGP localpref
 set to zero and no BGP communities.
 
 You can configure more elaborate advertisements by adding a
@@ -100,7 +100,7 @@ You can configure more elaborate advertisements by adding a
 advertisements.
 
 In addition to specifying localpref and communities, you can use this
-to advertise aggregate routes. The `aggregation-length` advertisement
+to advertise aggregate routes. The `aggregation-length` (`aggregation-length-v6` for IPv6) advertisement
 option lets you "roll up" the /32s into a larger prefix. Combined with
 multiple advertisement configurations, this lets you create elaborate
 advertisements that interoperate with the rest of your BGP network.


### PR DESCRIPTION
Hi,
It looks like we were working on the same feature with @TheEnbyperor in parallel.
TheEnbyperor PR: https://github.com/metallb/metallb/pull/574

I also added IPv6 support for BGP speaker, but I'm late with PR.
In any case, I want to submit my PR so that you can see an alternative point of view on the feature implementation.

My implementation is a little different and provide some additional feature.
1)    MP BGP encoding will be used for IPv4 prefixes announcement if the peer supports it, legacy encoding will be used otherwise.
2)    Don’t announce IPv6 prefixes for peer which don’t support them
3)    You can use IPv4 or IPv6 to establish a BGP session for IPv4 and IPv6 prefixes announcement
4) You can use different aggregation length for IPv6 prefixes
@TheEnbyperor already provide implementation for the feature, so PR is more for reference.
Feel free to close this PR if you don’t need it.
