### PR TITLE
Remove NET_ADMIN and SYS_ADMIN capabilities

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -50,9 +50,7 @@ metadata:
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:
-  - NET_ADMIN
   - NET_RAW
-  - SYS_ADMIN
   allowedHostPaths: []
   defaultAddCapabilities: []
   defaultAllowPrivilegeEscalation: false
@@ -327,9 +325,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add:
-            - NET_ADMIN
             - NET_RAW
-            - SYS_ADMIN
             drop:
             - ALL
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Those capabilities are not needed and allow to break out of the container

This was introduced in a18378a3359284da08acdae4cdb134f8376019ed / #382
Fixes #762