### PR TITLE
Make BGP source address configurable

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -29,6 +29,7 @@ type Session struct {
 	routerID         net.IP // May be nil, meaning "derive from context"
 	myNode           string
 	addr             string
+	srcAddr          net.IP
 	peerASN          uint32
 	peerFBASNSupport bool
 	holdTime         time.Duration
@@ -170,7 +171,7 @@ func (s *Session) connect() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	deadline, _ := ctx.Deadline()
-	conn, err := dialMD5(ctx, s.addr, s.password)
+	conn, err := dialMD5(ctx, s.addr, s.srcAddr, s.password)
 	if err != nil {
 		return fmt.Errorf("dial %q: %s", s.addr, err)
 	}
@@ -357,9 +358,10 @@ func (s *Session) sendKeepalive() error {
 //
 // The session will immediately try to connect and synchronize its
 // local state with the peer.
-func New(l log.Logger, addr string, asn uint32, routerID net.IP, peerASN uint32, holdTime time.Duration, password string, myNode string) (*Session, error) {
+func New(l log.Logger, addr string, srcAddr net.IP, asn uint32, routerID net.IP, peerASN uint32, holdTime time.Duration, password string, myNode string) (*Session, error) {
 	ret := &Session{
 		addr:        addr,
+		srcAddr:     srcAddr,
 		asn:         asn,
 		routerID:    routerID.To4(),
 		myNode:      myNode,
@@ -525,8 +527,26 @@ type tcpmd5sig struct {
 // proper TCP MD5 options when the password is not empty. Works by manupulating
 // the low level FD's, skipping the net.Conn API as it has not hooks to set
 // the neccessary sockopts for TCP MD5.
-func dialMD5(ctx context.Context, addr, password string) (net.Conn, error) {
-	laddr, err := net.ResolveTCPAddr("tcp", "[::]:0")
+func dialMD5(ctx context.Context, addr string, srcAddr net.IP, password string) (net.Conn, error) {
+	// If srcAddr exists on any of the local network interfaces, use it as the
+	// source address of the TCP socket. Otherwise, use the IPv6 unspecified
+	// address ("::") to let the kernel figure out the source address.
+	// NOTE: On Linux, "::" also includes "0.0.0.0" (all IPv4 addresses).
+	a := "[::]"
+	if srcAddr != nil {
+		ifs, err := net.Interfaces()
+		if err != nil {
+			return nil, fmt.Errorf("Querying local interfaces: %w", err)
+		}
+
+		if !localAddressExists(ifs, srcAddr) {
+			return nil, fmt.Errorf("Address %q doesn't exist on this host", srcAddr)
+		}
+
+		a = fmt.Sprintf("[%s]", srcAddr.String())
+	}
+
+	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", a))
 	if err != nil {
 		return nil, fmt.Errorf("Error resolving local address: %s ", err)
 	}
@@ -670,4 +690,27 @@ func buildTCPMD5Sig(addr net.IP, key string) tcpmd5sig {
 	copy(t.key[0:], []byte(key))
 
 	return t
+}
+
+// localAddressExists returns true if the address addr exists on any of the
+// network interfaces in the ifs slice.
+func localAddressExists(ifs []net.Interface, addr net.IP) bool {
+	for _, i := range ifs {
+		addresses, err := i.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, a := range addresses {
+			ip, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ip.IP.Equal(addr) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type peer struct {
 	MyASN         uint32         `yaml:"my-asn"`
 	ASN           uint32         `yaml:"peer-asn"`
 	Addr          string         `yaml:"peer-address"`
+	SrcAddr       string         `yaml:"source-address"`
 	Port          uint16         `yaml:"peer-port"`
 	HoldTime      string         `yaml:"hold-time"`
 	RouterID      string         `yaml:"router-id"`
@@ -99,6 +100,8 @@ type Peer struct {
 	ASN uint32
 	// Address to dial when establishing the session.
 	Addr net.IP
+	// Source address to use when establishing the session.
+	SrcAddr net.IP
 	// Port to dial when establishing the session.
 	Port uint16
 	// Requested BGP hold time, per RFC4271.
@@ -278,6 +281,10 @@ func parsePeer(p peer) (*Peer, error) {
 			return nil, fmt.Errorf("invalid router ID %q", p.RouterID)
 		}
 	}
+	src := net.ParseIP(p.SrcAddr)
+	if p.SrcAddr != "" && src == nil {
+		return nil, fmt.Errorf("invalid source IP %q", p.SrcAddr)
+	}
 
 	// We use a non-pointer in the raw json object, so that if the
 	// user doesn't provide a node selector, we end up with an empty,
@@ -303,6 +310,7 @@ func parsePeer(p peer) (*Peer, error) {
 		MyASN:         p.MyASN,
 		ASN:           p.ASN,
 		Addr:          ip,
+		SrcAddr:       src,
 		Port:          port,
 		HoldTime:      holdTime,
 		RouterID:      routerID,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,7 @@ peers:
   peer-port: 1179
   hold-time: 180s
   router-id: 10.20.30.40
+  source-address: 10.20.30.40
 - my-asn: 100
   peer-asn: 200
   peer-address: 2.3.4.5
@@ -98,6 +99,7 @@ address-pools:
 						MyASN:         42,
 						ASN:           142,
 						Addr:          net.ParseIP("1.2.3.4"),
+						SrcAddr:       net.ParseIP("10.20.30.40"),
 						Port:          1179,
 						HoldTime:      180 * time.Second,
 						RouterID:      net.ParseIP("10.20.30.40"),

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -18,6 +18,9 @@ data:
       # (optional) the TCP port to talk to. Defaults to 179, you shouldn't
       # need to set this in production.
       peer-port: 179
+      # (optional) The source IP address to use when establishing the BGP
+      # session. The address must be configured on a local network interface.
+      source-address: 10.0.0.2
       # (optional) The proposed value of the BGP Hold Time timer. Refer to
       # BGP reference material to understand what setting this implies.
       hold-time: 120s

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -191,7 +191,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
+			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.SrcAddr, p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -291,6 +291,6 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+var newBGP = func(logger log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
+	return bgp.New(logger, addr, srcAddr, myASN, routerID, asn, hold, password, myNode)
 }

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -96,7 +96,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ net.IP, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -232,6 +232,48 @@ peers:
       values: [hostA, hostB]
 ```
 
+### Configuring the BGP source address
+
+When a host has multiple network interfaces or multiple IP addresses
+configured on one interface, the host's TCP/IP stack usually selects
+the IP address that is used as the source IP address for outbound
+connections automatically. This is true also for BGP connections.
+
+Sometimes, the automatically-selected address may not be the desired
+one for some reason. In such cases, MetalLB supports explicitly
+specifying the source address to be used when establishing a BGP
+session:
+
+```yaml
+peers:
+- peer-address: 10.0.0.1
+  peer-asn: 64501
+  my-asn: 64500
+  source-address: 10.0.0.2
+  node-selectors:
+  - match-labels:
+      kubernetes.io/hostname: node-1
+```
+
+The configuration above tells the MetalLB speaker to check if the
+address `10.0.0.2` exists locally on one of the host's network
+interfaces, and if so - to use it as the source address when
+establishing BGP sessions. If the address isn't found, the default
+behavior takes place (that is, the kernel selects the source address
+automatically).
+
+{{% notice warning %}}
+In most cases the `source-address` field should only be used with
+**per-node peers**, i.e. peers with node selectors which select only
+one node.
+
+By default, a BGP peer configured under the `peers` configuration
+section runs on **all** speaker nodes. It is likely meaningless to use
+the `source-address` field in a peer configuration that applies to
+more than one node because two nodes in a given network usually
+shouldn't have the same IP address.
+{{% /notice %}}
+
 ## Advanced address pool configuration
 
 ### Controlling automatic address allocation


### PR DESCRIPTION
This is a follow up for #672.

TODO:

- [x] Add docs
- [ ] ~Add tests~

>NOTE: There doesn't seem to be an easy way to test the source address functionality. We would likely need to do some significant refactoring to the tests and possibly to the way we deal with BGP sessions in the code itself.

Fixes #670.