### PR TITLE
allow speaker to run on nodes that have taints

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -339,8 +339,12 @@ spec:
       serviceAccountName: speaker
       terminationGracePeriodSeconds: 2
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - operator: Exists
+        effect: NoExecute
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
this is a small change on the speaker daemonSet taint toleration.
just to let speaker to run on nodes that user have put custom taints on. 
otherwise those nodes won't get speaker running therefore can't be the nodes for external traffic.

 Changes to be committed:
	modified:   metallb.yaml

