### PR TITLE
Disallow duplicate peers in config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -199,6 +200,14 @@ func Parse(bs []byte) (*Config, error) {
 		peer, err := parsePeer(p)
 		if err != nil {
 			return nil, fmt.Errorf("parsing peer #%d: %s", i+1, err)
+		}
+		for _, ep := range cfg.Peers {
+			// TODO: Be smarter regarding conflicting peers. For example, two
+			// peers could have a different hold time but they'd still result
+			// in two BGP sessions between the speaker and the remote host.
+			if reflect.DeepEqual(peer, ep) {
+				return nil, fmt.Errorf("peer #%d already exists", i+1)
+			}
 		}
 		cfg.Peers = append(cfg.Peers, peer)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,6 +346,19 @@ peers:
 		},
 
 		{
+			desc: "duplicate peers",
+			raw: `
+peers:
+- my-asn: 42
+  peer-asn: 42
+  peer-address: 1.2.3.4
+- my-asn: 42
+  peer-asn: 42
+  peer-address: 1.2.3.4
+`,
+		},
+
+		{
 			desc: "no pool name",
 			raw: `
 address-pools:


### PR DESCRIPTION
Configuring the same peer twice is an error. Configuring two identical peers results in a rapidly-flapping BGP session. This PR disallows identical peers in the configuration. In the future we may want to perform smarter checks, however at the very least this fix will catch copy-paste mistakes.