### PR TITLE
layer2: fallback speaker election if no endpoints are in nodes with speaker daemonset

### DIFF
--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -112,7 +112,7 @@ func TestUsableNodes(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		response := usableNodes(test.eps, nil)
+		response := usableNodes(test.eps, nil, false)
 		sort.Strings(response)
 		if !compareUseableNodesReturnedValue(response, test.cExpectedResult) {
 			t.Errorf("%q: shouldAnnounce for controller returned incorrect result, expected '%s', but received '%s'", test.desc, test.cExpectedResult, response)


### PR DESCRIPTION
Fixes #302.
As the issue states, even if service specifies `externalTrafficPolicy: Cluster`, MetalLB will not announce if no endpoint reside in the node with speakers. This can occur if speakers are deployed only on a subset of nodes in the cluster.

This commit makes use of `activeNodes` as a fallback if no usable nodes are available. If memberlist is not enabled, it will act same as if the fallback is disabled.
The idea is basically same as #613, with minor code implementation differences.