### PR TITLE
Change e2etest for non kind clusters

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -34,11 +34,17 @@ import (
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 )
 
+// use ephemeral port for pod, instead of well-known port (tcp/80)
+var servicePodPort uint
+var skipDockerCmd bool
+
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+	flag.UintVar(&servicePodPort, "service-pod-port", 80, "port number that pod opens, default: 80")
+	flag.BoolVar(&skipDockerCmd, "skip-docker", false, "et this to true if the BGP daemon is running on the host instead of in a container")
 	flag.Parse()
 }
 

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -54,10 +54,10 @@ var _ = ginkgo.Describe("L2", func() {
 		serviceName := "external-local-lb"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
 
-		svc, err := jig.CreateLoadBalancerService(loadBalancerCreateTimeout, nil)
+		svc, err := jig.CreateLoadBalancerService(loadBalancerCreateTimeout, tweakServicePort())
 		framework.ExpectNoError(err)
 
-		_, err = jig.Run(nil)
+		_, err = jig.Run(tweakRCPort())
 		framework.ExpectNoError(err)
 
 		defer func() {


### PR DESCRIPTION
This change enables to run e2etest in non kind deployments
 - parameterize kubeconfig and system namespace
 - add option to change port of Pod because some distribution cannot open port tcp/80 in pod due to security considerations

This PR is for #884 