### PR TITLE
Fix image publish CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ jobs:
       # double check and exit early if this is a job against a PR.
       - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then circleci-agent step halt; fi
       - setup_remote_docker
-      - run: sudo apt-get update && sudo apt-get install -y python-pip
-      - run: pip install invoke semver pyyaml
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
+      - run: sudo pip3 install invoke semver pyyaml
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool
@@ -67,8 +67,8 @@ jobs:
       # double check and exit early if this is a job against a PR.
       - run: if [ -n "$CIRCLE_PULL_REQUEST" ]; then circleci-agent step halt; fi
       - setup_remote_docker
-      - run: sudo apt-get update && sudo apt-get install -y python-pip
-      - run: pip install invoke semver pyyaml
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
+      - run: sudo pip3 install invoke semver pyyaml
       - run: docker login quay.io -u $QUAY_USER -p $QUAY_PASSWORD
       - run: mkdir -p ./bin
       - run: wget -O ./bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64 && chmod +x ./bin/manifest-tool


### PR DESCRIPTION
The image publish jobs are currently failing due to the `python-pip`
package not being found.  I'm guessing this has to do with a newer
ubuntu version.  The patch updates these jobs to install `python3-pip`
instead, which is what the unit testing and linting jobs already use.