### PR TITLE
Update kind to v0.9.0

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -162,17 +162,18 @@ def validate_kind_version():
     # If kind is not installed, this first command will raise an UnexpectedExit
     # exception, and inv will exit at this point making it clear running "kind"
     # failed.
-    raw_version = run("kind version", echo=True)
+    min_version = "0.8.0"
 
-    # x.y.z
-    version = re.search("v\d*\.(\d*)\.\d*", raw_version.stdout)
     try:
-        y = int(version.group(1))
-    except Exception:
-        raise Exit(message="Unexpected output of 'kind version'")
+        raw = run("kind version", echo=True)
+    except Exception as e:
+        raise Exit(message="Could not determine kind version (is kind installed?)")
 
-    if y < 8:
-        raise Exit(message="kind version >= 0.8 required")
+    actual_version = re.search("v(\d*\.\d*\.\d*)", raw.stdout).group(1)
+    delta = semver.compare(actual_version, min_version)
+
+    if delta < 0:
+        raise Exit(message=f"kind version >= {min_version} required")
 
 
 @task(help={

--- a/tasks.py
+++ b/tasks.py
@@ -162,7 +162,7 @@ def validate_kind_version():
     # If kind is not installed, this first command will raise an UnexpectedExit
     # exception, and inv will exit at this point making it clear running "kind"
     # failed.
-    min_version = "0.8.0"
+    min_version = "0.9.0"
 
     try:
         raw = run("kind version", echo=True)
@@ -197,7 +197,7 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None):
     mk_cluster = name not in clusters
     if mk_cluster:
         config = {
-            "apiVersion": "kind.sigs.k8s.io/v1alpha3",
+            "apiVersion": "kind.x-k8s.io/v1alpha4",
             "kind": "Cluster",
             "nodes": [{"role": "control-plane"},
                       {"role": "worker"},

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -120,7 +120,7 @@ To develop MetalLB, you'll need a couple of pieces of software:
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/), the Kubernetes commandline interface
 - [Invoke](https://www.pyinvoke.org) to drive the build system
 
->NOTE: The development environment was tested with **kind `v0.7.0`**. Older
+>NOTE: The development environment was tested with **kind `v0.9.0`**. Older
 >versions may not work since there have been breaking changes between minor
 >versions.
 


### PR DESCRIPTION
This PR updates kind to the current latest version - `v0.9.0` which also uses k8s `v1.19` by default.