### PR TITLE
fix: Specify type for fenced code blocks

### DIFF
--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -146,9 +146,11 @@ are needed. Speakers need those and `-node-name`.
 
 For example:
 
- metallb$ go run ./controller/main.go ./controller/service.go -config-ns metallb-system -kubeconfig $KUBECONFIG
+```bash
+metallb$ go run ./controller/main.go ./controller/service.go -config-ns metallb-system -kubeconfig $KUBECONFIG
 
- metallb$ go run ./speaker/main.go ./speaker/*controller.go -config-ns metallb-system -kubeconfig $KUBECONFIG -node-name node0
+metallb$ go run ./speaker/main.go ./speaker/*controller.go -config-ns metallb-system -kubeconfig $KUBECONFIG -node-name node0
+```
 
 For development, fork
 the [github repository](https://github.com/metallb/metallb), and add

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -19,7 +19,7 @@ you'll have to either resolve them, or bump to the next version.
 MetalLB uses release branches to track releases. Relevant commits should be cherry-picked onto the release branch.
 For example:
 
-```
+```bash
 git checkout v0.9
 git cherry-pick -x f1f86ed658c1e8a6f90f967ed94881d61476b4c0
 git push

--- a/website/content/configuration/romana.md
+++ b/website/content/configuration/romana.md
@@ -63,7 +63,7 @@ in
 set up the route publisher addon. In `publisher.conf`, add a neighbor
 configuration for MetalLB:
 
-```
+```ini
 protocol bgp metallb {
   local as 1234;
   neighbor 127.0.0.1 as 2345;
@@ -219,3 +219,4 @@ graph BT
       romanaA("Romana Route<br>Publisher")-- iBGP -->routerA(BGP Router)
     end
 {{< /mermaid >}}
+

--- a/website/content/configuration/troubleshooting.md
+++ b/website/content/configuration/troubleshooting.md
@@ -26,7 +26,7 @@ In this example, `arping` is used to trigger a request and it should receive a r
 
 The output should look similar to the following:
 
-```
+```bash
 $ arping -I ens3 192.168.1.240
 ARPING 192.168.1.240 from 192.168.1.35 ens3
 Unicast reply from 192.168.1.240 [FA:16:3E:5A:39:4C]  1.077ms
@@ -45,7 +45,7 @@ Received 4 response(s)
 
 Capture all replies from `192.168.1.240`:
 
-```
+```bash
 $ tcpdump -n -i ens3 arp src host 192.168.1.240
 tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
 listening on ens3, link-type EN10MB (Ethernet), capture size 262144 bytes
@@ -63,7 +63,7 @@ listening on ens3, link-type EN10MB (Ethernet), capture size 262144 bytes
 
 In addition to the above, make sure to watch the logs of MetalLB's speaker component for ARP requests and responses (using [kubetail](https://github.com/johanhaleby/kubetail)):
 
-```
+```bash
 $ kubetail -l component=speaker -n metallb-system
 ...
 ```

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -6,7 +6,8 @@ weight: 6
 ## Can I have several address pools?
 
 Yes, for example:
-```
+
+```yaml
 addresses:
 - 192.168.12.0/24
 - 192.168.144.0/20

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -24,7 +24,7 @@ If you're using kube-proxy in IPVS mode, since Kubernetes v1.14.2 you have to en
 
 You can achieve this by editing kube-proxy config in current cluster:
 
-```shell
+```bash
 kubectl edit configmap -n kube-system kube-proxy
 ```
 
@@ -42,7 +42,7 @@ You can also add this configuration snippet to your kubeadm-config, just append 
 
 If you are trying to automate this change, these shell snippets may help you:
 
-```shell
+```bash
 # see what changes would be made, returns nonzero returncode if different
 kubectl get configmap kube-proxy -n kube-system -o yaml | \
 sed -e "s/strictARP: false/strictARP: true/" | \
@@ -58,7 +58,7 @@ kubectl apply -f - -n kube-system
 
 To install MetalLB, apply the manifest:
 
-```shell
+```bash
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/namespace.yaml
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/manifests/metallb.yaml
 ```
@@ -102,7 +102,7 @@ the configMap, as MetalLB is waiting for a configMap named `config`
 (see
 [https://github.com/kubernetes-sigs/kustomize/blob/master/examples/generatorOptions.md](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/generatorOptions.md)):
 
-```
+```yaml
 # kustomization.yml
 namespace: metallb-system
 
@@ -123,17 +123,19 @@ generatorOptions:
 You can install MetallLB with [helm](https://helm.sh/)
 by using the helm chart repository: https://metallb.github.io/metallb
 
-```yaml
+```bash
 helm repo add metallb https://metallb.github.io/metallb
 helm install metallb metallb/metallb
 ```
 
 A values file may be specified on installation. This is recommended for providing configs in helm values:
-```yaml
+
+```bash
 helm install metallb metallb/metallb -f values.yaml
 ```
 
 MetalLB configs are set in values.yaml under `configInLine`:
+
 ```yaml
 configInline:
   address-pools:

--- a/website/content/installation/clouds.md
+++ b/website/content/installation/clouds.md
@@ -78,7 +78,7 @@ Additionally, you have to grant the `speaker` DaemonSet elevated
 privileges, so that it can do the raw networking required to make
 LoadBalancers work. You can do this with:
 
-```shell
+```bash
 oc adm policy add-scc-to-user privileged -n metallb-system -z speaker
 ```
 


### PR DESCRIPTION
Fixed #857

* Use `bash` instead of `shell`.
* Use `ini` on the Romana page. It's fishy, but the
  appearance is OK.
* Add `yaml` to a few and swap a few `yaml` to `bash`.
