### PR TITLE
ci: Set up build and unit test CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: metallb-ci
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+env:
+  GO_VERSION: 1.13.4
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "::set-env name=GOPATH::$GOPATH"
+        export PATH=$GOPATH/bin:$PATH
+        echo "::add-path::$GOPATH/bin"
+
+    - name: Install invoke -- www.pyinvoke.org
+      run: |
+        sudo pip install invoke semver
+
+    - name: Build
+      run: |
+        inv build
+
+  unit:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "::set-env name=GOPATH::$GOPATH"
+        export PATH=$GOPATH/bin:$PATH
+        echo "::add-path::$GOPATH/bin"
+
+    - name: Install invoke -- www.pyinvoke.org
+      run: |
+        sudo pip install invoke semver
+
+    - name: Run tests
+      run: |
+        inv unit

--- a/tasks.py
+++ b/tasks.py
@@ -77,7 +77,7 @@ def build(ctx, binaries, architectures, tag="dev", docker_user="metallb"):
     binaries = _check_binaries(binaries)
     architectures = _check_architectures(architectures)
     _make_build_dirs()
-    
+
     commit = run("git describe --dirty --always", hide=True).stdout.strip()
     branch = run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
 
@@ -142,7 +142,7 @@ def push_multiarch(ctx, binaries, tag="dev", docker_user="metallb"):
     binaries = _check_binaries(binaries)
     architectures = _check_architectures(["all"])
     push(ctx, binaries=binaries, architectures=architectures, tag=tag, docker_user=docker_user)
-    
+
     platforms = ",".join("linux/{}".format(arch) for arch in architectures)
     for bin in binaries:
         run("manifest-tool push from-args "
@@ -272,7 +272,7 @@ def release(ctx, version, skip_release_notes=False):
     status = run("git status --porcelain", hide=True).stdout.strip()
     if status != "":
         raise Exit(message="git checkout not clean, cannot release")
-    
+
     version = semver.parse_version_info(version)
     is_patch_release = version.patch != 0
 
@@ -323,3 +323,8 @@ def release(ctx, version, skip_release_notes=False):
     run("git commit -a -m 'Automated update for release v{}'".format(version), echo=True)
     run("git tag v{} -m 'See the release notes for details:\n\nhttps://metallb.universe.tf/release-notes/#version-{}-{}-{}'".format(version, version.major, version.minor, version.patch), echo=True)
     run("git checkout main", echo=True)
+
+@task()
+def unit(ctx):
+    """Run unit tests."""
+    run("go test -short ./...", echo=True)


### PR DESCRIPTION
This change sets up two CI jobs using Github actions.  This
environment seems like a good fit since it's free, included with
github, and capable of running e2e CI jobs based on kind.

In addition to the CI jobs, this change adds a new "unit" target for
invoke so that it's easy to manually run the same commands that are
used in CI.