### PR TITLE
tasks.py: Update kustomize version on release

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -310,6 +310,13 @@ def release(ctx, version, skip_release_notes=False):
     run("perl -pi -e 's,image: metallb/speaker:.*,image: metallb/speaker:v{},g' manifests/metallb.yaml".format(version), echo=True)
     run("perl -pi -e 's,image: metallb/controller:.*,image: metallb/controller:v{},g' manifests/metallb.yaml".format(version), echo=True)
 
+    # Update the version in kustomize instructions
+    #
+    # TODO: Check if kustomize instructions really need the version in the
+    # website or if there is a simpler way. For now, though, we just replace the
+    # only page that mentions the version on release.
+    run("perl -pi -e 's,github.com/metallb/metallb//manifests\?ref=.*,github.com/metallb/metallb//manifests\?ref=v{},g' website/content/installation/_index.md".format(version), echo=True)
+
     # Update the version embedded in the binary
     run("perl -pi -e 's/version\s+=.*/version = \"{}\"/g' internal/version/version.go".format(version), echo=True)
     run("gofmt -w internal/version/version.go", echo=True)

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -94,7 +94,7 @@ on the remote kustomization fle :
 namespace: metallb-system
 
 resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
+  - github.com/metallb/metallb//manifests?ref=v0.8.2
   - configmap.yml 
   - secret.yml
 ```
@@ -111,7 +111,7 @@ the configMap, as MetalLB is waiting for a configMap named `config`
 namespace: metallb-system
 
 resources:
-  - github.com/danderson/metallb//manifests?ref=v0.8.2
+  - github.com/metallb/metallb//manifests?ref=v0.8.2
 
 configMapGenerator:
 - name: config


### PR DESCRIPTION
While we are there, update the github link to use the metallb org.

Fixes: #489

I've tested this locally, running the `inv release --skip-release-notes 0.9.4`. Make sure this commit is on `main` _and_ `v0.9` branch to test, though. Iit worked just fine here.

To undo the release created locally, you can run: `git checkout  v0.9 && git tag -d v0.9.4 && git reset --hard HEAD^`

There are some PRs open to update the kustomize instructions, so hopefully this might be removed soon. For now, it's better to have the proper version on new releases :)