### PR TITLE
website: Fix a hugo error

### DIFF
--- a/website/content/_header.md
+++ b/website/content/_header.md
@@ -1,3 +1,5 @@
+---
+---
 <img align="left" src="/images/logo/metallb-white.png" width="25%"></img>
 MetalLB (latest version)
 <p style="clear: both"></p>


### PR DESCRIPTION
When I try to run `hugo server` right now, I get the following error:

  Error: Error building site: "/home/rbryant/go/src/github.com/metallb/metallb/website/content/_header.md:1:1": plain HTML documents not supported

It seems like this is an issue with a more recent version of hugo.
I'm using the following version from a Fedora package:

  Hugo Static Site Generator v0.80.0/extended linux/amd64 BuildDate: unknown

This change is based on a suggested workaround in the following issue:

  https://github.com/gohugoio/hugo/issues/7296

The workaround seems harmless, and may no longer be needed if the
following issue gets resolved at some point in the future:

  https://github.com/gohugoio/hugo/issues/6098