### PR TITLE
WIP: Add invoke tasks for unit tests and linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,14 @@ jobs:
       - image: cimg/go:1.13
     steps:
       - checkout
-      - run: go test -short ./...
-      - run: go test -short -race ./...
+      - run: inv unit-tests
       - run: cp manifests/metallb.yaml manifests/metallb.yaml.prev
   lint-1.13:
     docker:
       - image: cimg/go:1.13
     steps:
       - checkout
-      - run: curl -L https://git.io/vp6lP | sh # gometalinter
-      - run: PATH=./bin:$PATH gometalinter --deadline=5m --disable-all --enable=gofmt --enable=vet --vendor ./...
+      - run: inv linter
   publish-images:
     docker:
       - image: cimg/go:1.13

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 build/
 website/public
 .envrc
-e2etest/vmlinuz
-e2etest/initrd.img
-e2etest/*.qcow2
-e2etest/e2etest
-e2etest-cached-universe
+kind.yaml
+bin

--- a/tasks.py
+++ b/tasks.py
@@ -444,3 +444,16 @@ def release(ctx, version, skip_release_notes=False):
     run("git commit -a -m 'Automated update for release v{}'".format(version), echo=True)
     run("git tag v{} -m 'See the release notes for details:\n\nhttps://metallb.universe.tf/release-notes/#version-{}-{}-{}'".format(version, version.major, version.minor, version.patch), echo=True)
     run("git checkout main", echo=True)
+
+@task
+def unit_tests(ctx):
+    """Run unit tests."""
+    run("go test ./...")
+    run("go test -race ./...")
+
+@task
+def linter(ctx):
+    """Run linter."""
+    # Install "gometalinter" and run linter
+    run("curl -L https://git.io/vp6lP | sh")
+    run("PATH=./bin/$PATH ./bin/gometalinter --deadline=5m --disable-all --enable=gofmt --enable=vet --vendor ./...")


### PR DESCRIPTION
This PR adds tasks to "invoke" in order to enable convenient execution of the linter and unit-test stage from circleci.