### PR TITLE
Use distroless static images

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest as intermediate
 
 ADD controller /controller
 
@@ -6,5 +6,9 @@ ADD controller /controller
 # '+x' for others, it won't be possible to execute. Make sure all can execute,
 # just in case
 RUN chmod a+x /controller
+
+# Production image
+FROM gcr.io/distroless/static:latest
+COPY --from=intermediate /controller /controller
 
 ENTRYPOINT ["/controller"]

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest as intermediate
 
 ADD speaker /speaker
 
@@ -6,5 +6,9 @@ ADD speaker /speaker
 # '+x' for others, it won't be possible to execute. Make sure all can execute,
 # just in case
 RUN chmod a+x /speaker
+
+# Production image
+FROM gcr.io/distroless/static:latest
+COPY --from=intermediate /speaker /speaker
 
 ENTRYPOINT ["/speaker"]


### PR DESCRIPTION
Reduce final image size and attack surface

Note: to keep executable permission we must keep
alpine as intermediate container beacuse not all
the developers use the latest Docker which supports
chmod flag for COPY/ADD command.

Image size changes:
 - controller: 74.8MB -> 36.4MB
 - speaker: 83.6MB -> 40.9MB

Fixed #676

Docker xref: https://github.com/moby/buildkit/pull/1492

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>
