### PR TITLE
charts: Clear version in Chart.yaml in main branch

### DIFF
--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # NOTE: this value is updated by the metallb release process
-version: 0.9.6
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # NOTE: this value is updated by the metallb release process
-appVersion: v0.9.6
+appVersion: v0.0.0


### PR DESCRIPTION
These versions get updated automatically as part of the release process.
This will update release branches and tags, but never in main. To avoid
confusion, just leave the version as 0.0.0 in main, along side the
comment that says this is updated automatically.