### PR TITLE
Migrate linter from gometalinter to golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,11 @@ jobs:
       - image: cimg/go:1.16
     steps:
       - checkout
-      - run: curl -L https://git.io/vp6lP | sh # gometalinter
-      - run: PATH=./bin:$PATH gometalinter --deadline=5m --disable-all --enable=gofmt --enable=vet --vendor ./...
       - run: sudo apt-get update
       - run: sudo apt-get install python3-pip
       - run: sudo pip3 install invoke semver pyyaml
       - run: inv checkpatch
+      - run: inv lint -e host
   # FIXME: this is pinned to v3.0.0 because subsequent versions of ct pull in new versions of helm, which are subject
   #        to this bug: https://github.com/helm/helm/issues/8835, specifically for rbac object names with ':' in them
   helm-lint:

--- a/.golangci.exclude
+++ b/.golangci.exclude
@@ -1,0 +1,1 @@
+(github.com/go-kit/kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  errcheck:
+    exclude: .golangci.exclude

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -370,18 +370,6 @@ func poolFor(pools map[string]*config.Pool, ip net.IP) string {
 	return ""
 }
 
-func portsEqual(a, b []Port) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // ipConfusesBuggyFirmwares returns true if ip is an IPv4 address ending in 0 or 255.
 //
 // Such addresses can confuse smurf protection on crappy CPE

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,7 @@ type Proto string
 // MetalLB supported protocols.
 const (
 	BGP    Proto = "bgp"
-	Layer2       = "layer2"
+	Layer2 Proto = "layer2"
 )
 
 // Peer is the configuration of a BGP peering session.
@@ -475,12 +475,4 @@ func cidrContainsCIDR(outer, inner *net.IPNet) bool {
 		return true
 	}
 	return false
-}
-
-func isIPv4(ip net.IP) bool {
-	return ip.To16() != nil && ip.To4() != nil
-}
-
-func isIPv6(ip net.IP) bool {
-	return ip.To16() != nil && ip.To4() == nil
 }

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -245,9 +245,12 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	http.Handle("/metrics", promhttp.Handler())
-	go func() {
-		http.ListenAndServe(fmt.Sprintf("%s:%d", cfg.MetricsHost, cfg.MetricsPort), nil)
-	}()
+	go func(l log.Logger) {
+		err := http.ListenAndServe(fmt.Sprintf("%s:%d", cfg.MetricsHost, cfg.MetricsPort), nil)
+		if err != nil {
+			l.Log("op", "listenAndServe", "err", err, "msg", "cannot listen and serve", "host", cfg.MetricsHost, "port", cfg.MetricsPort)
+		}
+	}(c.logger)
 
 	return c, nil
 }

--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -133,8 +133,6 @@ func (a *Announce) updateInterfaces() {
 			a.logger.Log("interface", client.Interface(), "event", "deleteNDPResponder", "msg", "deleted NDP responder for interface")
 		}
 	}
-
-	return
 }
 
 func (a *Announce) spamLoop() {

--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -273,8 +273,6 @@ func (sl *SpeakerList) Rejoin() {
 	default:
 		sl.l.Log("op", "memberDiscovery", "msg", "previous discovery in progress - doing nothing")
 	}
-
-	return
 }
 
 // UsableSpeakers returns a map of usable speaker nodes.

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -21,9 +21,7 @@ func (sl *fakeSpeakerList) UsableSpeakers() map[string]bool {
 	return sl.speakers
 }
 
-func (sl *fakeSpeakerList) Rejoin() {
-	return
-}
+func (sl *fakeSpeakerList) Rejoin() {}
 
 func compareUseableNodesReturnedValue(a, b []string) bool {
 	if &a == &b {

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	stopCh := make(chan struct{})
 	go func() {
-		c1 := make(chan os.Signal)
+		c1 := make(chan os.Signal, 1)
 		signal.Notify(c1, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 		<-c1
 		logger.Log("op", "shutdown", "msg", "starting shutdown")

--- a/tasks.py
+++ b/tasks.py
@@ -519,3 +519,25 @@ def checkpatch(ctx):
     except UnexpectedExit:
         # Will exit non-zero if no double-space-after-period lines are found.
         pass
+
+
+@task(help={
+    "env": "Specify in which environment to run the linter . Default 'container'. Supported: 'container','host'"
+})
+def lint(ctx, env="container"):
+    """Run linter.
+
+    By default, this will run a golangci-lint docker image against the code.
+    However, in some environments (such as the MetalLB CI), it may be more
+    convenient to install the golangci-lint binaries on the host. This can be
+    achieved by running `inv lint --env host`.
+    """
+    version = "1.39.0"
+
+    if env == "container":
+        run("docker run --rm -v $(git rev-parse --show-toplevel):/app -w /app golangci/golangci-lint:v{} golangci-lint run $(git rev-parse --show-toplevel)/...".format(version), echo=True)
+    elif env == "host":
+        run("curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v{}".format(version))
+        run("golangci-lint run --timeout 5m0s $(git rev-parse --show-toplevel)/...")
+    else:
+        raise Exit(message="Unsupported linter environment: {}". format(env))


### PR DESCRIPTION
In the process of adding a linter task to `tasks.py`, I discovered that `gometalinter` has been deprecated. This PR adds that task and migrates the linter.