### PR TITLE
gitignore: Update .gitignore to remove e2etest reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,3 @@
 build/
 website/public
 .envrc
-e2etest/vmlinuz
-e2etest/initrd.img
-e2etest/*.qcow2
-e2etest/e2etest
-e2etest-cached-universe


### PR DESCRIPTION
We should remove the e2etest references as these were dropped.