### PR TITLE
Remove unused Service Update()

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -65,11 +65,6 @@ type testK8S struct {
 	t                   *testing.T
 }
 
-func (s *testK8S) Update(svc *v1.Service) (*v1.Service, error) {
-	s.updateService = svc
-	return svc, nil
-}
-
 func (s *testK8S) UpdateStatus(svc *v1.Service) error {
 	s.updateServiceStatus = &svc.Status
 	return nil

--- a/controller/main.go
+++ b/controller/main.go
@@ -32,7 +32,6 @@ import (
 
 // Service offers methods to mutate a Kubernetes service object.
 type service interface {
-	Update(svc *v1.Service) (*v1.Service, error)
 	UpdateStatus(svc *v1.Service) error
 	Infof(svc *v1.Service, desc, msg string, args ...interface{})
 	Errorf(svc *v1.Service, desc, msg string, args ...interface{})
@@ -76,19 +75,11 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		return k8s.SyncStateSuccess
 	}
 
-	var err error
-	if !(reflect.DeepEqual(svcRo.Annotations, svc.Annotations) && reflect.DeepEqual(svcRo.Spec, svc.Spec)) {
-		svcRo, err = c.client.Update(svc)
-		if err != nil {
-			l.Log("op", "updateService", "error", err, "msg", "failed to update service")
-			return k8s.SyncStateError
-		}
-	}
 	if !reflect.DeepEqual(svcRo.Status, svc.Status) {
 		var st v1.ServiceStatus
 		st, svc = svc.Status, svcRo.DeepCopy()
 		svc.Status = st
-		if err = c.client.UpdateStatus(svc); err != nil {
+		if err := c.client.UpdateStatus(svc); err != nil {
 			l.Log("op", "updateServiceStatus", "error", err, "msg", "failed to update service status")
 			return k8s.SyncStateError
 		}

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -331,13 +331,6 @@ func (c *Client) ForceSync() {
 	}
 }
 
-// Update writes svc back into the Kubernetes cluster. If successful,
-// the updated Service is returned. Note that changes to svc.Status
-// are not propagated, for that you need to call UpdateStatus.
-func (c *Client) Update(svc *v1.Service) (*v1.Service, error) {
-	return c.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{})
-}
-
 // UpdateStatus writes the protected "status" field of svc back into
 // the Kubernetes cluster.
 func (c *Client) UpdateStatus(svc *v1.Service) error {

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -110,7 +110,6 @@ rules:
   - get
   - list
   - watch
-  - update
 - apiGroups:
   - ''
   resources:

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -174,10 +174,6 @@ type testK8S struct {
 	t             *testing.T
 }
 
-func (s *testK8S) Update(svc *v1.Service) (*v1.Service, error) {
-	panic("never called")
-}
-
 func (s *testK8S) UpdateStatus(svc *v1.Service) error {
 	panic("never called")
 }

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -49,7 +49,6 @@ var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 // Service offers methods to mutate a Kubernetes service object.
 type service interface {
-	Update(svc *v1.Service) (*v1.Service, error)
 	UpdateStatus(svc *v1.Service) error
 	Infof(svc *v1.Service, desc, msg string, args ...interface{})
 	Errorf(svc *v1.Service, desc, msg string, args ...interface{})


### PR DESCRIPTION
The Update() to the Service object is never triggered because the code
does not modify the object between the deep copy and when Update() is
called.

Previously, commit cdd44aa9 ("Initial commit. Somewhat working
controller, half-written BGP speaker") modified the Spec and Annotations
field of the Service. However, since commit 3e10f6ea ("Clean up processing
to exclusively use status.loadBalancer.ingress.ip"), that is no longer
the case, as the code exclusively only touches the Status field.

Therefore, this commit removes this dead code and revokes the update
privileges from the ClusterRole as well.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
