### PR TITLE
dev-env: Create vtysh.conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
       - image: cimg/go:1.13
     steps:
       - checkout
+      # This job should not run against PRs, but we have seen it run unexpectedly, so
+      # double check and exit early if this is a job against a PR.
+      - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then circleci-agent step halt; fi
       - setup_remote_docker
       - run: sudo apt-get update && sudo apt-get install -y python-pip
       - run: pip install invoke semver pyyaml
@@ -34,6 +37,9 @@ jobs:
       - image: cimg/go:1.13
     steps:
       - checkout
+      # This job should not run against PRs, but we have seen it run unexpectedly, so
+      # double check and exit early if this is a job against a PR.
+      - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then circleci-agent step halt; fi
       - setup_remote_docker
       - run: sudo apt-get update && sudo apt-get install -y python-pip
       - run: pip install invoke semver pyyaml

--- a/tasks.py
+++ b/tasks.py
@@ -298,11 +298,11 @@ def bgp_dev_env():
         raise Exit(message='Failed to create frr-volume directory: %s'
                    % str(e))
 
-    # These two config files are static, so we just copy them straight in.
-    shutil.copyfile("%s/frr/zebra.conf" % dev_env_dir,
-                    "%s/zebra.conf" % frr_volume_dir)
-    shutil.copyfile("%s/frr/daemons" % dev_env_dir,
-                    "%s/daemons" % frr_volume_dir)
+    # These config files are static, so we copy them straight in.
+    copy_files = ('zebra.conf', 'daemons', 'vtysh.conf')
+    for f in copy_files:
+        shutil.copyfile("%s/frr/%s" % (dev_env_dir, f),
+                        "%s/%s" % (frr_volume_dir, f))
 
     # bgpd.conf is created from a template so that we can include the current
     # Node IPs.


### PR DESCRIPTION
Prior to this change, every time you ran the `vtysh` command in the
`frr` container when using the bgp dev environment, you would get an
error about `vtysh.conf` missing.  The error is misleading and makes
it seem like something is wrong.

Create an empty config file to suppress this error message.

Closes #713 