### PR TITLE
controller; Add support for dual-stack services (k8s dual-stack phase 3)

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -186,7 +186,7 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 	return c.ips.Allocate(key, isIPv6, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 }
 
-// Dual-stack
+// Dual-stack.
 
 func (c *controller) convergeBalancerDual(l log.Logger, key string, svc *v1.Service) bool {
 	var lbIP, lbIP2 net.IP

--- a/controller/service.go
+++ b/controller/service.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -45,6 +46,10 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		level.Info(l).Log("event", "clearAssignment", "reason", "noClusterIP", "msg", "No ClusterIP")
 		c.clearServiceState(key, svc)
 		return true
+	}
+
+	if svc.Spec.ClusterIPs != nil && len(svc.Spec.ClusterIPs) > 1 {
+		return c.convergeBalancerDual(l, key, svc)
 	}
 
 	// The assigned LB IP is the end state of convergence. If there's
@@ -179,4 +184,133 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 
 	// Okay, in that case just bruteforce across all pools.
 	return c.ips.Allocate(key, isIPv6, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+}
+
+// Dual-stack
+
+func (c *controller) convergeBalancerDual(l log.Logger, key string, svc *v1.Service) bool {
+	var lbIP, lbIP2 net.IP
+
+	// The assigned LB IP is the end state of convergence. If there's
+	// none or a malformed one, nuke all controlled state so that we
+	// start converging from a clean slate.
+	if len(svc.Status.LoadBalancer.Ingress) > 1 {
+		lbIP = net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
+		lbIP2 = net.ParseIP(svc.Status.LoadBalancer.Ingress[1].IP)
+	}
+
+	// It's possible the config mutated and the IP we have no longer
+	// makes sense. If so, clear it out and give the rest of the logic
+	// a chance to allocate again.
+	if lbIP != nil && lbIP2 != nil {
+		// This assign is idempotent if the config is consistent,
+		// otherwise it'll fail and tell us why.
+		if err := c.ips.AssignDual(key, lbIP, lbIP2, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+			l.Log("event", "clearAssignment", "reason", "notAllowedByConfig", "msg", "current IP not allowed by config, clearing")
+			c.clearServiceState(key, svc)
+			lbIP = nil
+		}
+
+		if lbIP != nil {
+			// The user might also have changed the pool annotation, and
+			// requested a different pool than the one that is currently
+			// allocated.
+			desiredPool := svc.Annotations["metallb.universe.tf/address-pool"]
+			if desiredPool != "" && c.ips.Pool(key) != desiredPool {
+				l.Log("event", "clearAssignment", "reason", "differentPoolRequested", "msg", "user requested a different pool than the one currently assigned")
+				c.clearServiceState(key, svc)
+				lbIP = nil
+			}
+		}
+	} else {
+		c.clearServiceState(key, svc)
+		lbIP = nil
+	}
+
+	// The (singular) svc.Spec.LoadBalancerIP is ignored for dual-stack
+	if svc.Spec.LoadBalancerIP != "" {
+		l.Log("event", "loadBalancerIP", "reason", "N/A", "msg", "loadBalancerIP ignored for dual-stack")
+	}
+
+	if requestedIPs := svc.Annotations["metallb.universe.tf/load-balancer-ips"]; requestedIPs != "" {
+		// Until a svc.Spec.LoadBalancerIPs exists we use an annotation.
+		// requestedIPs must be a comma-separated list of 2 addresses, one from each family.
+		ips := strings.Split(requestedIPs, ",")
+		if len(ips) != 2 {
+			l.Log("op", "allocateIP", "load-balancer-ips", len(ips), "msg", "Must be two addresses")
+			return true
+		}
+		if lbIP = net.ParseIP(strings.TrimSpace(ips[0])); lbIP == nil {
+			l.Log("op", "allocateIP", "load-balancer-ips", ips[0], "msg", "Invalid addresses")
+			return true
+		}
+		if lbIP2 = net.ParseIP(strings.TrimSpace(ips[1])); lbIP2 == nil {
+			l.Log("op", "allocateIP", "load-balancer-ips", ips[1], "msg", "Invalid addresses")
+			return true
+		}
+		if (lbIP.To4() == nil) == (lbIP2.To4() == nil) {
+			l.Log("op", "allocateIP", "load-balancer-ips", requestedIPs, "msg", "Same family")
+		}
+
+		// Try to assign the requested IPs
+		if err := c.ips.AssignDual(key, lbIP, lbIP2, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+			l.Log("op", "allocateIP", "error", err, "msg", "Can't assign requested IPs")
+			return true
+		}
+	}
+
+	// If lbIP's is still nil at this point, try to allocate.
+	if lbIP == nil {
+		if !c.synced {
+			l.Log("op", "allocateIP", "error", "controller not synced", "msg", "controller not synced yet, cannot allocate IP; will retry after sync")
+			return false
+		}
+		ip, ip2, err := c.allocateIPDual(key, svc)
+		if err != nil {
+			l.Log("op", "allocateIP", "error", err, "msg", "IP allocation failed")
+			c.client.Errorf(svc, "AllocationFailed", "Failed to allocate IP for %q: %s", key, err)
+			// The outer controller loop will retry converging this
+			// service when another service gets deleted, so there's
+			// nothing to do here but wait to get called again later.
+			return true
+		}
+		lbIP = ip
+		lbIP2 = ip2
+		l.Log("event", "ipAllocated", "ip", lbIP, "ip2", lbIP2, "msg", "IP address assigned by controller")
+		c.client.Infof(svc, "IPAllocated", "Assigned IP %q %q", lbIP, lbIP2)
+	}
+
+	if lbIP == nil || lbIP2 == nil {
+		l.Log("bug", "true", "msg", "internal error: failed to allocate an IP, but did not exit convergeService early!")
+		c.client.Errorf(svc, "InternalError", "didn't allocate an IP but also did not fail")
+		c.clearServiceState(key, svc)
+		return true
+	}
+
+	pool := c.ips.Pool(key)
+	if pool == "" || c.config.Pools[pool] == nil {
+		l.Log("bug", "true", "ip", lbIP, "msg", "internal error: allocated IP has no matching address pool")
+		c.client.Errorf(svc, "InternalError", "allocated an IP that has no pool")
+		c.clearServiceState(key, svc)
+		return true
+	}
+
+	// At this point, we have an IP selected somehow, all that remains
+	// is to program the data plane.
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: lbIP.String()}, {IP: lbIP2.String()}}
+	return true
+}
+
+func (c *controller) allocateIPDual(key string, svc *v1.Service) (net.IP, net.IP, error) {
+	desiredPool := svc.Annotations["metallb.universe.tf/address-pool"]
+	if desiredPool != "" {
+		ip, ip2, err := c.ips.AllocateFromPoolDual(key, desiredPool, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+		if err != nil {
+			return nil, nil, err
+		}
+		return ip, ip2, nil
+	}
+
+	// Okay, in that case just bruteforce across all pools.
+	return c.ips.AllocateDual(key, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 }

--- a/controller/service.go
+++ b/controller/service.go
@@ -53,7 +53,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		return true
 	}
 
-	if svc.Spec.ClusterIPs != nil && len(svc.Spec.ClusterIPs) > 1 {
+	if len(svc.Spec.ClusterIPs) > 1 && svc.Spec.LoadBalancerIP == "" {
 		return c.convergeBalancerDual(l, key, svc)
 	}
 
@@ -230,11 +230,6 @@ func (c *controller) convergeBalancerDual(l log.Logger, key string, svc *v1.Serv
 	} else {
 		c.clearServiceState(key, svc)
 		lbIP = nil
-	}
-
-	// The (singular) svc.Spec.LoadBalancerIP is ignored for dual-stack
-	if svc.Spec.LoadBalancerIP != "" {
-		l.Log("event", "loadBalancerIP", "reason", "N/A", "msg", "loadBalancerIP ignored for dual-stack")
 	}
 
 	lbIP, lbIP2, err := parseRequestedIPs(svc.Annotations[annotationLoadBalancerIPs])

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -373,7 +373,7 @@ func ipConfusesBuggyFirmwares(ip net.IP) bool {
 	return ip[3] == 0 || ip[3] == 255
 }
 
-// Dual-stack;
+// Dual-stack.
 
 // AssignDual assigns the requested ip's to svc, if the assignment is
 // permissible by sharingKey and backendKey.

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -159,7 +159,6 @@ func (a *Allocator) Assign(svc string, ip net.IP, ports []Port, sharingKey, back
 		key:   *sk,
 	}
 	for i, port := range ports {
-		port := port
 		alloc.ports[i] = port
 	}
 	a.assign(svc, alloc)
@@ -414,7 +413,6 @@ func (a *Allocator) AssignDual(svc string, ip, ip2 net.IP, ports []Port, sharing
 		key:   *sk,
 	}
 	for i, port := range ports {
-		port := port
 		alloc.ports[i] = port
 	}
 	a.assign(svc, alloc)
@@ -430,7 +428,6 @@ func (a *Allocator) AllocateFromPoolDual(svc string, poolName string, ports []Po
 		return alloc.ip, alloc.ip2, nil
 	}
 
-	fmt.Println("AllocateFromPoolDual", svc, poolName)
 	pool := a.pools[poolName]
 	if pool == nil {
 		return nil, nil, fmt.Errorf("unknown pool %q", poolName)


### PR DESCRIPTION
#  Draft PR

Fixes #698 

### Build

To build metallb with this PR you must use a local version of the K8s API. At the moment;
```
git clone --depth 1 -b dualstack-phase-3 https://github.com/khenidak/kubernetes.git
```
later when the PR https://github.com/kubernetes/kubernetes/pull/91824 has been merged the `master` branch for K8s shall be used. A "replace" section must be added in `go.mod` to point out the local clone;
```
replace (
        k8s.io/api => /home/uablrek/go/src/k8s.io/kubernetes/staging/src/k8s.io/api
        k8s.io/apimachinery => /home/uablrek/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery
        k8s.io/client-go => /home/uablrek/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go
)
```
You must use your own path of course.

### Progress

- [x] Build towards a local K8s API
- [x] Detect the presence of a dual-stack service by examining the length of `clusterIPs`
- [x] Assign both ipv4 and ipv6 load-balancer addresses to dual-stack services
- [x] A "metallb.universe.tf/load-balancer-ips" annotation for dual-stack
- [x] Check that metrics works with dual-stack services
- [ ] Test re-start of the controller (state is updated from K8s)
- [x] Unit tests for `allocator` updates
- [ ] Many more tests...

