### PR TITLE
bgp: Decode hold timer expired notification

### DIFF
--- a/internal/bgp/messages.go
+++ b/internal/bgp/messages.go
@@ -121,6 +121,8 @@ var notificationCodes = map[uint16]string{
 	0x030a: "Invalid Network Field",
 	0x030b: "Malformed AS_PATH",
 
+	0x0400: "Hold Timer Expired (unspecific)",
+
 	0x0500: "BGP FSM state error (unspecific)",
 	0x0501: "Receive Unexpected Message in OpenSent State",
 	0x0502: "Receive Unexpected Message in OpenConfirm State",


### PR DESCRIPTION
While setting up a dev and test environment for BGP mode, I got the
following error in my speaker log:

{"caller":"bgp.go:408","error":"got BGP notification code 0x0400 (unknown code)",
    "event":"peerNotification","localASN":64513,
    "msg":"peer sent notification, closing session",
    "peer":"172.18.0.5:179","peerASN":64512,"ts":"2020-07-22T21:20:07.673523481Z"}

0x0400 is an unspecific "Hold timer expired" notification.  The code
portion of "04" is "Hold timer expired", and the sub-code of "00"
means there is unspecific.

Update the code to provide an improved error message in this case.
The updated message is:

{"caller":"bgp.go:408",
    "error":"got BGP notification code 0x0400 (Hold Timer Expired (unspecific))",
    "event":"peerNotification","localASN":64513,
    "msg":"peer sent notification, closing session",
    "peer":"172.18.0.5:179","peerASN":64512,"ts":"2020-07-22T22:02:56.887511947Z"}

The related IANA assignments can be found here:
https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-3