### PR TITLE
Update manifests/metallb.yaml for kubernetes v1.19

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -335,7 +335,7 @@ spec:
           readOnlyRootFilesystem: true
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: speaker
       terminationGracePeriodSeconds: 2
       tolerations:
@@ -386,7 +386,7 @@ spec:
             - all
           readOnlyRootFilesystem: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
According to kubernetes documentation, since v1.19 kubernetes stops using labels with "beta." prefix. Installation manifest manifests/metallb.yaml fixes nodeSelector to kubernetes.io/os.

Fixed   #743