### PR TITLE
layer2: Send GARPs on cluster membership changes

### DIFF
--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -112,7 +112,7 @@ func TestUsableNodes(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		response := usableNodes(test.eps, nil)
+		response := usableNodes(nil, test.eps)
 		sort.Strings(response)
 		if !compareUseableNodesReturnedValue(response, test.cExpectedResult) {
 			t.Errorf("%q: shouldAnnounce for controller returned incorrect result, expected '%s', but received '%s'", test.desc, test.cExpectedResult, response)

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -244,9 +244,10 @@ func newController(cfg controllerConfig) (*controller, error) {
 			return nil, fmt.Errorf("making layer2 announcer: %s", err)
 		}
 		protocols[config.Layer2] = &layer2Controller{
-			announcer: a,
-			myNode:    cfg.MyNode,
-			mList:     cfg.MList,
+			announcer:   a,
+			myNode:      cfg.MyNode,
+			mList:       cfg.MList,
+			activeNodes: make(map[string]map[string]bool),
 		}
 	}
 


### PR DESCRIPTION
Speaker ownership of IPs is recalculated each time membership of the
cluster changes.  When a new speaker is chosen, that speaker will send
a set of gratuitous ARP or NDP messages to inform the network of the
new location for that IP address.

A problem existed where the cluster could end up in an inconsistent
state if a speaker lost ownership of an IP but didn't realize it.
In the meantime, a new speaker will have taken over the IP.  When the
original owner rejoins the cluster, it will fail to reclaim the IP
with gratuitous ARP / NDP if it thinks it never lost it in the first
place.

One way to look at this problem is that it's a failure to enforce
quorum before assuming ownership of an IP address.  If this was
guaranteed, we know that a Node on the losing side of a cluster
partition would not continue to think it owns any IPs.  It seems that
memberlist, the cluster membership library in use by metallb, does not
provide quorum enforcement, so we must address this problem a
different way.

When the speaker is run with memberlist enabled, we already force a
sync of all Services when a cluster membership occurs: either with a
Node joins or leaves a cluster.  This patch builds on that by keeping
track of the last known state of cluster membership each time we sync
a Service.  When a change is detected, gratuitous ARP or NDP messages
are sent.  This will inform the network of the current correct
ownership in case the change is the result of recovering from a
network partition.

The cluster membership tracking is done on a per-IP basis.  We can not
do this globally, because the first time we see that cluster
membership has changed, we likely have not finished syncing all
services to figure out who is the new owner of each IP.  By tracking
changes on a per-IP basis, we ensure we send the messages only after
confirming we are still the owner of that IP after the cluster
membership change.

One downside of this change is that it creates points in time where we
send a larger amount of ARP or NDP traffic without any attempted rate
limiting in place.  It is our guess that this will not be high enough
in volume to be problematic.  We may have to revisit this in the
future if sending gratuitous ARP or NDP messages for all load balancer
IPs in the cluster breaks something.

Closes #584 