### PR TITLE
Store kind logs in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,9 @@ jobs:
       - setup_kind
       - run: inv build
       - run: inv dev-env -p bgp
-      - run: inv e2etest
+      - run: inv e2etest -e /tmp/kind_logs
+      - store_artifacts:
+          path: /tmp/kind_logs
   e2etest-layer2:
     machine:
       image: ubuntu-2004:202104-01
@@ -40,7 +42,9 @@ jobs:
       - setup_kind
       - run: inv build
       - run: inv dev-env -p layer2
-      - run: inv e2etest
+      - run: inv e2etest -e /tmp/kind_logs
+      - store_artifacts:
+          path: /tmp/kind_logs
   lint-1-16:
     docker:
       - image: cimg/go:1.16

--- a/tasks.py
+++ b/tasks.py
@@ -545,8 +545,9 @@ def lint(ctx, env="container"):
 
 @task(help={
     "name": "name of the kind cluster to test.",
+    "export": "where to export kind logs"
 })
-def e2etest(ctx, name="kind"):
+def e2etest(ctx, name="kind", export=None):
     """Run E2E tests against development cluster."""
     validate_kind_version()
     clusters = run("kind get clusters", hide=True).stdout.strip().splitlines()
@@ -569,3 +570,6 @@ def e2etest(ctx, name="kind"):
             "go test --provider=local -ginkgo.focus=BGP --kubeconfig={}".format(kubeconfig.name))
     else:
         print("dev-env environment not configured. Try running `inv dev-env -p <layer2/bgp>`")
+    
+    if export != None:
+        run("kind export logs {}".format(export))


### PR DESCRIPTION
In order to triage CI failures, we store the output of kind export logs to circle CI.