### PR TITLE
chart: new additionalLabels for podMonitors and PrometheusRules

### DIFF
--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- if .Values.prometheus.podMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.podMonitor.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ .Values.prometheus.podMonitor.jobLabel | quote }}
   selector:
@@ -37,6 +40,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: speaker
+    {{- if .Values.prometheus.podMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.podMonitor.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ .Values.prometheus.podMonitor.jobLabel | quote }}
   selector:

--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "metallb.fullname" . }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
+    {{- if .Values.prometheus.prometheusRule.additionalLabels }}
+{{ toYaml .Values.prometheus.prometheusRule.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   groups:
   - name: {{ template "metallb.fullname" . }}.rules

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -51,6 +51,9 @@ prometheus:
     # enable support for Prometheus Operator
     enabled: false
 
+    # optional additionnal labels for podMonitors
+    additionalLabels: {}
+
     # Job label for scrape target
     jobLabel: "app.kubernetes.io/name"
 
@@ -77,6 +80,9 @@ prometheus:
 
     # enable alertmanager alerts
     enabled: false
+
+    # optional additionnal labels for prometheusRules
+    additionalLabels: {}
 
     # MetalLBStaleConfig
     staleConfig:


### PR DESCRIPTION
Signed-off-by: Yves Mettier <ymettier@free.fr>

This PR allows to specify additionnal labels on podMonitors and PrometheusRules.

This is needed when you are using Prometheus-Operator and when you configured it to use specific podMonitors and specific PrometheusRules using a specific label.


Important note : I have not bumped the chart version in Chart.yaml (because I don't know when you may merge this PR).