### PR TITLE
Limit announcement of address pools to specific BGP peers

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,7 @@ peers:
   peer-port: 1179
   hold-time: 180s
   router-id: 10.20.30.40
+  address-pools: ["pool2"]
 - my-asn: 100
   peer-asn: 200
   peer-address: 2.3.4.5
@@ -102,6 +103,7 @@ address-pools:
 						HoldTime:      180 * time.Second,
 						RouterID:      net.ParseIP("10.20.30.40"),
 						NodeSelectors: []labels.Selector{labels.Everything()},
+						AddressPools:  map[string]struct{}{"pool2": {}},
 					},
 					{
 						MyASN:         100,
@@ -110,10 +112,12 @@ address-pools:
 						Port:          179,
 						HoldTime:      90 * time.Second,
 						NodeSelectors: []labels.Selector{selector("bar in (quux),foo=bar")},
+						AddressPools:  nil,
 					},
 				},
 				Pools: map[string]*Pool{
 					"pool1": {
+						Name:          "pool1",
 						Protocol:      BGP,
 						CIDR:          []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
 						AvoidBuggyIPs: true,
@@ -134,6 +138,7 @@ address-pools:
 						},
 					},
 					"pool2": {
+						Name:       "pool2",
 						Protocol:   BGP,
 						CIDR:       []*net.IPNet{ipnet("30.0.0.0/8")},
 						AutoAssign: true,
@@ -145,6 +150,7 @@ address-pools:
 						},
 					},
 					"pool3": {
+						Name:     "pool3",
 						Protocol: Layer2,
 						CIDR: []*net.IPNet{
 							ipnet("40.0.0.0/25"),
@@ -162,6 +168,7 @@ address-pools:
 						AutoAssign: true,
 					},
 					"pool4": {
+						Name:       "pool4",
 						Protocol:   Layer2,
 						CIDR:       []*net.IPNet{ipnet("2001:db8::/64")},
 						AutoAssign: true,
@@ -412,6 +419,7 @@ address-pools:
 			want: &Config{
 				Pools: map[string]*Pool{
 					"pool1": {
+						Name:       "pool1",
 						Protocol:   BGP,
 						AutoAssign: true,
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
@@ -437,6 +445,7 @@ address-pools:
 			want: &Config{
 				Pools: map[string]*Pool{
 					"pool1": {
+						Name:       "pool1",
 						Protocol:   BGP,
 						AutoAssign: true,
 						CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
@@ -599,6 +608,31 @@ address-pools:
   - 10.0.0.0/16
   bgp-advertisements:
   - communities: ["flarb"]
+`,
+		},
+		{
+			desc: "Unknown address pool in peer config",
+			raw: `
+peers:
+- my-asn: 42
+  peer-asn: 42
+  peer-address: 1.2.3.4
+  address-pools: ["pool1"]
+`,
+		},
+		{
+			desc: "Invalid address pool type in peer config",
+			raw: `
+peers:
+- my-asn: 42
+  peer-asn: 42
+  peer-address: 1.2.3.4
+  address-pools: ["pool1"]
+address-pools:
+- name: pool1
+  protocol: layer2
+  addresses:
+  - 10.0.0.0/16
 `,
 		},
 	}

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -44,6 +44,10 @@ data:
         - key: beta.kubernetes.io/arch
           operator: In
           values: [amd64, arm]
+      # (optional) Select address pools which will be anounced to the peer
+      # By default, all address-pools will be anounced
+      address-pools:
+      -  my-ip-space
 
     # The address-pools section lists the IP addresses that MetalLB is
     # allowed to allocate, along with settings for how to advertise

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/k8s"
 	"go.universe.tf/metallb/internal/layer2"
@@ -230,7 +229,7 @@ func newController(cfg controllerConfig) (*controller, error) {
 		config.BGP: &bgpController{
 			logger: cfg.Logger,
 			myNode: cfg.MyNode,
-			svcAds: make(map[string][]*bgp.Advertisement),
+			svcAds: make(map[string][]*advertisementData),
 		},
 	}
 

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -275,3 +275,31 @@ misguided
 If you encounter this issue with your users or networks, you can set
 `avoid-buggy-ips: true` on an address pool to mark `.0` and `.255`
 addresses as unusable.
+
+### Limit which peers will receive announcements for address pool
+By default, every address pool will be announced to each BGP peer defined in the configuration.
+It is possible to explicitly select which address pools will be announced to the peer.
+
+```yaml
+peers:
+- peer-address: 10.0.0.1
+  peer-asn: 64501
+  my-asn: 64500
+- peer-address: 10.0.0.2
+  peer-asn: 64502
+  my-asn: 64500
+  address-pools:
+  - pool2
+address-pools:
+- name: pool1
+  protocol: bgp
+  addresses:
+  - 192.168.144.0/20
+- name: pool2
+  protocol: bgp
+  addresses:
+  - 42.176.25.64/30
+```
+
+Peer `10.0.0.1` will receive prefixes from `pool1` and `pool2`.
+Peer  `10.0.0.2` will receive prefixes from `pool2` only.


### PR DESCRIPTION
This patch provides ability to configure exact set of address pools that should be announced to a specific BGP peer, as described in https://github.com/metallb/metallb/issues/521
Example config:
```
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: metallb-system
  name: config
data:
  config: |
    peers:
    - peer-address: 10.0.0.1
      peer-asn: 64501
      my-asn: 64500
      address-pools:
      - default
    - peer-address: 172.0.0.1
      peer-asn: 64501
      my-asn: 64500
      address-pools:
      - dmz       
    address-pools:
    - name: default
      protocol: bgp
      addresses:
      - 192.168.10.0/24
    - name: dmz
      protocol: bgp
      addresses:
      - 10.168.10.0/24
```
![image](https://user-images.githubusercontent.com/60463629/80602718-1d253200-8a38-11ea-9880-9aa1a8c5927c.png)

