### PR TITLE
Add support for MP BGP encoding for IPv4 and IPv6

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -23,6 +23,11 @@ import (
 
 var errClosed = errors.New("session closed")
 
+type NextHop struct {
+	ipv4 net.IP
+	ipv6 net.IP
+}
+
 // Session represents one BGP session to an external router.
 type Session struct {
 	asn              uint32
@@ -45,15 +50,14 @@ type Session struct {
 	// passed from peer config, allows to announce IPv6 prefixes to the peer
 	allowV6Prefixes bool
 
-	mu               sync.Mutex
-	cond             *sync.Cond
-	closed           bool
-	conn             net.Conn
-	actualHoldTime   time.Duration
-	defaultNextHopV4 net.IP
-	defaultNextHopV6 net.IP
-	advertised       map[string]*Advertisement
-	new              map[string]*Advertisement
+	mu             sync.Mutex
+	cond           *sync.Cond
+	closed         bool
+	conn           net.Conn
+	actualHoldTime time.Duration
+	defaultNextHop NextHop
+	advertised     map[string]*Advertisement
+	new            map[string]*Advertisement
 }
 
 // run tries to stay connected to the peer, and pumps route updates to it.
@@ -171,8 +175,7 @@ func (s *Session) handleNewAdvertisements() {
 				"msg", fmt.Sprintf("skip prefix announcement because %s prefixes are not allowed by the peer config", prefixType))
 			delete(s.new, c)
 		}
-		s.updateNextHop(adv)
-		if adv.NextHop == nil {
+		if !s.hasNextHop(adv) {
 			s.logger.Log("op", "SetAdvertisement", "prefix", c,
 				"msg", "skip prefix announcement because there is no next hop for it")
 			delete(s.new, c)
@@ -190,7 +193,7 @@ func (s *Session) handleNewAdvertisements() {
 }
 
 func (s *Session) sendUpdateForAdvertisement(adv *Advertisement) bool {
-	if err := sendUpdate(s.conn, s.asn, s.isIBGP(), s.peerFBASNSupport, s.useMPBGP(adv), adv); err != nil {
+	if err := sendUpdate(s.conn, s.asn, s.isIBGP(), s.peerFBASNSupport, s.useMPBGP(adv), s.defaultNextHop, adv); err != nil {
 		s.abort()
 		s.logger.Log("op", "sendUpdate", "prefix", adv.Prefix.String(),
 			"error", err, "msg", "failed to send BGP update")
@@ -204,15 +207,14 @@ func (s *Session) isIBGP() bool {
 	return s.asn == s.peerASN
 }
 
-func (s *Session) updateNextHop(adv *Advertisement) {
+func (s *Session) hasNextHop(adv *Advertisement) bool {
 	if adv.NextHop != nil {
-		return
+		return true
 	}
 	if adv.Prefix.IP.To4() == nil {
-		adv.NextHop = s.defaultNextHopV6
-		return
+		return s.defaultNextHop.ipv6 != nil
 	}
-	adv.NextHop = s.defaultNextHopV4
+	return s.defaultNextHop.ipv4 != nil
 }
 
 // we should use MP BGP encoding in case:
@@ -252,7 +254,7 @@ func (s *Session) connect() error {
 	}
 	routerID := s.routerID
 	if routerID == nil {
-		routerID = getRouterID(s.defaultNextHopV4, s.myNode)
+		routerID = getRouterID(s.defaultNextHop.ipv4, s.myNode)
 	}
 
 	if err = sendOpen(conn, s.asn, routerID, s.holdTime); err != nil {
@@ -313,16 +315,16 @@ func (s *Session) getDefaultNextHops(conn net.Conn) error {
 		return fmt.Errorf("error getting local addr for default nexthop to %q", s.addr)
 	}
 	if addr.IP.To4() != nil {
-		s.defaultNextHopV4 = addr.IP
-		s.defaultNextHopV6 = findAltIP(addr.IP)
-		if s.defaultNextHopV6 == nil {
+		s.defaultNextHop.ipv4 = addr.IP
+		s.defaultNextHop.ipv6 = findAltIP(addr.IP)
+		if s.defaultNextHop.ipv6 == nil {
 			s.logger.Log("op", "connect", "msg", "can't find IPv6 address to use as next hop")
 		}
 		return nil
 	}
-	s.defaultNextHopV6 = addr.IP
-	s.defaultNextHopV4 = findAltIP(addr.IP)
-	if s.defaultNextHopV4 == nil {
+	s.defaultNextHop.ipv6 = addr.IP
+	s.defaultNextHop.ipv4 = findAltIP(addr.IP)
+	if s.defaultNextHop.ipv4 == nil {
 		s.logger.Log("op", "connect", "msg", "can't find IPv4 address to use as next hop")
 	}
 	return nil

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -31,6 +31,8 @@ type Session struct {
 	addr             string
 	peerASN          uint32
 	peerFBASNSupport bool
+	mpIPv4Support    bool
+	mpIPv6Support    bool
 	holdTime         time.Duration
 	logger           log.Logger
 	password         string
@@ -38,14 +40,15 @@ type Session struct {
 	newHoldTime chan bool
 	backoff     backoff
 
-	mu             sync.Mutex
-	cond           *sync.Cond
-	closed         bool
-	conn           net.Conn
-	actualHoldTime time.Duration
-	defaultNextHop net.IP
-	advertised     map[string]*Advertisement
-	new            map[string]*Advertisement
+	mu               sync.Mutex
+	cond             *sync.Cond
+	closed           bool
+	conn             net.Conn
+	actualHoldTime   time.Duration
+	defaultNextHopV4 net.IP
+	defaultNextHopV6 net.IP
+	advertised       map[string]*Advertisement
+	new              map[string]*Advertisement
 }
 
 // run tries to stay connected to the peer, and pumps route updates to it.
@@ -86,21 +89,15 @@ func (s *Session) sendUpdates() bool {
 	if s.conn == nil {
 		return true
 	}
-
-	ibgp := s.asn == s.peerASN
-	fbasn := s.peerFBASNSupport
-
+	s.handleNewAdvertisements()
 	if s.new != nil {
 		s.advertised, s.new = s.new, nil
 	}
 
-	for c, adv := range s.advertised {
-		if err := sendUpdate(s.conn, s.asn, ibgp, fbasn, s.defaultNextHop, adv); err != nil {
-			s.abort()
-			s.logger.Log("op", "sendUpdate", "ip", c, "error", err, "msg", "failed to send BGP update")
-			return true
+	for _, adv := range s.advertised {
+		if ret := s.sendUpdateForAdvertisement(adv); ret {
+			return ret
 		}
-		stats.UpdateSent(s.addr)
 	}
 	stats.AdvertisedPrefixes(s.addr, len(s.advertised))
 
@@ -115,25 +112,21 @@ func (s *Session) sendUpdates() bool {
 		if s.conn == nil {
 			return true
 		}
+		s.handleNewAdvertisements()
 		if s.new == nil {
 			// nil is "no pending updates", contrast to a non-nil
 			// empty map which means "withdraw all".
 			continue
 		}
-
 		for c, adv := range s.new {
 			if adv2, ok := s.advertised[c]; ok && adv.Equal(adv2) {
 				// Peer already has correct state for this
 				// advertisement, nothing to do.
 				continue
 			}
-
-			if err := sendUpdate(s.conn, s.asn, ibgp, fbasn, s.defaultNextHop, adv); err != nil {
-				s.abort()
-				s.logger.Log("op", "sendUpdate", "prefix", c, "error", err, "msg", "failed to send BGP update")
-				return true
+			if ret := s.sendUpdateForAdvertisement(adv); ret {
+				return ret
 			}
-			stats.UpdateSent(s.addr)
 		}
 
 		wdr := []*net.IPNet{}
@@ -143,7 +136,7 @@ func (s *Session) sendUpdates() bool {
 			}
 		}
 		if len(wdr) > 0 {
-			if err := sendWithdraw(s.conn, wdr); err != nil {
+			if err := sendWithdraw(s.conn, s.mpIPv4Support, wdr); err != nil {
 				s.abort()
 				for _, pfx := range wdr {
 					s.logger.Log("op", "sendWithdraw", "prefix", pfx, "error", err, "msg", "failed to send BGP withdraw")
@@ -157,12 +150,65 @@ func (s *Session) sendUpdates() bool {
 	}
 }
 
+// remove Advertisements which can't be announced
+func (s *Session) handleNewAdvertisements() {
+	if len(s.new) == 0 || s.new == nil {
+		return
+	}
+	for c, adv := range s.new {
+		s.updateNextHop(adv)
+		if adv.NextHop == nil {
+			s.logger.Log("op", "SetAdvertisement", "prefix", c,
+				"msg", "skip prefix announcement because there is no next hop for it")
+			delete(s.new, c)
+		}
+		if adv.Prefix.IP.To4() == nil && !s.mpIPv6Support {
+			s.logger.Log("op", "SetAdvertisement", "prefix", c,
+				"msg", "skip prefix announcement because MP BGP for IPv6 is not supported by peer")
+			delete(s.new, c)
+		}
+	}
+	if len(s.new) == 0 {
+		s.new = nil
+		stats.PendingPrefixes(s.addr, 0)
+	}
+}
+
+func (s *Session) sendUpdateForAdvertisement(adv *Advertisement) bool {
+	if err := sendUpdate(s.conn, s.asn, s.isIBGP(), s.peerFBASNSupport, s.useMPBGP(adv), adv); err != nil {
+		s.abort()
+		s.logger.Log("op", "sendUpdate", "prefix", adv.Prefix.String(),
+			"error", err, "msg", "failed to send BGP update")
+		return true
+	}
+	stats.UpdateSent(s.addr)
+	return false
+}
+
+func (s *Session) isIBGP() bool {
+	return s.asn == s.peerASN
+}
+
+func (s *Session) updateNextHop(adv *Advertisement) {
+	if adv.NextHop != nil {
+		return
+	}
+	if adv.Prefix.IP.To4() == nil {
+		adv.NextHop = s.defaultNextHopV6
+		return
+	}
+	adv.NextHop = s.defaultNextHopV4
+}
+
+func (s *Session) useMPBGP(adv *Advertisement) bool {
+	return s.mpIPv4Support || adv.Prefix.IP.To4() == nil
+}
+
 // connect establishes the BGP session with the peer.
 // sets TCP_MD5 sockopt if password is !="",
 func (s *Session) connect() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	if s.closed {
 		return errClosed
 	}
@@ -179,17 +225,12 @@ func (s *Session) connect() error {
 		conn.Close()
 		return fmt.Errorf("setting deadline on conn to %q: %s", s.addr, err)
 	}
-
-	addr, ok := conn.LocalAddr().(*net.TCPAddr)
-	if !ok {
-		conn.Close()
-		return fmt.Errorf("getting local addr for default nexthop to %q: %s", s.addr, err)
+	if err := s.getDefaultNextHops(conn); err != nil {
+		return err
 	}
-	s.defaultNextHop = addr.IP
-
 	routerID := s.routerID
 	if routerID == nil {
-		routerID = getRouterID(s.defaultNextHop, s.myNode)
+		routerID = getRouterID(s.defaultNextHopV4, s.myNode)
 	}
 
 	if err = sendOpen(conn, s.asn, routerID, s.holdTime); err != nil {
@@ -211,6 +252,8 @@ func (s *Session) connect() error {
 		conn.Close()
 		return fmt.Errorf("peer does not support 4-byte ASNs")
 	}
+	s.mpIPv4Support = op.mp4
+	s.mpIPv6Support = op.mp6
 
 	// BGP session is established, clear the connect timeout deadline.
 	if err := conn.SetDeadline(time.Time{}); err != nil {
@@ -241,22 +284,53 @@ func (s *Session) connect() error {
 	return nil
 }
 
+func (s *Session) getDefaultNextHops(conn net.Conn) error {
+	addr, ok := conn.LocalAddr().(*net.TCPAddr)
+	if !ok {
+		conn.Close()
+		return fmt.Errorf("error getting local addr for default nexthop to %q", s.addr)
+	}
+	if addr.IP.To4() != nil {
+		s.defaultNextHopV4 = addr.IP
+		s.defaultNextHopV6 = findAltIP(addr.IP)
+		if s.defaultNextHopV6 == nil {
+			s.logger.Log("op", "connect", "msg", "can't find IPv6 address to use as next hop")
+		}
+		return nil
+	}
+	s.defaultNextHopV6 = addr.IP
+	s.defaultNextHopV4 = findAltIP(addr.IP)
+	if s.defaultNextHopV4 == nil {
+		s.logger.Log("op", "connect", "msg", "can't find IPv4 address to use as next hop")
+	}
+	return nil
+}
+
 func hashRouterId(hostname string) net.IP {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.LittleEndian, crc32.ChecksumIEEE([]byte(hostname)))
 	return net.IP(buf.Bytes())
 }
 
-// Ipv4; Use the address as-is.
-// Ipv6; Pick the first ipv4 address on the same interface as the address
+// Ipv4 address will be used if it exist
+// hash from hostname value will be used as fallback
 func getRouterID(addr net.IP, myNode string) net.IP {
 	if addr.To4() != nil {
 		return addr
 	}
+	return hashRouterId(myNode)
+}
 
+// if addr is IPv4, will return IPv6 address on the same interface or nil
+// if addr is IPv6, will return IPv4 address on the same interface or nil
+func findAltIP(addr net.IP) net.IP {
+	var findIPv4 bool
+	if addr.To4() == nil {
+		findIPv4 = true
+	}
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return hashRouterId(myNode)
+		return nil
 	}
 	for _, i := range ifaces {
 		addrs, err := i.Addrs()
@@ -271,10 +345,9 @@ func getRouterID(addr net.IP, myNode string) net.IP {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-
 			if ip.Equal(addr) {
 				// This is the interface.
-				// Loop through the addresses again and search for ipv4
+				// Loop through the addresses again and search for IP
 				for _, a := range addrs {
 					var ip net.IP
 					switch v := a.(type) {
@@ -283,15 +356,24 @@ func getRouterID(addr net.IP, myNode string) net.IP {
 					case *net.IPAddr:
 						ip = v.IP
 					}
-					if ip.To4() != nil {
-						return ip
+					if ip == nil {
+						continue
+					}
+					if findIPv4 {
+						if ip.To4() != nil {
+							return ip
+						}
+					} else {
+						if ip.To4() == nil && ip.IsGlobalUnicast() {
+							return ip
+						}
 					}
 				}
-				return hashRouterId(myNode)
+				return nil
 			}
 		}
 	}
-	return hashRouterId(myNode)
+	return nil
 }
 
 // sendKeepalives sends BGP KEEPALIVE packets at the negotiated rate
@@ -425,13 +507,6 @@ func (s *Session) Set(advs ...*Advertisement) error {
 
 	newAdvs := map[string]*Advertisement{}
 	for _, adv := range advs {
-		if adv.Prefix.IP.To4() == nil {
-			return fmt.Errorf("cannot advertise non-v4 prefix %q", adv.Prefix)
-		}
-
-		if adv.NextHop != nil && adv.NextHop.To4() == nil {
-			return fmt.Errorf("next-hop must be IPv4, got %q", adv.NextHop)
-		}
 		if len(adv.Communities) > 63 {
 			return fmt.Errorf("max supported communities is 63, got %d", len(adv.Communities))
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,8 @@ type peer struct {
 	NodeSelectors        []nodeSelector `yaml:"node-selectors"`
 	Password             string         `yaml:"password"`
 	AllowMPBGPEncodingV4 bool           `yaml:"allow-mp-bgp-encoding-ipv4"`
+	AllowV4Prefixes      *bool          `yaml:"allow-ipv4-prefixes"`
+	AllowV6Prefixes      *bool          `yaml:"allow-ipv6-prefixes"`
 }
 
 type nodeSelector struct {
@@ -114,6 +116,10 @@ type Peer struct {
 	Password string
 	// AllowMPBGPEncodingV4 allows MP BGP encoding for IPv4
 	AllowMPBGPEncodingV4 bool
+	// AllowV4Prefixes allows IPv4 prefixes announcements to the peer
+	AllowV4Prefixes bool
+	// AllowV4Prefixes allows IPv6 prefixes announcements to the peer
+	AllowV6Prefixes bool
 	// TODO: more BGP session settings
 }
 
@@ -306,6 +312,15 @@ func parsePeer(p peer) (*Peer, error) {
 	if p.Password != "" {
 		password = p.Password
 	}
+	allowV4Prefixes := true
+	if p.AllowV4Prefixes != nil {
+		allowV4Prefixes = *p.AllowV4Prefixes
+	}
+	allowV6Prefixes := true
+	if p.AllowV6Prefixes != nil {
+		allowV6Prefixes = *p.AllowV6Prefixes
+	}
+
 	return &Peer{
 		MyASN:                p.MyASN,
 		ASN:                  p.ASN,
@@ -316,6 +331,8 @@ func parsePeer(p peer) (*Peer, error) {
 		NodeSelectors:        nodeSels,
 		Password:             password,
 		AllowMPBGPEncodingV4: p.AllowMPBGPEncodingV4,
+		AllowV4Prefixes:      allowV4Prefixes,
+		AllowV6Prefixes:      allowV6Prefixes,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,14 +38,15 @@ type configFile struct {
 }
 
 type peer struct {
-	MyASN         uint32         `yaml:"my-asn"`
-	ASN           uint32         `yaml:"peer-asn"`
-	Addr          string         `yaml:"peer-address"`
-	Port          uint16         `yaml:"peer-port"`
-	HoldTime      string         `yaml:"hold-time"`
-	RouterID      string         `yaml:"router-id"`
-	NodeSelectors []nodeSelector `yaml:"node-selectors"`
-	Password      string         `yaml:"password"`
+	MyASN                uint32         `yaml:"my-asn"`
+	ASN                  uint32         `yaml:"peer-asn"`
+	Addr                 string         `yaml:"peer-address"`
+	Port                 uint16         `yaml:"peer-port"`
+	HoldTime             string         `yaml:"hold-time"`
+	RouterID             string         `yaml:"router-id"`
+	NodeSelectors        []nodeSelector `yaml:"node-selectors"`
+	Password             string         `yaml:"password"`
+	AllowMPBGPEncodingV4 bool           `yaml:"allow-mp-bgp-encoding-ipv4"`
 }
 
 type nodeSelector struct {
@@ -111,6 +112,8 @@ type Peer struct {
 	NodeSelectors []labels.Selector
 	// Authentication password for routers enforcing TCP MD5 authenticated sessions
 	Password string
+	// AllowMPBGPEncodingV4 allows MP BGP encoding for IPv4
+	AllowMPBGPEncodingV4 bool
 	// TODO: more BGP session settings
 }
 
@@ -304,14 +307,15 @@ func parsePeer(p peer) (*Peer, error) {
 		password = p.Password
 	}
 	return &Peer{
-		MyASN:         p.MyASN,
-		ASN:           p.ASN,
-		Addr:          ip,
-		Port:          port,
-		HoldTime:      holdTime,
-		RouterID:      routerID,
-		NodeSelectors: nodeSels,
-		Password:      password,
+		MyASN:                p.MyASN,
+		ASN:                  p.ASN,
+		Addr:                 ip,
+		Port:                 port,
+		HoldTime:             holdTime,
+		RouterID:             routerID,
+		NodeSelectors:        nodeSels,
+		Password:             password,
+		AllowMPBGPEncodingV4: p.AllowMPBGPEncodingV4,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,9 +69,10 @@ type addressPool struct {
 }
 
 type bgpAdvertisement struct {
-	AggregationLength *int `yaml:"aggregation-length"`
-	LocalPref         *uint32
-	Communities       []string
+	AggregationLength   *int `yaml:"aggregation-length"`
+	AggregationLengthV6 *int `yaml:"aggregation-length-v6"`
+	LocalPref           *uint32
+	Communities         []string
 }
 
 // Config is a parsed MetalLB configuration.
@@ -141,6 +142,9 @@ type BGPAdvertisement struct {
 	// length. Optional, defaults to 32 (i.e. no aggregation) if not
 	// specified.
 	AggregationLength int
+	// Optional, defaults to 128 (i.e. no aggregation) if not
+	// specified.
+	AggregationLengthV6 int
 	// Value of the LOCAL_PREF BGP path attribute. Used only when
 	// advertising to IBGP peers (i.e. Peer.MyASN == Peer.ASN).
 	LocalPref uint32
@@ -361,9 +365,10 @@ func parseBGPAdvertisements(ads []bgpAdvertisement, cidrs []*net.IPNet, communit
 	if len(ads) == 0 {
 		return []*BGPAdvertisement{
 			{
-				AggregationLength: 32,
-				LocalPref:         0,
-				Communities:       map[uint32]bool{},
+				AggregationLength:   32,
+				AggregationLengthV6: 128,
+				LocalPref:           0,
+				Communities:         map[uint32]bool{},
 			},
 		}, nil
 	}
@@ -371,21 +376,35 @@ func parseBGPAdvertisements(ads []bgpAdvertisement, cidrs []*net.IPNet, communit
 	var ret []*BGPAdvertisement
 	for _, rawAd := range ads {
 		ad := &BGPAdvertisement{
-			AggregationLength: 32,
-			LocalPref:         0,
-			Communities:       map[uint32]bool{},
+			AggregationLength:   32,
+			AggregationLengthV6: 128,
+			LocalPref:           0,
+			Communities:         map[uint32]bool{},
 		}
 
 		if rawAd.AggregationLength != nil {
 			ad.AggregationLength = *rawAd.AggregationLength
 		}
 		if ad.AggregationLength > 32 {
-			return nil, fmt.Errorf("invalid aggregation length %q", ad.AggregationLength)
+			return nil, fmt.Errorf("invalid aggregation length for IPv4 %q", ad.AggregationLength)
 		}
+
+		if rawAd.AggregationLengthV6 != nil {
+			ad.AggregationLengthV6 = *rawAd.AggregationLengthV6
+		}
+		if ad.AggregationLengthV6 > 128 {
+			return nil, fmt.Errorf("invalid aggregation length for IPv6 %q", ad.AggregationLengthV6)
+		}
+
 		for _, cidr := range cidrs {
 			o, _ := cidr.Mask.Size()
-			if ad.AggregationLength < o {
-				return nil, fmt.Errorf("invalid aggregation length %d: prefix %q in this pool is more specific than the aggregation length", ad.AggregationLength, cidr)
+			maxLength := ad.AggregationLength
+			if cidr.IP.To4() == nil {
+				maxLength = ad.AggregationLengthV6
+			}
+			if maxLength < o {
+				return nil, fmt.Errorf("invalid aggregation length %d: prefix %q in "+
+					"this pool is more specific than the aggregation length", ad.AggregationLength, cidr)
 			}
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,7 @@ address-pools:
   auto-assign: false
   bgp-advertisements:
   - aggregation-length: 32
+    aggregation-length-v6: 64
     localpref: 100
     communities: ["bar", "1234:2345"]
   - aggregation-length: 24
@@ -120,16 +121,18 @@ address-pools:
 						AutoAssign:    false,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								LocalPref:         100,
+								AggregationLength:   32,
+								AggregationLengthV6: 64,
+								LocalPref:           100,
 								Communities: map[uint32]bool{
 									0xfc0004d2: true,
 									0x04D20929: true,
 								},
 							},
 							{
-								AggregationLength: 24,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   24,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -139,8 +142,9 @@ address-pools:
 						AutoAssign: true,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -430,8 +434,9 @@ address-pools:
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},
@@ -455,8 +460,9 @@ address-pools:
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								Communities:         map[uint32]bool{},
 							},
 						},
 					},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,6 +58,7 @@ peers:
 - my-asn: 100
   peer-asn: 200
   peer-address: 2.3.4.5
+  allow-ipv6-prefixes: false
   node-selectors:
   - match-labels:
       foo: bar
@@ -105,6 +106,8 @@ address-pools:
 						RouterID:             net.ParseIP("10.20.30.40"),
 						NodeSelectors:        []labels.Selector{labels.Everything()},
 						AllowMPBGPEncodingV4: true,
+						AllowV4Prefixes:      true,
+						AllowV6Prefixes:      true,
 					},
 					{
 						MyASN:                100,
@@ -114,6 +117,8 @@ address-pools:
 						HoldTime:             90 * time.Second,
 						NodeSelectors:        []labels.Selector{selector("bar in (quux),foo=bar")},
 						AllowMPBGPEncodingV4: false,
+						AllowV4Prefixes:      true,
+						AllowV6Prefixes:      false,
 					},
 				},
 				Pools: map[string]*Pool{
@@ -188,12 +193,14 @@ peers:
 			want: &Config{
 				Peers: []*Peer{
 					{
-						MyASN:         42,
-						ASN:           42,
-						Addr:          net.ParseIP("1.2.3.4"),
-						Port:          179,
-						HoldTime:      90 * time.Second,
-						NodeSelectors: []labels.Selector{labels.Everything()},
+						MyASN:           42,
+						ASN:             42,
+						Addr:            net.ParseIP("1.2.3.4"),
+						Port:            179,
+						HoldTime:        90 * time.Second,
+						NodeSelectors:   []labels.Selector{labels.Everything()},
+						AllowV4Prefixes: true,
+						AllowV6Prefixes: true,
 					},
 				},
 				Pools: map[string]*Pool{},
@@ -272,12 +279,14 @@ peers:
 			want: &Config{
 				Peers: []*Peer{
 					{
-						MyASN:         42,
-						ASN:           42,
-						Addr:          net.ParseIP("1.2.3.4"),
-						Port:          179,
-						HoldTime:      90 * time.Second,
-						NodeSelectors: []labels.Selector{labels.Everything()},
+						MyASN:           42,
+						ASN:             42,
+						Addr:            net.ParseIP("1.2.3.4"),
+						Port:            179,
+						HoldTime:        90 * time.Second,
+						NodeSelectors:   []labels.Selector{labels.Everything()},
+						AllowV4Prefixes: true,
+						AllowV6Prefixes: true,
 					},
 				},
 				Pools: map[string]*Pool{},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,7 @@ peers:
   peer-port: 1179
   hold-time: 180s
   router-id: 10.20.30.40
+  allow-mp-bgp-encoding-ipv4: true
 - my-asn: 100
   peer-asn: 200
   peer-address: 2.3.4.5
@@ -96,21 +97,23 @@ address-pools:
 			want: &Config{
 				Peers: []*Peer{
 					{
-						MyASN:         42,
-						ASN:           142,
-						Addr:          net.ParseIP("1.2.3.4"),
-						Port:          1179,
-						HoldTime:      180 * time.Second,
-						RouterID:      net.ParseIP("10.20.30.40"),
-						NodeSelectors: []labels.Selector{labels.Everything()},
+						MyASN:                42,
+						ASN:                  142,
+						Addr:                 net.ParseIP("1.2.3.4"),
+						Port:                 1179,
+						HoldTime:             180 * time.Second,
+						RouterID:             net.ParseIP("10.20.30.40"),
+						NodeSelectors:        []labels.Selector{labels.Everything()},
+						AllowMPBGPEncodingV4: true,
 					},
 					{
-						MyASN:         100,
-						ASN:           200,
-						Addr:          net.ParseIP("2.3.4.5"),
-						Port:          179,
-						HoldTime:      90 * time.Second,
-						NodeSelectors: []labels.Selector{selector("bar in (quux),foo=bar")},
+						MyASN:                100,
+						ASN:                  200,
+						Addr:                 net.ParseIP("2.3.4.5"),
+						Port:                 179,
+						HoldTime:             90 * time.Second,
+						NodeSelectors:        []labels.Selector{selector("bar in (quux),foo=bar")},
+						AllowMPBGPEncodingV4: false,
 					},
 				},
 				Pools: map[string]*Pool{

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -186,7 +186,8 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			}
 			s, err := newBGP(c.logger, net.JoinHostPort(
 				p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN,
-				routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode, p.cfg.AllowMPBGPEncodingV4)
+				routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode,
+				p.cfg.AllowMPBGPEncodingV4, p.cfg.AllowV4Prefixes, p.cfg.AllowV6Prefixes)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -291,6 +292,8 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 }
 
 var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP,
-	asn uint32, hold time.Duration, password string, myNode string, allowMPBGPEncodingV4 bool) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode, allowMPBGPEncodingV4)
+	asn uint32, hold time.Duration, password string, myNode string,
+	allowMPBGPEncodingV4, allowV4Prefixes, allowV6Prefixes bool) (session, error) {
+	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode,
+		allowMPBGPEncodingV4, allowV4Prefixes, allowV6Prefixes)
 }

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -184,7 +184,9 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
+			s, err := newBGP(c.logger, net.JoinHostPort(
+				p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN,
+				routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode, p.cfg.AllowMPBGPEncodingV4)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -288,6 +290,7 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP,
+	asn uint32, hold time.Duration, password string, myNode string, allowMPBGPEncodingV4 bool) (session, error) {
+	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode, allowMPBGPEncodingV4)
 }

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -211,6 +211,10 @@ func (c *bgpController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 	c.svcAds[name] = nil
 	for _, adCfg := range pool.BGPAdvertisements {
 		m := net.CIDRMask(adCfg.AggregationLength, 32)
+		isIPv6 := lbIP.To4() == nil
+		if isIPv6 {
+			m = net.CIDRMask(adCfg.AggregationLengthV6, 128)
+		}
 		ad := &bgp.Advertisement{
 			Prefix: &net.IPNet{
 				IP:   lbIP.Mask(m),

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -95,7 +95,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string, _ bool) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string, _, _, _ bool) (session, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -95,7 +95,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string, _ bool) (session, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -92,6 +92,9 @@ By default, BGP speaker will announce IPv4 prefixes as specified in RFC4271.
 For IPv6 prefixes Multiprotocol extension for BGP-4 (RFC4760) will be used.
 If peer supports Multiprotocol encoding for IPv4 you can allow MetalLB to use it via `allow-mp-bgp-encoding-ipv4` option.
 
+`allow-ipv4-prefixes` and `allow-ipv6-prefixes` peers options provide additional control of prefixes announcement to the peer. By default, both options are `true`. As a result, announce of both address families will happen to the peer. You can disable announcements of the specific IP address family by settings these options to `false`.
+
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -108,12 +111,13 @@ data:
     - peer-address: 10.0.0.2
       peer-asn: 64501
       my-asn: 64500
-      allow-mp-bgp-encoding-ipv4: false
+      allow-ipv6-prefixes: false
     address-pools:
     - name: default
       protocol: bgp
       addresses:
       - 192.168.10.0/24
+      - 2001:db8:a0b:12f0::/64
 ```
 
 ### Advertisement configuration

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -92,7 +92,7 @@ data:
 
 By default, BGP mode advertises each allocated IP to the configured
 peers with no additional BGP attributes. The peer router(s) will
-receive one `/32` route for each service IP, with the BGP localpref
+receive one `/32` (`/128` for IPv6) route for each service IP, with the BGP localpref
 set to zero and no BGP communities.
 
 You can configure more elaborate advertisements by adding a
@@ -100,7 +100,7 @@ You can configure more elaborate advertisements by adding a
 advertisements.
 
 In addition to specifying localpref and communities, you can use this
-to advertise aggregate routes. The `aggregation-length` advertisement
+to advertise aggregate routes. The `aggregation-length` (`aggregation-length-v6` for IPv6) advertisement
 option lets you "roll up" the /32s into a larger prefix. Combined with
 multiple advertisement configurations, this lets you create elaborate
 advertisements that interoperate with the rest of your BGP network.

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -88,6 +88,34 @@ data:
       - 192.168.10.0/24
 ```
 
+By default, BGP speaker will announce IPv4 prefixes as specified in RFC4271. 
+For IPv6 prefixes Multiprotocol extension for BGP-4 (RFC4760) will be used.
+If peer supports Multiprotocol encoding for IPv4 you can allow MetalLB to use it via `allow-mp-bgp-encoding-ipv4` option.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers:
+    - peer-address: 10.0.0.1
+      peer-asn: 64501
+      my-asn: 64500
+      allow-mp-bgp-encoding-ipv4: true
+    - peer-address: 10.0.0.2
+      peer-asn: 64501
+      my-asn: 64500
+      allow-mp-bgp-encoding-ipv4: false
+    address-pools:
+    - name: default
+      protocol: bgp
+      addresses:
+      - 192.168.10.0/24
+```
+
 ### Advertisement configuration
 
 By default, BGP mode advertises each allocated IP to the configured


### PR DESCRIPTION
Another implementation of IPv6 support for BGP speaker.
Implementation based on rfc4760. 
MP BGP encoding will be used for IPv4 and IPv6 prefixes if the peer supports it. If peer don't announce support for MP BGP for IPv4, then legacy BGP encoding will be used.
It is possible to announce IPv4 prefixes over IPv6 and vice versa.
Additional configuration option was added to support aggregation for IPv6 prefixes.

The patch was tested with Dell OS 10 switches.
PCAP files:
https://github.com/ykulazhenkov/metallb-pcap