### PR TITLE
Move images to Quay

### DIFF
--- a/e2etest/manifests/mirror-server.yaml
+++ b/e2etest/manifests/mirror-server.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mirror
-        image: metallb/mirror-server:main
+        image: quay.io/metallb/mirror-server:main
         env:
         - name: NODE_NAME
           valueFrom:

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -313,7 +313,7 @@ spec:
             secretKeyRef:
               name: memberlist
               key: secretkey
-        image: metallb/speaker:main
+        image: quay.io/metallb/speaker:main
         imagePullPolicy: Always
         name: speaker
         ports:
@@ -369,7 +369,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: metallb/controller:main
+        image: quay.io/metallb/controller:main
         imagePullPolicy: Always
         name: controller
         ports:

--- a/tasks.py
+++ b/tasks.py
@@ -63,11 +63,11 @@ def _make_build_dirs():
       help={
           "binaries": "binaries to build. One or more of {}, or 'all'".format(", ".join(sorted(all_binaries))),
           "architectures": "architectures to build. One or more of {}, or 'all'".format(", ".join(sorted(all_architectures))),
-          "registry": "Docker registry under which to tag the images. Default 'docker.io'.",
+          "registry": "Docker registry under which to tag the images. Default 'quay.io'.",
           "repo": "Docker repository under which to tag the images. Default 'metallb'.",
           "tag": "Docker image tag prefix to use. Actual tag will be <tag>-<arch>. Default 'dev'.",
       })
-def build(ctx, binaries, architectures, registry="docker.io", repo="metallb", tag="dev"):
+def build(ctx, binaries, architectures, registry="quay.io", repo="metallb", tag="dev"):
     """Build MetalLB docker images."""
     binaries = _check_binaries(binaries)
     architectures = _check_architectures(architectures)
@@ -109,11 +109,11 @@ def build(ctx, binaries, architectures, registry="docker.io", repo="metallb", ta
       help={
           "binaries": "binaries to build. One or more of {}, or 'all'".format(", ".join(sorted(all_binaries))),
           "architectures": "architectures to build. One or more of {}, or 'all'".format(", ".join(sorted(all_architectures))),
-          "registry": "Docker registry under which to tag the images. Default 'docker.io'.",
+          "registry": "Docker registry under which to tag the images. Default 'quay.io'.",
           "repo": "Docker repository under which to tag the images. Default 'metallb'.",
           "tag": "Docker image tag prefix to use. Actual tag will be <tag>-<arch>. Default 'dev'.",
       })
-def push(ctx, binaries, architectures, registry="docker.io", repo="metallb", tag="dev"):
+def push(ctx, binaries, architectures, registry="quay.io", repo="metallb", tag="dev"):
     """Build and push docker images to registry."""
     binaries = _check_binaries(binaries)
     architectures = _check_architectures(architectures)
@@ -132,11 +132,11 @@ def push(ctx, binaries, architectures, registry="docker.io", repo="metallb", tag
 @task(iterable=["binaries"],
       help={
           "binaries": "binaries to build. One or more of {}, or 'all'".format(", ".join(sorted(all_binaries))),
-          "registry": "Docker registry under which to tag the images. Default 'docker.io'.",
+          "registry": "Docker registry under which to tag the images. Default 'quay.io'.",
           "repo": "Docker repository under which to tag the images. Default 'metallb'.",
           "tag": "Docker image tag prefix to use. Actual tag will be <tag>-<arch>. Default 'dev'.",
       })
-def push_multiarch(ctx, binaries, registry="docker.io", repo="metallb", tag="dev"):
+def push_multiarch(ctx, binaries, registry="quay.io", repo="metallb", tag="dev"):
     """Build and push multi-architecture docker images to registry."""
     binaries = _check_binaries(binaries)
     architectures = _check_architectures(["all"])
@@ -194,9 +194,9 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None):
         run("kubectl apply -f e2etest/manifests/{}.yaml".format(cni), echo=True)
 
     build(ctx, binaries=["controller", "speaker", "mirror-server"], architectures=[architecture])
-    run("kind load docker-image --name={} metallb/controller:dev-{}".format(name, architecture), echo=True)
-    run("kind load docker-image --name={} metallb/speaker:dev-{}".format(name, architecture), echo=True)
-    run("kind load docker-image --name={} metallb/mirror-server:dev-{}".format(name, architecture), echo=True)
+    run("kind load docker-image --name={} quay.io/metallb/controller:dev-{}".format(name, architecture), echo=True)
+    run("kind load docker-image --name={} quay.io/metallb/speaker:dev-{}".format(name, architecture), echo=True)
+    run("kind load docker-image --name={} quay.io/metallb/mirror-server:dev-{}".format(name, architecture), echo=True)
 
     run("kubectl delete po -nmetallb-system --all", echo=True)
 

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -81,7 +81,7 @@ tag. You need to wait for these images to be pushed live before
 continuing, because the manifests for the new release point to image
 tags that don't exist until CircleCI makes them exist.
 
-Check on Docker Hub for a `vX.Y.Z` tag on each image, or check on
+Check on Quay for a `vX.Y.Z` tag on each image, or check on
 CircleCI that the deploy has completed.
 
 ### Repoint the live website


### PR DESCRIPTION
This PR points the manifests to Quay instead of Docker Hub.

Fixes #696.