### PR TITLE
Update addresses_in_use_total metric in Unassign

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -207,6 +207,7 @@ func (a *Allocator) Unassign(svc string) bool {
 		delete(a.poolIPsInUse[al.pool], al.ip.String())
 	}
 	a.poolServices[al.pool]--
+	stats.poolActive.WithLabelValues(al.pool).Set(float64(a.poolServices[al.pool]))
 	return true
 }
 


### PR DESCRIPTION
Update stats in the `Allocator.Unassign()` method.

Fixes #622

Signed-off-by: Lars Ekman <lars.g.ekman@est.tech>
