### PR TITLE
Document maintainership of MetalLB

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# For more information on the syntax of the CODEOWNERS file, see:
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# The MetalLB maintainers team
+*   @daxmc99 @johananl @rata
+
+# Emeritus Maintainers
+#
+# The following people were previously members of the maintainers team, but are
+# not currently focused on the project.
+#
+# - danderson  # Creator of MetalLB

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -166,3 +166,8 @@ visit
 When editing the website, you can preview your changes locally by
 installing [Hugo](https://gohugo.io/) and running `hugo server` from
 the `website` directory.
+
+## Maintainers
+
+For information about the current maintainers of MetalLB, see the [maintainers
+page]({{% relref "maintainers.md" %}}).

--- a/website/content/community/maintainers.md
+++ b/website/content/community/maintainers.md
@@ -1,0 +1,53 @@
+---
+title: Maintainers
+weight: 1
+---
+
+MetalLB was created by Dave Anderson. We are thankful for his efforts to
+create MetalLB as a valuable contribution to the Kubernetes ecosystem. Ongoing
+MetalLB development and maintenance is led by a team of current maintainers.
+
+MetalLB maintainers are participants in the project with the ability to approve
+changes to the MetalLB code base. The current list of maintainers can be found
+in the [MetalLB CODEOWNERS
+file](https://github.com/metallb/metallb/blob/main/CODEOWNERS).
+
+## Maintainer Expectations
+
+An active maintainer should:
+
+* Actively participate in reviewing pull requests and incoming issues. Note
+  that there are no hard rules on what is "active enough" and this is left up
+  to the judgement of the current group of maintainers.
+
+* Actively participate in discussions about design and the future of the
+  project.
+
+* Take responsibility for backports to appropriate branches for PRs they approve
+  and merge.
+
+* Do their best to follow all code, testing, and design conventions as
+  determined by consensus among active maintainers.
+
+* Gracefully step down from their maintainership role when they are no longer
+  planning to actively participate in the project.
+
+## Adding New Maintainers
+
+New maintainers are added by consensus among the current group of maintainers.
+This can be done via a private discussion via Slack or email. A majority of
+maintainers should support the addition of the new person, and no single
+maintainer should object to adding the new maintainer.
+
+## Removing Maintainers
+
+It is normal for maintainers to come and go based on their other
+responsibilities. Inactive maintainers may be removed if there is no
+expectation of ongoing participation. If a former maintainer resumes
+participation, they should be given quick consideration for re-adding to the
+team.
+
+If there becomes a conflict among maintainers that may lead to removal, active
+maintainers should first work to resolve the conflict. If absolutely
+necessary, a maintainer may be removed by a majority vote of existing
+maintainers.


### PR DESCRIPTION
When I first joined the MetalLB development community, I was curious
who the current maintainers were.  This patch is a proposed method of
communicating who that team is, as well as how the team is governed.

First, create OWNERS file. Nothing will actually read this file, but
it is a convenient and familiar format to list maintainers within the
Kubernetes ecosystem.

This patch also introduces a document in the community section of the
web site that discusses the group of maintainers and how people are
added or removed.

Consider this a starting point for discussion.  It's really something for the
current maintainers to decide on.
