### PR TITLE
chart: fix validation of .Values.imagePullSecrets

### DIFF
--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -127,7 +127,14 @@
       "description": "Secrets used for pulling images",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [ "name" ],
+        "additionalProperties": false
       }
     },
     "nameOverride": {


### PR DESCRIPTION
imagePullSecrets is an array of objects with a single property "name"

Fixed #897