### PR TITLE
website: Update maintainers description

### DIFF
--- a/website/content/concepts/maturity.md
+++ b/website/content/concepts/maturity.md
@@ -55,13 +55,13 @@ MetalLB's copyright was owned by Google, until March 2019. However, it
 was never an official Google project. The project doesn't have any
 form of corporate sponsorship.
 
-The majority of code changes, as well as the overall direction of the project,
-is a personal endeavor of [one person](https://www.dave.tf), working on MetalLB
-in their spare time as motivation allows.
+MetalLB was created by [one person](https://www.dave.tf), working on MetalLB in
+their spare time as motivation allows.  The original author has now been
+empowering a [team of maintainers]({{% relref "community/_index.md"
+%}}#contributing) to assist with moving the project forward.
 
-This means that, currently, support and new feature development is mostly at the
-mercy of one person's availability and resources. You should set your
-expectations appropriately.
+Most support and new feature development is at the mercy of the availability of
+this small group, so you should set your expectations accordingly.
 
 If you would like to help improve this balance, [contributions]({{% relref
 "community/_index.md" %}}#contributing) are very welcome! In addition to code


### PR DESCRIPTION
I'm very new to the MetalLB community, but based on my limited
experience so far, it seemed like this text wasn't quite up to date
with the current state since I've seen other maintainers handling some
PRs.

This change also links to the contributing page as a place to find out
more info on who the current maintainers are.  That information is not
there currently, but it seems like an appropriate place to add it.