### PR TITLE
SpeakerList improvements

### DIFF
--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -56,17 +56,6 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "metallb.fullname" . }}-pod-lister
-  namespace: {{ .Release.Namespace }}
-  labels: {{- include "metallb.labels" . | nindent 4 }}
-rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list"]
 {{- if .Values.speaker.memberlist.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -135,20 +124,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "metallb.fullname" . }}-config-watcher
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "metallb.fullname" . }}-pod-lister
-  namespace: {{ .Release.Namespace }}
-  labels: {{- include "metallb.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "metallb.fullname" . }}-pod-lister
-subjects:
-- kind: ServiceAccount
-  name: {{ include "metallb.speaker.serviceAccountName" . }}
 {{- if .Values.speaker.memberlist.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -62,6 +62,8 @@ spec:
               fieldPath: status.podIP
         - name: METALLB_ML_LABELS
           value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
+        - name: METALLB_SERVICE
+          value: "{{ include "metallb.fullname" . }}-speaker-svc"
         - name: METALLB_ML_BIND_PORT
           value: "{{ .Values.speaker.memberlist.mlBindPort }}"
         - name: METALLB_ML_SECRET_KEY
@@ -135,4 +137,16 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "metallb.fullname" . }}-speaker-svc
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "metallb.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "metallb.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: speaker
+  clusterIP: None
 {{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -60,8 +60,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        - name: METALLB_ML_LABELS
-          value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
         - name: METALLB_SERVICE
           value: "{{ include "metallb.fullname" . }}-speaker-svc"
         - name: METALLB_ML_BIND_PORT

--- a/controller/main.go
+++ b/controller/main.go
@@ -156,7 +156,7 @@ func main() {
 	client, err := k8s.New(&k8s.Config{
 		ProcessName:   "metallb-controller",
 		ConfigMapName: *config,
-		ConfigMapNS:   *namespace,
+		Namespace:     *namespace,
 		MetricsPort:   *port,
 		Logger:        logger,
 		Kubeconfig:    *kubeconfig,

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -380,19 +380,6 @@ func (c *Client) CreateMlSecret(namespace, controllerDeploymentName, secretName 
 	return err
 }
 
-// PodIPs returns the IPs of all the pods matched by the labels string.
-func (c *Client) PodIPs(namespace, labels string) ([]string, error) {
-	pl, err := c.client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels})
-	if err != nil {
-		return nil, err
-	}
-	iplist := []string{}
-	for _, pod := range pl.Items {
-		iplist = append(iplist, pod.Status.PodIP)
-	}
-	return iplist, nil
-}
-
 // Run watches for events on the Kubernetes cluster, and dispatches
 // calls to the Controller.
 func (c *Client) Run(stopCh <-chan struct{}) error {

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -76,7 +76,7 @@ const (
 type Config struct {
 	ProcessName   string
 	ConfigMapName string
-	ConfigMapNS   string
+	Namespace     string
 	NodeName      string
 	MetricsHost   string
 	MetricsPort   int
@@ -267,7 +267,7 @@ func New(cfg *Config) (*Client, error) {
 				}
 			},
 		}
-		cmWatcher := cache.NewListWatchFromClient(c.client.CoreV1().RESTClient(), "configmaps", cfg.ConfigMapNS, fields.OneTermEqualSelector("metadata.name", cfg.ConfigMapName))
+		cmWatcher := cache.NewListWatchFromClient(c.client.CoreV1().RESTClient(), "configmaps", cfg.Namespace, fields.OneTermEqualSelector("metadata.name", cfg.ConfigMapName))
 		c.cmIndexer, c.cmInformer = cache.NewIndexerInformer(cmWatcher, &v1.ConfigMap{}, 0, cmHandlers, cache.Indexers{})
 
 		c.configChanged = cfg.ConfigChanged

--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -27,6 +27,7 @@ import (
 
 // SpeakerList represents a list of healthy speakers.
 type SpeakerList struct {
+	sync.Mutex  // Must be locked while accessing any of the internal SpeakerList maps or arrays.
 	l           log.Logger
 	client      *k8s.Client
 	resyncSvcCh chan struct{}
@@ -38,8 +39,7 @@ type SpeakerList struct {
 	ml        *memberlist.Memberlist
 	mlJoinCh  chan struct{}
 
-	mlMux        sync.Mutex // Mutex for mlSpeakerIPs.
-	mlSpeakerIPs []string   // Speaker pod IPs.
+	mlSpeakerIPs []string // Speaker pod IPs.
 }
 
 // New creates a new SpeakerList and returns a pointer to it.
@@ -139,9 +139,9 @@ func (sl *SpeakerList) Start(client *k8s.Client) {
 		iplist = nil
 	}
 
-	sl.mlMux.Lock()
+	sl.Lock()
 	sl.mlSpeakerIPs = iplist
-	sl.mlMux.Unlock()
+	sl.Unlock()
 
 	// Update mlSpeakerIPs in the background.
 	go sl.updateSpeakerIPs()
@@ -170,9 +170,9 @@ func (sl *SpeakerList) updateSpeakerIPs() {
 				continue
 			}
 
-			sl.mlMux.Lock()
+			sl.Lock()
 			sl.mlSpeakerIPs = iplist
-			sl.mlMux.Unlock()
+			sl.Unlock()
 		}
 	}
 }
@@ -242,8 +242,8 @@ func (sl *SpeakerList) mlJoin() {
 
 	members := sl.members()
 
-	sl.mlMux.Lock()
-	defer sl.mlMux.Unlock()
+	sl.Lock()
+	defer sl.Unlock()
 
 	for _, ip := range sl.mlSpeakerIPs {
 		// If an IP is not a member of the cluster, add it to joinIPs.

--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -228,6 +228,11 @@ func (sl *SpeakerList) members() map[string]struct{} {
 	return members
 }
 
+// SetSpeakers updates k8sSpeakers.
+func (sl *SpeakerList) SetSpeakers(eps k8s.EpsOrSlices) {
+	// to be implemented
+}
+
 // mlJoin joins speaker pods that are not members of this cluster
 // to the cluster. It performs a memberlist.Join() with the IPs in
 // mlSpeakerIPs that are not members of the cluster.

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -194,21 +194,6 @@ kind: Role
 metadata:
   labels:
     app: metallb
-  name: pod-lister
-  namespace: metallb-system
-rules:
-- apiGroups:
-  - ''
-  resources:
-  - pods
-  verbs:
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app: metallb
   name: controller
   namespace: metallb-system
 rules:
@@ -279,21 +264,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller
-- kind: ServiceAccount
-  name: speaker
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app: metallb
-  name: pod-lister
-  namespace: metallb-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: pod-lister
-subjects:
 - kind: ServiceAccount
   name: speaker
 ---
@@ -371,8 +341,6 @@ spec:
         # and the PodSecurityPolicy hostPorts definition
         #- name: METALLB_ML_BIND_PORT
         #  value: "7946"
-        - name: METALLB_ML_LABELS
-          value: "app=metallb,component=speaker"
         - name: METALLB_SERVICE
           value: "speaker"
         - name: METALLB_ML_SECRET_KEY

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -297,6 +297,20 @@ subjects:
 - kind: ServiceAccount
   name: speaker
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    app: metallb
+    component: speaker
+  clusterIP: None
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -359,6 +373,8 @@ spec:
         #  value: "7946"
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
+        - name: METALLB_SERVICE
+          value: "speaker"
         - name: METALLB_ML_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -295,3 +295,7 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 var newBGP = func(logger log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
 	return bgp.New(logger, addr, srcAddr, myASN, routerID, asn, hold, password, myNode)
 }
+
+func (c *bgpController) SetSpeakers(l log.Logger, eps k8s.EpsOrSlices) error {
+	return nil
+}

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -131,3 +131,8 @@ func (c *layer2Controller) SetNode(log.Logger, *v1.Node) error {
 	c.sList.Rejoin()
 	return nil
 }
+
+func (c *layer2Controller) SetSpeakers(l log.Logger, eps k8s.EpsOrSlices) error {
+	c.sList.SetSpeakers(eps)
+	return nil
+}

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -18,8 +18,8 @@ type fakeSpeakerList struct {
 	speakers map[string]bool
 }
 
-func (sl *fakeSpeakerList) UsableSpeakers() map[string]bool {
-	return sl.speakers
+func (sl *fakeSpeakerList) UsableSpeakers() (map[string]bool, error) {
+	return sl.speakers, nil
 }
 
 func (sl *fakeSpeakerList) SetSpeakers(eps k8s.EpsOrSlices) {}

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -22,6 +22,8 @@ func (sl *fakeSpeakerList) UsableSpeakers() map[string]bool {
 	return sl.speakers
 }
 
+func (sl *fakeSpeakerList) SetSpeakers(eps k8s.EpsOrSlices) {}
+
 func (sl *fakeSpeakerList) Rejoin() {}
 
 func compareUseableNodesReturnedValue(a, b []string) bool {

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -131,7 +131,7 @@ func main() {
 	client, err := k8s.New(&k8s.Config{
 		ProcessName:   "metallb-speaker",
 		ConfigMapName: *config,
-		ConfigMapNS:   *namespace,
+		Namespace:     *namespace,
 		NodeName:      *myNode,
 		Logger:        logger,
 		Kubeconfig:    *kubeconfig,

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -26,7 +26,21 @@ Changes in behavior:
   speaker when installing using manifests, or by overriding helm values `controller.logLevel=all` 
   and `speaker.logLevel=all` when installing with Helm.
 
+- MetalLB now uses a headless service to track the speakers. You must
+  configure `METALLB_SERVICE`/`service` and create the service. Manifests and
+  charts provided by MetalLB have been updated to create this new service.
+  If you are using your own manifests, you must update them. ([#595](https://github.com/metallb/metallb/pull/595))
+
+- The `METALLB_ML_LABELS`/`ml-labels` config option has been removed.
+  The `pod-lister` role/rolebinding are not used anymore and have been removed.
+  If you are using MetalLB-provided manifests to deploy, you can clean the old resources up by running
+  `kubectl delete -n metallb-system role/pod-lister rolebinding/pod-lister`. ([#595](https://github.com/metallb/metallb/pull/595))
+
 Bug Fixes:
+
+- MetalLB now only considers ready speakers when memberlist is disabled.
+  This allows `externalTrafficPolicy: cluster` services to work when MetalLB
+  speakers run only on a subset of the nodes. ([#595](https://github.com/metallb/metallb/pull/595))
 
 ## Version 0.10.3
 


### PR DESCRIPTION
## General

This was a fix for #589. Now it's just the end of the SpeakerList refactor.

At the beginning, this PR was just a full rework of memberlist and bits of layer2. A part of it was merged along the way and it's still big in part because it undoes https://github.com/metallb/metallb/pull/662/commits/cf494a91b267626753530c47ae482250ae1886eb.

It does multiple cleanups / fixes:

1) Stop using Memberlist.Members() as it's racy.
2) Remove the direct dependency between SpeakerList and k8s.Client.
3) Stop polling the API and use watches.
4) Only consider ready speakers when memberlist is disabled.

To achieve no. 3, there is one user-facing change: We introduce a headless speaker service.

## TODO

- [ ] Tests