### PR TITLE
Fix website typos on release process

### DIFF
--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -27,7 +27,7 @@ previous releases point to `vX-Y-Z--metallb.netlify.com`, which is the
 website pinned at that tagged release.
 
 To get a list of contributors to the release, run `git log
---format="%aN" $(git merge-base CUR-BRANCH PREV-TAG)..HEAD | sort -u |
+--format="%aN" $(git merge-base CUR-BRANCH PREV-TAG)..CUR-BRANCH | sort -u |
 tr '\n' ',' | sed -e 's/,/, /g'`. `CUR-BRANCH` is `main` if you're
 making a minor release (e.g. 0.9.0), or the release branch for the
 current version if you're making a patch release (e.g. `v0.8` if

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -23,7 +23,7 @@ those out as well.
 
 Also update the documentation link so that the soon-to-be latest
 release's documentation link points to `metallb.universe.tf`, and the
-previous releases point to `vX.Y.Z--metallb.netlify.com`, which is the
+previous releases point to `vX-Y-Z--metallb.netlify.com`, which is the
 website pinned at that tagged release.
 
 To get a list of contributors to the release, run `git log

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -45,8 +45,8 @@ Note, you don't need this if you're using kube-router as service-proxy because i
 To install MetalLB, apply the manifest:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/google/metallb/main/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/metallb.yaml
 # On first install only
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 ```


### PR DESCRIPTION
This patches were created some weeks ago when doing the 0.9.x release, of the random things I noticed I did differently from the release process document.

There is also a simple fix to reference metallb github org in the install instructions. Actions to do that thoroughly are already in progress (https://github.com/metallb/metallb/pull/570 and https://github.com/metallb/metallb/issues/567), this is just an old patch that I had in my queue.

More details in the commit messages :)