### PR TITLE
website: Fix Netlify publish dir

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "website"
-  publish = "website/public"
+  publish = "public"
   command = "hugo"
 
 [build.environment]


### PR DESCRIPTION
This should fix the Netlify links to older releases under https://metallb.universe.tf/release-notes/.