### PR TITLE
dev-env: Fix syntax

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -173,7 +173,7 @@ def validate_kind_version():
     delta = semver.compare(actual_version, min_version)
 
     if delta < 0:
-        raise Exit(message=f"kind version >= {min_version} required")
+        raise Exit(message="kind version >= {} required".format(min_version))
 
 
 @task(help={


### PR DESCRIPTION
Our CI environment uses Python 2 which doesn't support f-strings. We should update to Python 3 but in the meantime we need a working CI.

This wasn't caught before merging because we don't push images for PRs.