### PR TITLE
Add wget retries to both layer2 and bgp e2e tests

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		hostport := net.JoinHostPort(ingressIP, port)
 		address := fmt.Sprintf("http://%s/", hostport)
-		_, err = runCommand(true, "wget", "-O-", "-q", address, "-T", "60")
+		err = wgetRetry(true, address)
 		framework.ExpectNoError(err)
 	})
 

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("L2", func() {
 
 		hostport := net.JoinHostPort(ingressIP, port)
 		address := fmt.Sprintf("http://%s/", hostport)
-		_, err = runCommand(false, "wget", "-O-", "-q", address, "-T", "60")
+		err = wgetRetry(false, address)
 		framework.ExpectNoError(err)
 	})
 

--- a/e2etest/utils.go
+++ b/e2etest/utils.go
@@ -7,6 +7,11 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+const (
+	NetworkFailure = 4
+	retryLimit     = 4
+)
+
 // DescribeSvc logs the output of kubectl describe svc for the given namespace
 func DescribeSvc(ns string) {
 	framework.Logf("\nOutput of kubectl describe svc:\n")
@@ -24,4 +29,27 @@ func runCommand(bgp bool, name string, args ...string) (string, error) {
 	}
 	out, err := exec.Command(name, args...).CombinedOutput()
 	return string(out), err
+}
+
+func wgetRetry(bgp bool, address string) error {
+	retrycnt := 0
+	code := 0
+	var err error
+
+	// Retry loop to handle wget NetworkFailure errors
+	for {
+		_, err = runCommand(bgp, "wget", "-O-", "-q", address, "-T", "60")
+		if exitErr, ok := err.(*exec.ExitError); err != nil && ok {
+			code = exitErr.ExitCode()
+		} else {
+			break
+		}
+		if retrycnt < retryLimit && code == NetworkFailure {
+			framework.Logf(" wget failed with code %d, err %s retrycnt %d\n", code, err, retrycnt)
+			retrycnt++
+		} else {
+			break
+		}
+	}
+	return err
 }


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

Add wget retries (4 attempts) to layer2 and bgp e2e tests, which was mentioned during the review of PR #882 
Unit-Test:

[unit-test-program](https://play.golang.org/p/TJTfphar8g4)