### PR TITLE
Add fsGroup to controller deployment

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -33,9 +33,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "metallb.controller.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
+{{- if .Values.controller.securityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534 # nobody
+{{ toYaml .Values.controller.securityContext | indent 8 }}
+{{- end }}
       containers:
       - name: controller
         image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -138,6 +138,11 @@ controller:
     # true, a name is generated using the fullname template
     name: ""
     annotations: {}
+  securityContext:
+    runAsNonRoot: true
+    # nobody
+    runAsUser: 65534
+    fsGroup: 65534
   resources: {}
     # limits:
       # cpu: 100m

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -439,5 +439,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        fsGroup: 65534
       serviceAccountName: controller
       terminationGracePeriodSeconds: 0

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -16,6 +16,15 @@ Changes in behavior:
 
 Bug Fixes:
 
+## Version 0.10.3
+
+Bug Fixes:
+
+- Add `fsGroup` to the MetalLB controller deployment to address compatibility with Kubernetes 1.21
+  and later. See [Kubernetes issue #70679](https://github.com/kubernetes/kubernetes/issues/70679).
+  This ensures the MetalLB controller can read the service account token volume.
+  ([Issue #890](https://github.com/metallb/metallb/issues/890))
+
 ## Version 0.10.2
 
 Bug Fixes:


### PR DESCRIPTION
Fixes #890
we need to set fsGroup for the controller to read the k8s api token.