### PR TITLE
Do not set resources limits by default

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -325,10 +325,6 @@ spec:
         - containerPort: 7946
           name: memberlist-udp
           protocol: UDP
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -379,10 +375,6 @@ spec:
         ports:
         - containerPort: 7472
           name: monitoring
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
I've experienced issues in the past where MetalLB was throttled
for 15s and then replying to all previous ARP request at the same time.
MetalLB is the entry point of the cluster, if it's not working everything
else in the cluster is useless, so let's just not set limits.