### PR TITLE
Added `controller-name` service annotation

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -37,6 +37,15 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		return true
 	}
 
+	// Service not handled by this controller
+	if c.config.ControllerName != "" {
+		controllerName := svc.Annotations["metallb.universe.tf/controller-name"]
+		if controllerName != c.config.ControllerName {
+			c.clearServiceState(key, svc)
+			return true
+		}
+	}
+
 	// If the ClusterIP is malformed or not set we can't determine the
 	// ipFamily to use.
 	clusterIP := net.ParseIP(svc.Spec.ClusterIP)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type configFile struct {
 	Peers          []peer
 	BGPCommunities map[string]string `yaml:"bgp-communities"`
 	Pools          []addressPool     `yaml:"address-pools"`
+	ControllerName string            `yaml:"controller-name"`
 }
 
 type peer struct {
@@ -79,6 +80,8 @@ type Config struct {
 	Peers []*Peer
 	// Address pools from which to allocate load balancer IPs.
 	Pools map[string]*Pool
+	// Controller name used by the service annotation
+	ControllerName string
 }
 
 // Proto holds the protocol we are speaking.
@@ -236,6 +239,8 @@ func Parse(bs []byte) (*Config, error) {
 
 		cfg.Pools[p.Name] = pool
 	}
+
+	cfg.ControllerName = raw.ControllerName
 
 	return cfg, nil
 }


### PR DESCRIPTION
With this annotation it could supports multiple metallb controllers in the same cluster or simply to ignore services handled by other load balancers.

#685