### PR TITLE
chart: clean up values schema of .Values.prometheus.*

### DIFF
--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -10,7 +10,8 @@
           "type": "boolean"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
       },
       "required": [ "enabled" ]
@@ -169,39 +170,87 @@
       "description": "Prometheus monitoring config",
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "staleConfig": { "$ref": "#/definitions/prometheusAlert" },
-        "configNotLoaded": { "$ref": "#/definitions/prometheusAlert" },
-        "addressPoolExhausted": { "$ref": "#/definitions/prometheusAlert" },
-        "addressPoolUsage": {
+        "scrapeAnnotations": { "type": "boolean" },
+        "podMonitor": {
+          "description": "Prometheus Operator PodMonitors",
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
+            "enabled": { "type": "boolean" },
+            "jobLabel": { "type": "string" },
+            "interval": {
+              "anyOf": [
+                { "type": "integer" },
+                { "type": "null" }
+              ]
             },
-            "thresholds": {
+            "metricRelabelings": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "percent": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 100
-                  },
-                  "labels": {
-                    "type": "object"
-                  }
-                },
-                "required": [ "percent" ]
+                "type": "object"
+              }
+            },
+            "relabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           }
         },
-        "bgpSessionDown": { "$ref": "#/definitions/prometheusAlert" }
-      }
+        "prometheusRule": {
+          "description": "Prometheus Operator alertmanager alerts",
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "staleConfig": { "$ref": "#/definitions/prometheusAlert" },
+            "configNotLoaded": { "$ref": "#/definitions/prometheusAlert" },
+            "addressPoolExhausted": { "$ref": "#/definitions/prometheusAlert" },
+            "addressPoolUsage": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "thresholds": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "percent": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                      }
+                    },
+                    "required": [ "percent" ]
+                  }
+                }
+              },
+              "required": [ "enabled" ]
+            },
+            "bgpSessionDown": { "$ref": "#/definitions/prometheusAlert" },
+            "extraAlerts": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "required": [
+            "enabled",
+            "staleConfig",
+            "configNotLoaded",
+            "addressPoolExhausted",
+            "addressPoolUsage",
+            "bgpSessionDown"
+          ]
+        }
+      },
+      "required": [ "podMonitor", "prometheusRule" ]
     },
     "controller": { 
       "allOf": [

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -42,7 +42,7 @@ prometheus:
   # can be left at false.
   scrapeAnnotations: false
 
-  # Prometheus Operator service monitors
+  # Prometheus Operator PodMonitors
   podMonitor:
 
     # enable support for Prometheus Operator
@@ -52,7 +52,7 @@ prometheus:
     jobLabel: "app.kubernetes.io/name"
 
     # Scrape interval. If not set, the Prometheus default scrape interval is used.
-    interval: ""
+    interval:
 
     # 	metric relabel configs to apply to samples before ingestion.
     metricRelabelings: []


### PR DESCRIPTION
.Values.prometheus.* underwent several re-writes during chart
development, the values.schema.json for this had fallen behind.

Changes:
* enforce labels are strings for prometheusAlert objects
* validate .Values.prometheus.podMonitor.*
* move PrometheusRule values from .Values.prometheus.* to
  .Values.prometheus.prometheusRule.*
* Clean up comment in values.yaml
* Fix type of .Values.prometheus.podMonitor.interval in values.yaml

Depends on #841 
