### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
-      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --docker-user=metallb
+      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
   deploy-speaker:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
@@ -50,7 +50,7 @@ jobs:
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
-      - run: PATH=./bin:$PATH inv push-multiarch --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --docker-user=metallb
+      - run: PATH=./bin:$PATH inv push-multiarch --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
 workflows:
   version: 2
   test-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,21 @@
 version: 2
 jobs:
   test-1.13:
-    working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: cimg/go:1.13
     steps:
       - checkout
-      - run: sudo apt-get install python-pip
-      - run: sudo pip install invoke semver pyyaml
-      - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: go test -short ./...
       - run: go test -short -race ./...
       - run: cp manifests/metallb.yaml manifests/metallb.yaml.prev
   lint-1.13:
-    working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: cimg/go:1.13
     steps:
       - checkout
-      - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: curl -L https://git.io/vp6lP | sh # gometalinter
       - run: PATH=./bin:$PATH gometalinter --deadline=5m --disable-all --enable=gofmt --enable=vet --vendor ./...
   publish-images:
-    working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: cimg/go:1.13
     steps:
@@ -35,10 +28,8 @@ jobs:
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
-      - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --registry=docker.io --repo=metallb --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}}
   publish-images-quay:
-    working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: cimg/go:1.13
     steps:
@@ -49,7 +40,6 @@ jobs:
       - run: docker login quay.io -u $QUAY_USER -p $QUAY_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
-      - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --registry=quay.io --repo=metallb --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}}
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,21 @@ jobs:
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
-      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
+      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --registry=docker.io --repo=metallb --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}}
+  publish-images-quay:
+    working_directory: /go/src/go.universe.tf/metallb
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: sudo apt-get install python-pip
+      - run: sudo pip install invoke semver pyyaml
+      - run: docker login quay.io -u $QUAY_USER -p $QUAY_PASSWORD
+      - run: mkdir -p ./bin
+      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
+      - run: echo "export GO111MODULE=on" >>$BASH_ENV
+      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --registry=quay.io --repo=metallb --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}}
 workflows:
   version: 2
   test-and-publish:
@@ -50,6 +64,17 @@ workflows:
             tags:
               only: /.*/
       - publish-images:
+          filters:
+            branches:
+              only:
+                - main
+                - /v.*/
+            tags:
+              only: /.*/
+          requires:
+            - test-1.13
+            - lint-1.13
+      - publish-images-quay:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   test-1.13:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.13
     steps:
       - checkout
       - run: sudo apt-get install python-pip
@@ -17,7 +17,7 @@ jobs:
   lint-1.13:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.13
     steps:
       - checkout
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
@@ -26,12 +26,12 @@ jobs:
   publish-images:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.13
     steps:
       - checkout
       - setup_remote_docker
-      - run: sudo apt-get install python-pip
-      - run: sudo pip install invoke semver pyyaml
+      - run: sudo apt-get update && sudo apt-get install -y python-pip
+      - run: pip install invoke semver pyyaml
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
@@ -40,12 +40,12 @@ jobs:
   publish-images-quay:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.13
     steps:
       - checkout
       - setup_remote_docker
-      - run: sudo apt-get install python-pip
-      - run: sudo pip install invoke semver pyyaml
+      - run: sudo apt-get update && sudo apt-get install -y python-pip
+      - run: pip install invoke semver pyyaml
       - run: docker login quay.io -u $QUAY_USER -p $QUAY_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: curl -L https://git.io/vp6lP | sh # gometalinter
       - run: PATH=./bin:$PATH gometalinter --deadline=5m --disable-all --enable=gofmt --enable=vet --vendor ./...
-  deploy-controller:
+  publish-images:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: circleci/golang:1.13
@@ -36,24 +36,10 @@ jobs:
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
-      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
-  deploy-speaker:
-    working_directory: /go/src/go.universe.tf/metallb
-    docker:
-      - image: circleci/golang:1.13
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: sudo apt-get install python-pip
-      - run: sudo pip install invoke semver pyyaml
-      - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - run: mkdir -p ./bin
-      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
-      - run: echo "export GO111MODULE=on" >>$BASH_ENV
-      - run: PATH=./bin:$PATH inv push-multiarch --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
+      - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
 workflows:
   version: 2
-  test-and-deploy:
+  test-and-publish:
     jobs:
       - test-1.13:
           filters:
@@ -63,18 +49,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - deploy-controller:
-          filters:
-            branches:
-              only:
-                - main
-                - /v.*/
-            tags:
-              only: /.*/
-          requires:
-            - test-1.13
-            - lint-1.13
-      - deploy-speaker:
+      - publish-images:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run: sudo pip install invoke semver pyyaml
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: mkdir -p ./bin
-      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
+      - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
       - run: echo "export GO111MODULE=on" >>$BASH_ENV
       - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}} --repo=metallb
 workflows:


### PR DESCRIPTION
This PR does the following:

- Add a CI job to publish images to Quay in parallel to the existing Docker Hub job.
- Update the CircleCI images we use for the build environment.
- Clean up old and unused CI code.
- Consolidate controller and speaker publish jobs to a single job to keep things DRY.
- Bump manifest-tool to `v1.0.3`.

Needed for https://github.com/metallb/metallb/issues/696.