### PR TITLE
RFC: Layer2: Make nodes re-join memberlist cluster

### DIFF
--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -1,0 +1,146 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package speakerlist
+
+import (
+	"crypto/sha256"
+	golog "log"
+	"strconv"
+	"time"
+
+	"go.universe.tf/metallb/internal/k8s"
+
+	gokitlog "github.com/go-kit/kit/log"
+	"github.com/hashicorp/memberlist"
+)
+
+// SpeakerList gives you the list of healthy speaker
+type SpeakerList struct {
+	l         gokitlog.Logger
+	client    *k8s.Client
+	stopCh    chan struct{}
+	namespace string
+	labels    string
+	// following fields are nil when MemberList is disabled
+	mlEventCh chan memberlist.NodeEvent
+	mList     *memberlist.Memberlist
+}
+
+// New creates a new SpeakerList
+func New(logger gokitlog.Logger, nodeName, bindAddr, bindPort, secret, namespace, labels string, stopCh chan struct{}) (*SpeakerList, error) {
+	sl := SpeakerList{
+		l:         logger,
+		stopCh:    stopCh,
+		namespace: namespace,
+		labels:    labels,
+	}
+
+	if namespace == "" || labels == "" || bindAddr == "" {
+		logger.Log("op", "startup", "msg", "Not starting fast dead node detection (MemberList), need ml-bindaddr / ml-labels / ml-namespace config")
+		return &sl, nil
+	}
+
+	mconfig := memberlist.DefaultLANConfig()
+	// mconfig.Name MUST be spec.nodeName, as we will match it against Enpoints nodeName in usableNodes()
+	mconfig.Name = nodeName
+	mconfig.BindAddr = bindAddr
+	if bindPort != "" {
+		mlport, err := strconv.Atoi(bindPort)
+		if err != nil {
+			sl.l.Log("op", "startup", "error", "unable to parse ml-bindport", "msg", err)
+			return nil, err
+		}
+		mconfig.BindPort = mlport
+		mconfig.AdvertisePort = mlport
+	}
+	loggerout := gokitlog.NewStdlibAdapter(gokitlog.With(sl.l, "component", "MemberList"))
+	mconfig.Logger = golog.New(loggerout, "", golog.Lshortfile)
+	if secret == "" {
+		sl.l.Log("op", "startup", "warning", "no ml-secret-key set, MemberList traffic will not be encrypted")
+	} else {
+		sha := sha256.New()
+		mconfig.SecretKey = sha.Sum([]byte(secret))[:16]
+	}
+	// ChannelEventDelegate hint that it should not block, so make mlEventCh 'big'
+	sl.mlEventCh = make(chan memberlist.NodeEvent, 1024)
+	mconfig.Events = &memberlist.ChannelEventDelegate{Ch: sl.mlEventCh}
+	var err error
+	sl.mList, err = memberlist.Create(mconfig)
+	if err != nil {
+		sl.l.Log("op", "startup", "error", err, "msg", "failed to create memberlist")
+		return nil, err
+	}
+	return &sl, nil
+}
+
+// Start starts the needed goroutines
+func (sl *SpeakerList) Start(client *k8s.Client) error {
+	sl.client = client
+
+	if sl.mList == nil {
+		return nil
+	}
+
+	go sl.memberlistWatchEvents()
+
+	iplist, err := sl.client.GetPodsIPs(sl.namespace, sl.labels)
+	if err != nil {
+		sl.l.Log("op", "startup", "error", err, "msg", "failed to get PodsIPs")
+		return err
+	}
+	n, err := sl.mList.Join(iplist)
+	sl.l.Log("op", "startup", "msg", "Memberlist join", "nb joigned", n, "error", err)
+
+	return nil
+}
+
+// UsableSpeakers return a map of usable nodes
+func (sl *SpeakerList) UsableSpeakers() map[string]bool {
+	if sl.mList == nil {
+		return nil
+	}
+	activeNodes := map[string]bool{}
+	for _, n := range sl.mList.Members() {
+		activeNodes[n.Name] = true
+	}
+	return activeNodes
+}
+
+// Stop properly Leave / Shutdown MemberList cluster
+func (sl *SpeakerList) Stop() {
+	if sl.mList == nil {
+		return
+	}
+	sl.l.Log("op", "shutdown", "msg", "leaving MemberList cluster")
+	err := sl.mList.Leave(time.Second)
+	sl.l.Log("op", "shutdown", "msg", "left MemberList cluster", "error", err)
+	err = sl.mList.Shutdown()
+	sl.l.Log("op", "shutdown", "msg", "MemberList shutdown", "error", err)
+}
+
+func event2String(e memberlist.NodeEventType) string {
+	return []string{"NodeJoin", "NodeLeave", "NodeUpdate"}[e]
+}
+
+func (sl *SpeakerList) memberlistWatchEvents() {
+	for {
+		select {
+		case e := <-sl.mlEventCh:
+			sl.l.Log("msg", "Node event", "node addr", e.Node.Addr, "node name", e.Node.Name, "node event", event2String(e.Event))
+			sl.l.Log("msg", "Call Force Sync")
+			sl.client.ForceSync()
+		case <-sl.stopCh:
+			return
+		}
+	}
+}

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -269,8 +269,6 @@ type session interface {
 	Set(advs ...*bgp.Advertisement) error
 }
 
-func (c *bgpController) SetLeader(log.Logger, bool) {}
-
 func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	nodeLabels := node.Labels
 	if nodeLabels == nil {

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 
 	"github.com/go-kit/kit/log"
-	"github.com/hashicorp/memberlist"
 	"go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/layer2"
 	"k8s.io/api/core/v1"
@@ -30,7 +29,7 @@ import (
 type layer2Controller struct {
 	announcer *layer2.Announce
 	myNode    string
-	mList     *memberlist.Memberlist
+	sList     Speakerlist
 }
 
 func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
@@ -39,23 +38,15 @@ func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
 
 // usableNodes returns all nodes that have at least one fully ready
 // endpoint on them.
-func usableNodes(eps *v1.Endpoints, mList *memberlist.Memberlist) []string {
-	var activeNodes map[string]bool
-	if mList != nil {
-		activeNodes = map[string]bool{}
-		for _, n := range mList.Members() {
-			activeNodes[n.Name] = true
-		}
-	}
-
+func usableNodes(eps *v1.Endpoints, usableSpeakers map[string]bool) []string {
 	usable := map[string]bool{}
 	for _, subset := range eps.Subsets {
 		for _, ep := range subset.Addresses {
 			if ep.NodeName == nil {
 				continue
 			}
-			if activeNodes != nil {
-				if _, ok := activeNodes[*ep.NodeName]; !ok {
+			if usableSpeakers != nil {
+				if _, ok := usableSpeakers[*ep.NodeName]; !ok {
 					continue
 				}
 			}
@@ -76,7 +67,7 @@ func usableNodes(eps *v1.Endpoints, mList *memberlist.Memberlist) []string {
 }
 
 func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps *v1.Endpoints) string {
-	nodes := usableNodes(eps, c.mList)
+	nodes := usableNodes(eps, c.sList.UsableSpeakers())
 	// Sort the slice by the hash of node + service name. This
 	// produces an ordering of ready nodes that is unique to this
 	// service.

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -101,5 +101,6 @@ func (c *layer2Controller) DeleteBalancer(l log.Logger, name, reason string) err
 }
 
 func (c *layer2Controller) SetNode(log.Logger, *v1.Node) error {
+	c.sList.ReJoin()
 	return nil
 }

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -13,6 +13,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+type fakeSpeakerList struct {
+	speakers map[string]bool
+}
+
+func (sl *fakeSpeakerList) UsableSpeakers() map[string]bool {
+	return sl.speakers
+}
+
 func compareUseableNodesReturnedValue(a, b []string) bool {
 	if &a == &b {
 		return true
@@ -43,6 +51,8 @@ func TestUsableNodes(t *testing.T) {
 
 		eps *v1.Endpoints
 
+		usableSpeakers map[string]bool
+
 		cExpectedResult []string
 	}{
 		{
@@ -63,6 +73,7 @@ func TestUsableNodes(t *testing.T) {
 					},
 				},
 			},
+			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1", "iris2"},
 		},
 
@@ -84,6 +95,7 @@ func TestUsableNodes(t *testing.T) {
 					},
 				},
 			},
+			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1"},
 		},
 
@@ -107,12 +119,13 @@ func TestUsableNodes(t *testing.T) {
 					},
 				},
 			},
+			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1"},
 		},
 	}
 
 	for _, test := range tests {
-		response := usableNodes(test.eps, nil)
+		response := usableNodes(test.eps, test.usableSpeakers)
 		sort.Strings(response)
 		if !compareUseableNodesReturnedValue(response, test.cExpectedResult) {
 			t.Errorf("%q: shouldAnnounce for controller returned incorrect result, expected '%s', but received '%s'", test.desc, test.cExpectedResult, response)
@@ -121,9 +134,16 @@ func TestUsableNodes(t *testing.T) {
 }
 
 func TestShouldAnnounce(t *testing.T) {
+	fakeSL := &fakeSpeakerList{
+		speakers: map[string]bool{
+			"iris1": true,
+			"iris2": true,
+		},
+	}
 	c1, err := newController(controllerConfig{
 		MyNode: "iris1",
 		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:  fakeSL,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
@@ -133,6 +153,7 @@ func TestShouldAnnounce(t *testing.T) {
 	c2, err := newController(controllerConfig{
 		MyNode: "iris2",
 		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:  fakeSL,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -15,27 +15,23 @@
 package main
 
 import (
-	"crypto/sha256"
 	"flag"
 	"fmt"
-	golog "log"
 	"net"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
-	"time"
 
 	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/k8s"
 	"go.universe.tf/metallb/internal/layer2"
 	"go.universe.tf/metallb/internal/logging"
+	"go.universe.tf/metallb/internal/speakerlist"
 	"go.universe.tf/metallb/internal/version"
 	v1 "k8s.io/api/core/v1"
 
 	gokitlog "github.com/go-kit/kit/log"
-	"github.com/hashicorp/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -99,44 +95,16 @@ func main() {
 	}()
 	defer logger.Log("op", "shutdown", "msg", "done")
 
-	var mlist *memberlist.Memberlist
-	var eventCh chan memberlist.NodeEvent
-	if *mlNamespace == "" || *mlLabels == "" || *mlBindAddr == "" {
-		logger.Log("op", "startup", "msg", "Not starting fast dead node detection (MemberList), need ml-bindaddr / ml-labels / ml-namespace config")
-	} else {
-		mconfig := memberlist.DefaultLANConfig()
-		// mconfig.Name MUST be spec.nodeName, as we will match it against Enpoints nodeName in usableNodes()
-		mconfig.Name = *myNode
-		mconfig.BindAddr = *mlBindAddr
-		if *mlBindPort != "" {
-			mlport, err := strconv.Atoi(*mlBindPort)
-			if err != nil {
-				logger.Log("op", "startup", "error", "unable to parse ml-bindport", "msg", err)
-				os.Exit(1)
-			}
-			mconfig.BindPort = mlport
-			mconfig.AdvertisePort = mlport
-		}
-		loggerout := gokitlog.NewStdlibAdapter(gokitlog.With(logger, "component", "MemberList"))
-		mconfig.Logger = golog.New(loggerout, "", golog.Lshortfile)
-		if *mlSecret != "" {
-			sha := sha256.New()
-			mconfig.SecretKey = sha.Sum([]byte(*mlSecret))[:16]
-		}
-		eventCh = make(chan memberlist.NodeEvent, 16)
-		mconfig.Events = &memberlist.ChannelEventDelegate{Ch: eventCh}
-		mlist, err = memberlist.Create(mconfig)
-		if err != nil {
-			logger.Log("op", "startup", "error", err, "msg", "failed to create memberlist")
-			os.Exit(1)
-		}
+	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, *mlSecret, *mlNamespace, *mlLabels, stopCh)
+	if err != nil {
+		os.Exit(1)
 	}
 
 	// Setup all clients and speakers, config decides what is being done runtime.
 	ctrl, err := newController(controllerConfig{
 		MyNode: *myNode,
 		Logger: logger,
-		MList:  mlist,
+		SList:  sList,
 	})
 	if err != nil {
 		logger.Log("op", "startup", "error", err, "msg", "failed to create MetalLB controller")
@@ -163,44 +131,14 @@ func main() {
 	}
 	ctrl.client = client
 
-	if mlist != nil {
-		go watchMemberListEvents(logger, eventCh, stopCh, client)
-
-		iplist, err := client.GetPodsIPs(*mlNamespace, *mlLabels)
-		if err != nil {
-			logger.Log("op", "startup", "error", err, "msg", "failed to get PodsIPs")
-			os.Exit(1)
-		}
-		n, err := mlist.Join(iplist)
-		logger.Log("op", "startup", "msg", "Memberlist join", "nb joigned", n, "error ?", err)
-		defer func() {
-			logger.Log("op", "shutdown", "msg", "leaving MemberList cluster")
-			err = mlist.Leave(time.Second)
-			logger.Log("op", "shutdown", "msg", "left MemberList cluster", "error ?", err)
-			mlist.Shutdown()
-			logger.Log("op", "shutdown", "msg", "MemberList shutdown", "error ?", err)
-		}()
+	err = sList.Start(client)
+	if err != nil {
+		os.Exit(1)
 	}
+	defer sList.Stop()
 
 	if err := client.Run(stopCh); err != nil {
 		logger.Log("op", "startup", "error", err, "msg", "failed to run k8s client")
-	}
-}
-
-func event2String(e memberlist.NodeEventType) string {
-	return [...]string{"NodeJoin", "NodeLeave", "NodeUpdate"}[e]
-}
-
-func watchMemberListEvents(logger gokitlog.Logger, eventCh chan memberlist.NodeEvent, stopCh chan struct{}, client *k8s.Client) {
-	for {
-		select {
-		case e := <-eventCh:
-			logger.Log("msg", "Node event", "node addr", e.Node.Addr, "node name", e.Node.Name, "node event", event2String(e.Event))
-			logger.Log("msg", "Call Force Sync")
-			client.ForceSync()
-		case <-stopCh:
-			return
-		}
 	}
 }
 
@@ -218,7 +156,7 @@ type controller struct {
 type controllerConfig struct {
 	MyNode string
 	Logger gokitlog.Logger
-	MList  *memberlist.Memberlist
+	SList  Speakerlist
 
 	// For testing only, and will be removed in a future release.
 	// See: https://github.com/google/metallb/issues/152.
@@ -242,7 +180,7 @@ func newController(cfg controllerConfig) (*controller, error) {
 		protocols[config.Layer2] = &layer2Controller{
 			announcer: a,
 			myNode:    cfg.MyNode,
-			mList:     cfg.MList,
+			sList:     cfg.SList,
 		}
 	}
 
@@ -424,4 +362,9 @@ type Protocol interface {
 	SetBalancer(gokitlog.Logger, string, net.IP, *config.Pool) error
 	DeleteBalancer(gokitlog.Logger, string, string) error
 	SetNode(gokitlog.Logger, *v1.Node) error
+}
+
+// A Speakerlist returns usable speakers.
+type Speakerlist interface {
+	UsableSpeakers() map[string]bool
 }

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -367,4 +367,5 @@ type Protocol interface {
 // A Speakerlist returns usable speakers.
 type Speakerlist interface {
 	UsableSpeakers() map[string]bool
+	ReJoin()
 }


### PR DESCRIPTION
This is a quick&dirty patch (probably can use only one channel, channel size is a random number, the mlJoin has an arbitrary number of retries without much thought, need to add and adapt tests and ton's several other things) to make nodes join the memberlist clusters. But I think it is enough to get the gist of what I was trying to say in the other PR.

As this is a quick&dirty PR, it is not the idea to discuss the specifics (like re-join after 5 min vs 1 min, etc.) but to see the general approach. 

I cherry-picked the first 2 commits from https://github.com/metallb/metallb/pull/595, that split the memberlist code in a separate package. I've added this re-join logic on top. If you see only the last commit, you will see my proposed approach. Looking at all the changes, without spiting by commit, will be hard to spot what I say here. Please, consider looking at the last patch only.

With this idea, a node can re-join a cluster when:
 * The k8s node object changes and the `SetNode()` is invoked
 * 5 min have passed and tries to re-join (5 min is a totally arbitrary number that I haven't thought about. It is just to show the idea).

The internal kubernetes watcher already has this logic to notify when the node this is running changes (not other nodes in the cluster, it has a selector to be only about changes to **this node** where this is running). In the Layer2 case, though, it was just a "return nil". Now, it queues the message to process a re-join.

So, if a node losses network connectivity it will leave the memberlist cluster and eventually kubernetes will mark it as not ready. If connection comes back, the node will change to ready state and the `SetNode()` callback will be called in that node only, as the node changed. And then, join the cluster.

In this way, we are using memberlist to detect node failure and k8s to detect when to join again. This is not ideal, but memberlist doesn't seem to support the re-join mechanism. IMHO, we can look for more improvements later (I have several ideas :)).

However, if the node losses network connectivity and is restored before kubernetes marks is as not ready, the `SetNode()` callback will not be invoked. In this case, there is the periodic "try to join memberlist" to catch those errors.


@champtar sorry if I wasn't clear on the other PR. This is what I meant. It is basically just re-joining with the same logic it is today on master, but with some retries, but on node changes and periodically. What do you think? Does it make sense? Am I missing something?

@johananl @russellb @daxmc99 Please have a look at the approach, if you have some time :)