### PR TITLE
Allow to share same subnet for metallb address pool and clusterIPs

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -152,8 +152,15 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 	isIPv6 := clusterIP.To4() == nil
 
 	// If the user asked for a specific IP, try that.
-	if svc.Spec.LoadBalancerIP != "" {
-		ip := net.ParseIP(svc.Spec.LoadBalancerIP)
+	if c.ips.IsAllowClusterIP(clusterIP) || svc.Spec.LoadBalancerIP != "" {
+                var ip net.IP
+		if (svc.Spec.LoadBalancerIP != "") {
+			// The user asked for a specific loadBalancer IP, try that.
+			ip = net.ParseIP(svc.Spec.LoadBalancerIP)
+		} else {
+			// The user asked for the cluster IP, try that.
+			ip = clusterIP
+		}
 		if ip == nil {
 			return nil, fmt.Errorf("invalid spec.loadBalancerIP %q", svc.Spec.LoadBalancerIP)
 		}

--- a/controller/service.go
+++ b/controller/service.go
@@ -153,8 +153,8 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 
 	// If the user asked for a specific IP, try that.
 	if c.ips.IsAllowClusterIP(clusterIP) || svc.Spec.LoadBalancerIP != "" {
-                var ip net.IP
-		if (svc.Spec.LoadBalancerIP != "") {
+		var ip net.IP
+		if svc.Spec.LoadBalancerIP != "" {
 			// The user asked for a specific loadBalancer IP, try that.
 			ip = net.ParseIP(svc.Spec.LoadBalancerIP)
 		} else {

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -393,3 +393,10 @@ func ipConfusesBuggyFirmwares(ip net.IP) bool {
 	}
 	return ip[3] == 0 || ip[3] == 255
 }
+
+// IsAllowClusterIP returns true if the pool owning the IP allows Cluster IPs	
+func (a *Allocator) IsAllowClusterIP(ip net.IP) bool {
+	poolName := poolFor(a.pools, ip)
+        pool := a.pools[poolName]
+        return pool != nil && pool.AllowClusterIP
+}

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -397,6 +397,6 @@ func ipConfusesBuggyFirmwares(ip net.IP) bool {
 // IsAllowClusterIP returns true if the pool owning the IP allows Cluster IPs	
 func (a *Allocator) IsAllowClusterIP(ip net.IP) bool {
 	poolName := poolFor(a.pools, ip)
-        pool := a.pools[poolName]
-        return pool != nil && pool.AllowClusterIP
+	pool := a.pools[poolName]
+	return pool != nil && pool.AllowClusterIP
 }

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -394,7 +394,7 @@ func ipConfusesBuggyFirmwares(ip net.IP) bool {
 	return ip[3] == 0 || ip[3] == 255
 }
 
-// IsAllowClusterIP returns true if the pool owning the IP allows Cluster IPs	
+// IsAllowClusterIP returns true if the pool owning the IP allows Cluster IPs
 func (a *Allocator) IsAllowClusterIP(ip net.IP) bool {
 	poolName := poolFor(a.pools, ip)
 	pool := a.pools[poolName]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,7 +323,7 @@ func parseAddressPool(p addressPool, bgpCommunities map[string]uint32) (*Pool, e
 		Protocol:       p.Protocol,
 		AvoidBuggyIPs:  p.AvoidBuggyIPs,
 		AllowClusterIP: p.AllowClusterIP,
-		AutoAssign:    true,
+		AutoAssign:     true,
 	}
 
 	if p.AutoAssign != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type addressPool struct {
 	Name              string
 	Addresses         []string
 	AvoidBuggyIPs     bool               `yaml:"avoid-buggy-ips"`
+	AllowClusterIP    bool               `yaml:"allow-cluster-ip"`
 	AutoAssign        *bool              `yaml:"auto-assign"`
 	BGPAdvertisements []bgpAdvertisement `yaml:"bgp-advertisements"`
 }
@@ -130,6 +131,8 @@ type Pool struct {
 	// If false, prevents IP addresses to be automatically assigned
 	// from this pool.
 	AutoAssign bool
+	// If true, assign the cluster IP as the external IP.
+	AllowClusterIP bool
 	// When an IP is allocated from this pool, how should it be
 	// translated into BGP announcements?
 	BGPAdvertisements []*BGPAdvertisement
@@ -317,8 +320,9 @@ func parseAddressPool(p addressPool, bgpCommunities map[string]uint32) (*Pool, e
 	}
 
 	ret := &Pool{
-		Protocol:      p.Protocol,
-		AvoidBuggyIPs: p.AvoidBuggyIPs,
+		Protocol:       p.Protocol,
+		AvoidBuggyIPs:  p.AvoidBuggyIPs,
+		AllowClusterIP: p.AllowClusterIP,
 		AutoAssign:    true,
 	}
 


### PR DESCRIPTION
I need to share the same network range for a metallb allocation pool and a kubernetes cluster IP range.
That's what this PR is addressing.
I've added an option in metallb config file:

apiVersion: v1
kind: ConfigMap
metadata:
  namespace: metallb-system
  name: config
data:
  config: |
    address-pools:
    - name: metallb-adress-pool
      allow-cluster-ip: true
      protocol: layer2
      addresses:
     - 10.0.252.0/22

and then when a service of type "LoadBalancer" is registered, the allocator return the clusterIP address of the service.

Note that without the option (allow-cluster-ip: true), the original behavior remains unchanged.

