### PR TITLE
Add kube-ovn to list

### DIFF
--- a/website/content/installation/network-addons.md
+++ b/website/content/installation/network-addons.md
@@ -21,6 +21,7 @@ Calico        | Mostly (see [known issues]({{% relref "configuration/calico.md" 
 Canal         | Yes
 Cilium        | Yes
 Flannel       | Yes
+Kube-ovn      | Yes
 Kube-router   | Mostly (see [known issues]({{% relref "configuration/kube-router.md" %}}))
 Romana        | Yes (see [guide]({{% relref "configuration/romana.md" %}}) for advanced integration)
 Weave Net     | Mostly (see [known issues]({{% relref "configuration/weave.md" %}}))


### PR DESCRIPTION
I've been using [kube-ovn](https://github.com/kubeovn/kube-ovn) with MetalLB in BGP mode for about a year and no issues so far.