### PR TITLE
Set default prometheus port to 7472 for speakers

### DIFF
--- a/speaker/main.go
+++ b/speaker/main.go
@@ -74,7 +74,7 @@ func main() {
 		mlNamespace = flag.String("ml-namespace", os.Getenv("METALLB_ML_NAMESPACE"), "Namespace of the speakers (for MemberList / fast dead node detection)")
 		mlSecret    = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
 		myNode      = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
-		port        = flag.Int("port", 80, "HTTP listening port")
+		port        = flag.Int("port", 7472, "HTTP listening port")
 	)
 	flag.Parse()
 

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -3,6 +3,15 @@ title: Release Notes
 weight: 8
 ---
 
+## Version 0.10.0 (Still in development)
+
+Changes in behavior:
+
+- The `port` option to the `speaker`, which is the prometheus metrics port, now
+  defaults to port `7472`. This was already the default in the manifests
+  included with MetalLB, but the binary itself previously defaulted to port
+  `80`.
+
 ## Version 0.9.6
 [Documentation for this release](https://metallb.universe.tf)
 


### PR DESCRIPTION
This is the value used in the manifests