### PR TITLE
tasks.py: Drop unused imports

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,15 +1,9 @@
-import glob
 import os
-import re
 import semver
 import shutil
 import sys
 import yaml
 import tempfile
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
 try:
     from urllib.request import urlopen
 except ImportError:


### PR DESCRIPTION
Drop a few imports that are not used.  These were pointed out by the
flake8 utility.