### PR TITLE
Fix small bug in tasks.py error handling

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -49,7 +49,7 @@ def _check_binaries(binaries):
             out |= all_binaries
         elif binary not in all_binaries:
             print("Unknown binary {}".format(binary))
-            print("Known binaries: {}".format(", ",join(sorted(all_binaries))))
+            print("Known binaries: {}".format(", ".join(sorted(all_binaries))))
             sys.exit(1)
         else:
             out.add(binary)


### PR DESCRIPTION
A comma got used where a period was needed.
