### PR TITLE
design: Create a directory for design proposals

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,10 @@
+# Design Documents
+
+To enable reviews against design proposals in the same way that we review code
+contributions, please create design proposals as markdown formatted files in
+this directory.
+
+While we do not have strict requirements on the outline of the proposal, we
+encourage the use of the [Kubernetes Enhancement Proposal (KEP)
+template](https://github.com/kubernetes/enhancements/tree/master/keps/NNNN-kep-template)
+as inspiration.

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -50,9 +50,11 @@ agree to abide by its terms.
 
 ## Code changes
 
-Before you make significant code changes, please open an issue to
-discuss your plans. This will minimize the amount of review required
-for pull requests.
+Before you make significant code changes, please consider opening a pull
+request with a proposed design in the `design/` directory.  That should
+reduce the amount of time required for code review.  If you don't have a full
+design proposal ready, feel free to open an issue to discuss what you would
+like to do.
 
 All submissions require review. We use GitHub pull requests for this
 purpose. Consult [GitHub


### PR DESCRIPTION
To allow for easier review on design proposals, create a directory for
design proposals.  Future PRs with proposed designs should be posted as
a PR to this directory.

While we don't require a specific outline, we encourage the use of the
KEP template for inspiration.