### PR TITLE
e2etest: Display error message when testing unconfigured dev-env

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -567,7 +567,12 @@ def e2etest(ctx, name="kind", export=None):
     for ns in namespaces:
         run("kubectl -n {} wait --for=condition=Ready --all pods --timeout 300s".format(ns), hide=True)
 
-    metallb_config = yaml.load(run("kubectl get configmaps -n metallb-system config -o jsonpath='{.data.config}'", hide=True).stdout)
+    try:
+        metallb_config = yaml.load(run("kubectl get configmaps -n metallb-system config -o jsonpath='{.data.config}'", hide=True).stdout)
+    except UnexpectedExit:
+        print("dev-env environment not configured. Try running `inv dev-env -p <layer2/bgp>`")
+        sys.exit(1)
+
     if metallb_config['address-pools'][0]['name'] == "dev-env-layer2":
         run("cd `git rev-parse --show-toplevel`/e2etest &&"
             "go test --provider=local -ginkgo.focus=L2 --kubeconfig={}".format(kubeconfig.name))
@@ -575,7 +580,7 @@ def e2etest(ctx, name="kind", export=None):
         run("cd `git rev-parse --show-toplevel`/e2etest &&"
             "go test --provider=local -ginkgo.focus=BGP --kubeconfig={}".format(kubeconfig.name))
     else:
-        print("dev-env environment not configured. Try running `inv dev-env -p <layer2/bgp>`")
+        print("dev-env environment not configured correctly. Try running `inv dev-env -p <layer2/bgp>`")
     
     if export != None:
         run("kind export logs {}".format(export))


### PR DESCRIPTION
When trying to run `inv e2etest` against an unconfigured dev-env,
the following message is displayed.

`
Encountered a bad command exit code!

Command: "kubectl get configmaps -n metallb-system config -o jsonpath='{.data.config}'"

Exit code: 1

Stdout:

Stderr:

Error from server (NotFound): configmaps "config" not found
`

This message does not clearly explain the problem. This commit
resolves this by providing a helpful message.

Fixes: 4e9ceccf9f06 ("tasks.py: circle ci does not fail on e2etest failure")
Signed-off-by: Mark Gray <mark.d.gray@redhat.com>