### PR TITLE
Add exec permission to controller in docker image

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,6 @@
 FROM alpine:latest
 
 ADD controller /controller
+# The file is owned by root. Make sure non-root user can execute it
+RUN chmod a+x /controller
 ENTRYPOINT ["/controller"]


### PR DESCRIPTION
metallb.yaml runs controller as non-root user but in docker image,
controller binary is owned by root. Because docker ADD keeps file
permission, this change makes sure that /controller can be exeucted by
non-root user in the docker image.

fixes #643

Thanks for sending a pull request! A few things before we get started:

1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/google/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
