### PR TITLE
Publish images for each open pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,57 @@ jobs:
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: PATH=./bin:$PATH inv push-multiarch --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --docker-user=metallb
+  deploy-controller-pr:
+    working_directory: /go/src/go.universe.tf/metallb
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: sudo apt-get install python-pip
+      - run: sudo pip install invoke semver pyyaml
+      - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+      - run: mkdir -p ./bin
+      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
+      - run: echo "export GO111MODULE=on" >>$BASH_ENV
+      - run: echo ${CIRCLE_PULL_REQUEST}
+      - run: echo ${CIRCLE_BRANCH}
+      - run: echo ${CIRCLE_TAG}
+      # CIRCLE_PULL_REQUEST is a URL in the form: https://github.com/metallb/metallb/pull/1
+      # We use sed to get the pull request ID out of the URL. CIRCLE_PR_NUMBER would be
+      # more convenient, but unfortunately it is not always available.
+      # https://circleci.com/docs/2.0/env-vars/
+      #
+      # If the job is being run against a PR, use "pr-<ID>" as the image tag and push the
+      # result to metallbdev/controller. Otherwise this job is not expected to run so we
+      # just fail.
+      - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then PATH=./bin:$PATH inv push-multiarch --binaries=controller --tag=pr-$(basename "$CIRCLE_PULL_REQUEST") --docker-user=metallbdev ; else exit 1 ; fi
+  deploy-speaker-pr:
+    working_directory: /go/src/go.universe.tf/metallb
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: sudo apt-get install python-pip
+      - run: sudo pip install invoke semver pyyaml
+      - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+      - run: mkdir -p ./bin
+      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
+      - run: echo "export GO111MODULE=on" >>$BASH_ENV
+      - run: echo ${CIRCLE_PULL_REQUEST}
+      - run: echo ${CIRCLE_BRANCH}
+      - run: echo ${CIRCLE_TAG}
+      # CIRCLE_PULL_REQUEST is a URL in the form: https://github.com/metallb/metallb/pull/1
+      # We use sed to get the pull request ID out of the URL. CIRCLE_PR_NUMBER would be
+      # more convenient, but unfortunately it is not always available.
+      # https://circleci.com/docs/2.0/env-vars/
+      #
+      # If the job is being run against a PR, use "pr-<ID>" as the image tag and push the
+      # result to metallbdev/speaker. Otherwise this job is not expected to run so we
+      # just fail.
+      - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then PATH=./bin:$PATH inv push-multiarch --binaries=speaker --tag=pr-$(basename "$CIRCLE_PULL_REQUEST") --docker-user=metallbdev ; else exit 1 ; fi
+
 workflows:
   version: 2
   test-and-deploy:
@@ -82,6 +133,29 @@ workflows:
                 - /v.*/
             tags:
               only: /.*/
+          requires:
+            - test-1.13
+            - lint-1.13
+      # The *-pr jobs should only run against pull requests.
+      - deploy-controller-pr:
+          filters:
+            branches:
+              ignore:
+                - main
+                - /v.*/
+            tags:
+              ignore: /.*/
+          requires:
+            - test-1.13
+            - lint-1.13
+      - deploy-speaker-pr:
+          filters:
+            branches:
+              ignore:
+                - main
+                - /v.*/
+            tags:
+              ignore: /.*/
           requires:
             - test-1.13
             - lint-1.13

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -145,6 +145,18 @@ the [github repository](https://github.com/google/metallb), and add
 your fork as a remote in `$GOPATH/src/go.universe.tf/metallb`, with
 `git remote add fork git@github.com:<your-github-user>/metallb.git`.
 
+## Testing a Pull Request
+
+MetalLB has a CI process which publishes Docker images from the latest code
+revision of each open pull request.  If you would like to test out a prebuilt
+image of a PR, make sure the `deploy-speaker` or `deploy-controller` jobs have
+succeeded on the PR, and then you may pull `metallbdev/speaker:pr-<ID>` or
+`metallbdev/controller:pr-<ID>`.
+
+If a new revision of a pull request is posted, the image will be rebuilt.  If
+you want to ensure you’re always running the latest version of a pull request,
+make sure you set `imagePullPolicy` to `Always` in your Pod spec.
+
 ## The website
 
 The website at https://metallb.universe.tf is pinned to the latest


### PR DESCRIPTION
CircleCI was previously only configured to publish images for pushes
to branches or tags.  While CI runs against open PRs, the publish jobs
that published images was excluded.

This PR updates the deploy jobs to detect when they are running
against a pull request.  When run against a PR, the images are pushed
to the `metallbdev` org instead of `metallb` and the image tag is
"pr-<ID>".

The dev docs on the web site are also updated to note how to pull an
image built for a PR.

Fixes #623
