### PR TITLE
inv: Add task to run unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,10 @@ jobs:
       - image: cimg/go:1.13
     steps:
       - checkout
-      - run: go test -short ./...
-      - run: go test -short -race ./...
+      - run: sudo apt-get update
+      - run: sudo apt-get install python3-pip
+      - run: sudo pip3 install invoke semver pyyaml
+      - run: inv test
       - run: cp manifests/metallb.yaml manifests/metallb.yaml.prev
   lint-1.13:
     docker:

--- a/tasks.py
+++ b/tasks.py
@@ -444,3 +444,10 @@ def release(ctx, version, skip_release_notes=False):
     run("git commit -a -m 'Automated update for release v{}'".format(version), echo=True)
     run("git tag v{} -m 'See the release notes for details:\n\nhttps://metallb.universe.tf/release-notes/#version-{}-{}-{}'".format(version, version.major, version.minor, version.patch), echo=True)
     run("git checkout main", echo=True)
+
+
+@task
+def test(ctx):
+    """Run unit tests."""
+    run("go test -short ./...")
+    run("go test -short -race ./...")


### PR DESCRIPTION
Since inv is used to run other dev workflows, add another task to run
the unit tests.  Also update CircleCI config to use inv to run the
tests so that we keep the local dev commands in sync with what runs in
CI.