### PR TITLE
Out of date insall instructions for kustomize

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -79,8 +79,10 @@ on the remote kustomization fle :
 # kustomization.yml
 namespace: metallb-system
 
+bases:
+  - https://github.com/metallb/metallb/manifests?ref=v0.9.3
+
 resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
   - configmap.yml 
   - secret.yml
 ```
@@ -96,8 +98,8 @@ the configMap, as MetalLB is waiting for a configMap named `config`
 # kustomization.yml
 namespace: metallb-system
 
-resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
+bases:
+  - https://github.com/metallb/metallb/manifests?ref=v0.9.3
 
 configMapGenerator:
 - name: config


### PR DESCRIPTION
I'm not sure if referring to a URL was ever permitted in the resources section, but it is not possible in the kustomize version bundled with recent releases of `kubectl`. Instead, remote `kustomization.yaml` files can be referenced in the `bases:` section. I've also updated the tag to the current release, I'm not sure if there is a better way to ensure that the tag remains up to date.
