### PR TITLE
adding option to set namespace of the prometheus instance

### DIFF
--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -3,6 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "metallb.fullname" . }}-controller
+  {{- if .Values.prometheus.podMonitor.namespace }}
+  namespace: {{ .Values.prometheus.podMonitor.namespace | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
@@ -37,6 +42,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
+  {{- if .Values.prometheus.podMonitor.namespace }}
+  namespace: {{ .Values.prometheus.podMonitor.namespace | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: speaker

--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -3,6 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "metallb.fullname" . }}
+  {{- if .Values.prometheus.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.prometheusRule.namespace | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     {{- if .Values.prometheus.prometheusRule.additionalLabels }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -51,6 +51,9 @@ prometheus:
     # enable support for Prometheus Operator
     enabled: false
 
+    # option to set namespace of the prometheus instance
+    # namespace: monitoring
+
     # optional additionnal labels for podMonitors
     additionalLabels: {}
 
@@ -80,6 +83,9 @@ prometheus:
 
     # enable alertmanager alerts
     enabled: false
+
+    # option to set namespace of the prometheus instance
+    # namespace: monitoring
 
     # optional additionnal labels for prometheusRules
     additionalLabels: {}


### PR DESCRIPTION
This is a simple to change to just give an option to set the namespace where the rules and monitors will be installed
