### PR TITLE
Add a note to the website about single-IP address pool

### DIFF
--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -265,6 +265,11 @@ Addresses can still be specifically allocated from the "expensive"
 pool with the methods described in
 the [usage](/usage/#requesting-specific-ips) section.
 
+{{% notice note %}}
+Please note that if you have a single address pool, you must use `/32`
+CIDR notation (e.g. `42.176.25.64/32`).
+{{% /notice %}}
+
 ### Handling buggy networks
 
 Some old consumer network equipment mistakenly blocks IP addresses


### PR DESCRIPTION
This PR concerns issue #669 I filled about configuration problem.
And the solution was to use a CIDR notation even for a single IP.

There is my proposal to the documentation.