### PR TITLE
Enforce commit message style

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+    rules: {
+        // Ensure we have a blank line between the header and the body.
+       'body-leading-blank': [2, 'always'],
+       // Ensure the body ends with a period.
+       'body-full-stop': [2, 'always'],
+       // Ensure we don't have lines longer than 72 chars.
+       'body-max-line-length': [2, 'always', 72],
+       // Ensure the header line doesn't end with a period.
+       'header-full-stop': [2, 'never'],
+    },
+};


### PR DESCRIPTION
This PR enforces some rules around commit message style. I find it useful because I find myself commenting on commit style repeatedly in code reviews and it's easier to let a machine enforce at least some rules.

I've opted for GitHub Actions because it was very tricky to get `commitlint` to work in CircleCI and in Actions it just works :tm: 

A sample result of the new linting job can be seen in the status of this PR.