### PR TITLE
contributing: Adopt the DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,10 @@
 
 See the [contributing section of the
 website](https://metallb.universe.tf/community) for information.
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -59,6 +59,14 @@ purpose. Consult [GitHub
 Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](https://github.com/metallb/metallb/blob/main/DCO)
+file for details.
+
 ## Code organization
 
 MetalLB's code is divided between a number of binaries, and some


### PR DESCRIPTION
This commit includes a light-weight approach for MetalLB to adopt the
DCO (Developer Certificate of Origin) for contributions.  Some projects
use a `Signed-off-by:` header in commit messages as an acknowledgement
of the DCO.  In this case, we just include the DCO file and update the
contributing docs to explain that by contributing, you agree to the DCO.

Some examples of other projects that adopted this approach to using the
DCO include:

 - several from github.com/coreos, such as github.com/coreos/ignition
 - projects under github.com/metal3-io/