### PR TITLE
Set imagePullPolicy to IfNotPresent

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -314,7 +314,6 @@ spec:
               name: memberlist
               key: secretkey
         image: quay.io/metallb/speaker:main
-        imagePullPolicy: Always
         name: speaker
         ports:
         - containerPort: 7472
@@ -370,7 +369,6 @@ spec:
         - --port=7472
         - --config=config
         image: quay.io/metallb/controller:main
-        imagePullPolicy: Always
         name: controller
         ports:
         - containerPort: 7472

--- a/tasks.py
+++ b/tasks.py
@@ -232,7 +232,6 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None):
         with open(manifests_dir + "/metallb.yaml") as f:
             manifest = f.read()
         manifest = manifest.replace(":main", ":dev-{}".format(architecture))
-        manifest = manifest.replace("imagePullPolicy: Always", "imagePullPolicy: Never")
         with open(tmpdir + "/metallb.yaml", "w") as f:
             f.write(manifest)
             f.flush()


### PR DESCRIPTION
There is no reason to have it set to Always and re-pulling the image every time can make k8s convergence and scaling slower.

Fixes #748.