### PR TITLE
Work with python invoke-powered build process

### DIFF
--- a/e2etest/main_test.go
+++ b/e2etest/main_test.go
@@ -17,11 +17,9 @@ func TestMain(m *testing.M) {
 	}
 
 	cmd := exec.Command(
-		"go", "run", "make.go",
-		"-a", "build,image",
-		"-b", "controller,speaker,e2etest-mirror-server",
+		"inv", "build",
+		"--binaries", "all",
 		"--tag", "e2e",
-		"--registry", "metallb",
 	)
 	cmd.Dir = ".."
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
main_test.go still assumed the old make.go process.  This doesn't get us to working e2e tests but it's a step in the right direction.
