### PR TITLE
docs(website): correct kustomize example to work with kustomize

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -91,10 +91,14 @@ on the remote kustomization fle :
 
 ```yaml
 # kustomization.yml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: metallb-system
 
+bases:
+  - github.com/metallb/metallb/manifests?ref=v0.9.4
+
 resources:
-  - github.com/metallb/metallb//manifests?ref=v0.9.3
   - configmap.yml 
   - secret.yml
 ```


### PR DESCRIPTION
Hi,

I'm no expert with kustomize but the example failed for me, quick look over at the kustomize repo ended up with this example so just pushing this. Happy if there is some versions this perhaps work with but for me it didn't like the example.

I can see the apiVersion from here https://github.com/kubernetes-sigs/kustomize/blob/436c688bd07757cf04fcbd9458a7f9011de2eb28/kyaml/yaml/merge3/kustomization_test.go#L12

![Screenshot 2020-11-01 at 13 37 06](https://user-images.githubusercontent.com/319498/97804372-576dc700-1c47-11eb-8520-9968e4ef05a1.png)

Strangely the documentation suggests a Github.com reference in references should work, yet it doesn't. 