### PR TITLE
Make BGP source address configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type peer struct {
 	MyASN         uint32         `yaml:"my-asn"`
 	ASN           uint32         `yaml:"peer-asn"`
 	Addr          string         `yaml:"peer-address"`
+	SrcAddr       string         `yaml:"src-address"`
 	Port          uint16         `yaml:"peer-port"`
 	HoldTime      string         `yaml:"hold-time"`
 	RouterID      string         `yaml:"router-id"`
@@ -98,6 +99,8 @@ type Peer struct {
 	ASN uint32
 	// Address to dial when establishing the session.
 	Addr net.IP
+	// Source address to use when establishing the session.
+	SrcAddr net.IP
 	// Port to dial when establishing the session.
 	Port uint16
 	// Requested BGP hold time, per RFC4271.
@@ -269,6 +272,7 @@ func parsePeer(p peer) (*Peer, error) {
 			return nil, fmt.Errorf("invalid router ID %q", p.RouterID)
 		}
 	}
+	src := net.ParseIP(p.SrcAddr)
 
 	// We use a non-pointer in the raw json object, so that if the
 	// user doesn't provide a node selector, we end up with an empty,
@@ -294,6 +298,7 @@ func parsePeer(p peer) (*Peer, error) {
 		MyASN:         p.MyASN,
 		ASN:           p.ASN,
 		Addr:          ip,
+		SrcAddr:       src,
 		Port:          port,
 		HoldTime:      holdTime,
 		RouterID:      routerID,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,7 @@ peers:
   peer-port: 1179
   hold-time: 180s
   router-id: 10.20.30.40
+  src-address: 10.20.30.40
 - my-asn: 100
   peer-asn: 200
   peer-address: 2.3.4.5
@@ -98,6 +99,7 @@ address-pools:
 						MyASN:         42,
 						ASN:           142,
 						Addr:          net.ParseIP("1.2.3.4"),
+						SrcAddr:       net.ParseIP("10.20.30.40"),
 						Port:          1179,
 						HoldTime:      180 * time.Second,
 						RouterID:      net.ParseIP("10.20.30.40"),

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -184,7 +184,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
+			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.SrcAddr.String(), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -286,6 +286,6 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+var newBGP = func(logger log.Logger, addr string, srcAddr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
+	return bgp.New(logger, addr, srcAddr, myASN, routerID, asn, hold, password, myNode)
 }

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -95,7 +95,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
 	f.Lock()
 	defer f.Unlock()
 


### PR DESCRIPTION
## General

Fixes #670.

This PR adds the `src-address` knob to the BGP peer configuration.

The implementation falls back to the existing behavior (let the kernel figure out the source address) in case the specified address doesn't exist or if there is any other problem with the specified address.

## Testing

To test this PR, deploy MetalLB using `quay.io/jlieb/metallb-speaker:bgp-src` as the speaker image and apply the following sample config while modifying the IPs and ASNs as necessary:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: config
  namespace: metallb-system
data:
  config: |
    address-pools:
    - name: default
      protocol: bgp
      addresses:
      - 1.2.3.4/32
    peers:
    - peer-address: 169.254.10.20
      peer-asn: 64501
      my-asn: 64500
      src-address: 10.1.2.3
```

## TODO

- [ ] Update docs
- [ ] Add more tests