### PR TITLE
Always pass namespace as METALLB_NAMESPACE

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -3,7 +3,6 @@ package k8s // import "go.universe.tf/metallb/internal/k8s"
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"go.universe.tf/metallb/internal/config"
@@ -114,15 +113,6 @@ func New(cfg *Config) (*Client, error) {
 		return nil, fmt.Errorf("creating Kubernetes client: %s", err)
 	}
 
-	namespace := cfg.ConfigMapNS
-	if namespace == "" {
-		bs, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		if err != nil {
-			return nil, fmt.Errorf("getting namespace from pod service account data: %s", err)
-		}
-		namespace = string(bs)
-	}
-
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(clientset.CoreV1().RESTClient()).Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: cfg.ProcessName})
@@ -212,7 +202,7 @@ func New(cfg *Config) (*Client, error) {
 				}
 			},
 		}
-		cmWatcher := cache.NewListWatchFromClient(c.client.CoreV1().RESTClient(), "configmaps", namespace, fields.OneTermEqualSelector("metadata.name", cfg.ConfigMapName))
+		cmWatcher := cache.NewListWatchFromClient(c.client.CoreV1().RESTClient(), "configmaps", cfg.ConfigMapNS, fields.OneTermEqualSelector("metadata.name", cfg.ConfigMapName))
 		c.cmIndexer, c.cmInformer = cache.NewIndexerInformer(cmWatcher, &v1.ConfigMap{}, 0, cmHandlers, cache.Indexers{})
 
 		c.configChanged = cfg.ConfigChanged

--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -51,8 +51,8 @@ func New(logger gokitlog.Logger, nodeName, bindAddr, bindPort, secret, namespace
 		labels:    labels,
 	}
 
-	if namespace == "" || labels == "" || bindAddr == "" {
-		logger.Log("op", "startup", "msg", "not starting fast dead node detection (memberlist), need ml-bindaddr / ml-labels / ml-namespace config")
+	if labels == "" || bindAddr == "" {
+		logger.Log("op", "startup", "msg", "not starting fast dead node detection (memberlist), need ml-bindaddr / ml-labels config")
 		return &sl, nil
 	}
 

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -287,6 +287,10 @@ spec:
         - --port=7472
         - --config=config
         env:
+        - name: METALLB_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:
@@ -304,10 +308,6 @@ spec:
         #  value: "7946"
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
-        - name: METALLB_ML_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: METALLB_ML_SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -369,6 +369,11 @@ spec:
       - args:
         - --port=7472
         - --config=config
+        env:
+        - name: METALLB_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: metallb/controller:main
         imagePullPolicy: Always
         name: controller

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -74,7 +74,7 @@ func main() {
 		mlLabels   = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
 		mlSecret   = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
 		myNode     = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
-		port       = flag.Int("port", 80, "HTTP listening port")
+		port       = flag.Int("port", 7472, "HTTP listening port")
 	)
 	flag.Parse()
 


### PR DESCRIPTION
For the speakers we had
- config-ns for the configmap
- ml-namespace for the speaker namespace
the memberlist secret is taken from the speakers namespace (secretKeyRef)

For the controller we also had config-ns

As we will need to have the secret namespace in the controller,
and we don't really need the extra complexity, just keep one namespace
setting 'namespace'/METALLB_NAMESPACE for both the speakers and the controller