### PR TITLE
Use go-kit log.NewStdlibAdapter instead of our own adapter

### DIFF
--- a/speaker/main.go
+++ b/speaker/main.go
@@ -117,7 +117,8 @@ func main() {
 			mconfig.BindPort = mlport
 			mconfig.AdvertisePort = mlport
 		}
-		mconfig.Logger = golog.New(goKitLogWriter{logger}, "", golog.Lshortfile)
+		loggerout := gokitlog.NewStdlibAdapter(gokitlog.With(logger, "component", "MemberList"))
+		mconfig.Logger = golog.New(loggerout, "", golog.Lshortfile)
 		if *mlSecret != "" {
 			sha := sha256.New()
 			mconfig.SecretKey = sha.Sum([]byte(*mlSecret))[:16]
@@ -201,21 +202,6 @@ func watchMemberListEvents(logger gokitlog.Logger, eventCh chan memberlist.NodeE
 			return
 		}
 	}
-}
-
-type goKitLogWriter struct {
-	gokitlog.Logger
-}
-
-func (l goKitLogWriter) Write(p []byte) (int, error) {
-	if len(p) > 1 {
-		// last char is '\n'
-		err := l.Log("component", "MemberList", "msg", string(p[:len(p)-1]))
-		if err != nil {
-			return 0, err
-		}
-	}
-	return len(p), nil
 }
 
 type controller struct {


### PR DESCRIPTION
New log looks like:
{"caller":"net.go:785","component":"MemberList","msg":"[DEBUG] memberlist: Initiating push/pull sync with: 10.11.12.13:7946","ts":"2020-04-17T00:31:37.51568936Z"}