### PR TITLE
Add command-line flags to run processes outside of k8s

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -134,8 +134,10 @@ func main() {
 	}
 
 	var (
-		port   = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
-		config = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+		port       = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
+		config     = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+		configNS   = flag.String("config-ns", "", "config file namespace (only needed when running outside of k8s)")
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
 	)
 	flag.Parse()
 
@@ -148,8 +150,10 @@ func main() {
 	client, err := k8s.New(&k8s.Config{
 		ProcessName:   "metallb-controller",
 		ConfigMapName: *config,
+		ConfigMapNS:   *configNS,
 		MetricsPort:   *port,
 		Logger:        logger,
+		Kubeconfig:    *kubeconfig,
 
 		ServiceChanged: c.SetBalancer,
 		ConfigChanged:  c.SetConfig,

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -70,6 +70,8 @@ func main() {
 
 	var (
 		config      = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+		configNS    = flag.String("config-ns", "", "config file namespace (only needed when running outside of k8s)")
+		kubeconfig  = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
 		host        = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
 		mlBindAddr  = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
 		mlBindPort  = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
@@ -146,8 +148,10 @@ func main() {
 	client, err := k8s.New(&k8s.Config{
 		ProcessName:   "metallb-speaker",
 		ConfigMapName: *config,
+		ConfigMapNS:   *configNS,
 		NodeName:      *myNode,
 		Logger:        logger,
+		Kubeconfig:    *kubeconfig,
 
 		MetricsHost:   *host,
 		MetricsPort:   *port,

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -116,7 +116,7 @@ To develop MetalLB, you'll need a couple of pieces of software:
 >versions may not work since there have been breaking changes between minor
 >versions.
 
-## Building the code
+## Building and running the code
 
 Start by fetching the MetalLB repository, with `git clone
 https://github.com/danderson/metallb`.
@@ -126,6 +126,19 @@ registries, and so forth. `inv -l` lists the available tasks.
 
 To build and deploy MetalLB to a local development environment using a kind
 cluster, run `inv dev-env`.
+
+When you're developing, running components at the command line and
+having them attach to a cluster might be more convenient than
+redeploying them to a cluster over and over.
+
+For the controller, the `-kubeconfig` and `-config-ns` command-line flags
+are needed.  Speakers need those and `-node-name`.
+
+For example:
+
+ metallb$ go run ./controller/main.go ./controller/service.go -config-ns metallb-system -kubeconfig $KUBECONFIG
+
+ metallb$ go run ./speaker/main.go ./speaker/*controller.go -config-ns metallb-system -kubeconfig $KUBECONFIG -node-name node0
 
 For development, fork
 the [github repository](https://github.com/google/metallb), and add


### PR DESCRIPTION
When you're developing, running components at the command line and
having them attach to a cluster might be more convenient than
redeploying them to a cluster over and over.

For the controller, -kubeconfig and -config-ns are needed.  Speakers
need those and -node-name.

For example:

 metallb$ go run ./controller/main.go ./controller/service.go -config-ns metallb-system -kubeconfig $KUBECONFIG

 metallb$ go run ./speaker/main.go ./speaker/*controller.go -config-ns metallb-system -kubeconfig $KUBECONFIG -node-name node0

Thanks for sending a pull request! A few things before we get started:

1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/google/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
