### PR TITLE
Bump Golang to 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@
 
 version: 2
 jobs:
-  test-1.13:
+  test-1.16:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.16
     steps:
       - checkout
       - run: sudo apt-get update
@@ -12,9 +12,9 @@ jobs:
       - run: sudo pip3 install invoke semver pyyaml
       - run: inv test
       - run: cp manifests/metallb.yaml manifests/metallb.yaml.prev
-  lint-1.13:
+  lint-1.16:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.16
     steps:
       - checkout
       - run: curl -L https://git.io/vp6lP | sh # gometalinter
@@ -45,7 +45,7 @@ jobs:
       - run: helm conftest charts/metallb/ -p charts/metallb/policy/ --fail-on-warn
   publish-images:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.16
     steps:
       - checkout
       # This job should not run against PRs, but we have seen it run unexpectedly, so
@@ -60,7 +60,7 @@ jobs:
       - run: PATH=./bin:$PATH inv push-multiarch --binaries=controller --binaries=speaker --registry=docker.io --repo=metallb --tag=${CIRCLE_BRANCH:-${CIRCLE_TAG}}
   publish-images-quay:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.16
     steps:
       - checkout
       # This job should not run against PRs, but we have seen it run unexpectedly, so
@@ -77,11 +77,11 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test-1.13:
+      - test-1.16:
           filters:
             tags:
               only: /.*/
-      - lint-1.13:
+      - lint-1.16:
           filters:
             tags:
               only: /.*/
@@ -102,8 +102,8 @@ workflows:
             tags:
               only: /.*/
           requires:
-            - test-1.13
-            - lint-1.13
+            - test-1.16
+            - lint-1.16
       - publish-images-quay:
           filters:
             branches:
@@ -113,5 +113,5 @@ workflows:
             tags:
               only: /.*/
           requires:
-            - test-1.13
-            - lint-1.13
+            - test-1.16
+            - lint-1.16

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.universe.tf/metallb
 
-go 1.12
+go 1.16
 
 require (
 	github.com/armon/go-radix v1.0.0 // indirect


### PR DESCRIPTION
Golang 1.13 has horrible bugs that might have affected MetalLB
as it's using client-go / watches,
see https://github.com/kubernetes/kubernetes/issues/87615
Newer client-go version (that we are now using) have implemented
HTTP/2 health check by default but this is a workaround not a fix.

Also Golang 1.13 is not supported anymore

This replace #816