### PR TITLE
circleci: Update branch filters for deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,9 @@ workflows:
       - deploy-controller:
           filters:
             branches:
-              ignore: /pull\/.*/
+              only:
+                - main
+                - /v.*/
             tags:
               only: /.*/
           requires:
@@ -63,7 +65,9 @@ workflows:
       - deploy-speaker:
           filters:
             branches:
-              ignore: /pull\/.*/
+              only:
+                - main
+                - /v.*/
             tags:
               only: /.*/
           requires:


### PR DESCRIPTION
The config attempted to filter out PRs already, but for some reason it
didn't work.  This updated config just explicitly lists the branches
to run against: main and the v.* release branches.  This makes it skip
PRs for those jobs in my testing.