### PR TITLE
Verify if interface master is up before skipping

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -73,7 +74,10 @@ func (a *Announce) updateInterfaces() {
 			continue
 		}
 		if _, err = os.Stat("/sys/class/net/" + ifi.Name + "/master"); !os.IsNotExist(err) {
-			continue
+			masterOperState, err := ioutil.ReadFile("/sys/class/net/" + ifi.Name + "/master/operstate")
+			if err == nil && strings.Contains(string(masterOperState), "up") {
+				continue
+			}
 		}
 		f, err := ioutil.ReadFile("/sys/class/net/" + ifi.Name + "/flags")
 		if err == nil {


### PR DESCRIPTION
In some cases such as wen using Open vSwitch, it is possible that
the interface master will be in down state (ovs-system) but MetalLB
skips the port because it is already assigned a master which means
that no ARP response ever goes through it.

This patch instead makes sure that the master interface is actually
up before skipping it to make sure that we can send traffic across
in one of the interfaces.

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>

Fixed #871 