### PR TITLE
Shared ip

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -137,7 +137,7 @@ func hasHealthyEndpoint(eps k8s.EpsOrSlices, filterNode func(*string) bool) bool
 	return false
 }
 
-func (c *bgpController) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices) string {
+func (c *bgpController) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices, _ net.IP) string {
 	// Should we advertise?
 	// Yes, if externalTrafficPolicy is
 	//  Cluster && any healthy endpoint exists

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -42,45 +42,51 @@ func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
 // The speakers parameter is a map with the node name as key and the readiness
 // status as value (true means ready, false means not ready).
 // If the speakers map is nil, it is ignored.
-func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
+func usableNodes(isTrafficLocal bool, eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 	usable := map[string]bool{}
-	switch eps.Type {
-	case k8s.Eps:
-		for _, subset := range eps.EpVal.Subsets {
-			for _, ep := range subset.Addresses {
-				if ep.NodeName == nil {
-					continue
-				}
-				if speakers != nil {
-					if ready, ok := speakers[*ep.NodeName]; !ok || !ready {
+	if isTrafficLocal {
+		switch eps.Type {
+		case k8s.Eps:
+			for _, subset := range eps.EpVal.Subsets {
+				for _, ep := range subset.Addresses {
+					if ep.NodeName == nil {
 						continue
 					}
+					if speakers != nil {
+						if ready, ok := speakers[*ep.NodeName]; !ok || !ready {
+							continue
+						}
+					}
+					if _, ok := usable[*ep.NodeName]; !ok {
+						usable[*ep.NodeName] = true
+					}
 				}
-				if _, ok := usable[*ep.NodeName]; !ok {
-					usable[*ep.NodeName] = true
+			}
+		case k8s.Slices:
+			for _, slice := range eps.SlicesVal {
+				for _, ep := range slice.Endpoints {
+					if !k8s.IsConditionReady(ep.Conditions) {
+						continue
+					}
+					nodeName := ep.Topology["kubernetes.io/hostname"]
+					if nodeName == "" {
+						continue
+					}
+					if speakers != nil {
+						if ready, ok := speakers[nodeName]; !ok || !ready {
+							continue
+						}
+					}
+					if _, ok := usable[nodeName]; !ok {
+						usable[nodeName] = true
+					}
 				}
 			}
 		}
-	case k8s.Slices:
-		for _, slice := range eps.SlicesVal {
-			for _, ep := range slice.Endpoints {
-				if !k8s.IsConditionReady(ep.Conditions) {
-					continue
-				}
-				nodeName := ep.Topology["kubernetes.io/hostname"]
-				if nodeName == "" {
-					continue
-				}
-				if speakers != nil {
-					if ready, ok := speakers[nodeName]; !ok || !ready {
-						continue
-					}
-				}
-				if _, ok := usable[nodeName]; !ok {
-					usable[nodeName] = true
-				}
-			}
-		}
+
+	} else {
+		// For non traffic local services, all nodes are usable.
+		usable = speakers
 	}
 
 	var ret []string
@@ -93,14 +99,14 @@ func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 	return ret
 }
 
-func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices) string {
-	nodes := usableNodes(eps, c.sList.UsableSpeakers())
-	// Sort the slice by the hash of node + service name. This
-	// produces an ordering of ready nodes that is unique to this
-	// service.
+func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices, lbIP net.IP) string {
+	nodes := usableNodes(svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal, eps, c.sList.UsableSpeakers())
+	// Sort the slice by the hash of node + service IP. This
+	// produces an ordering of ready nodes that is unique to the IP
+	// so that all services sharing the same IP are annonced from the same node.
 	sort.Slice(nodes, func(i, j int) bool {
-		hi := sha256.Sum256([]byte(nodes[i] + "#" + name))
-		hj := sha256.Sum256([]byte(nodes[j] + "#" + name))
+		hi := sha256.Sum256([]byte(nodes[i] + "#" + lbIP.String()))
+		hj := sha256.Sum256([]byte(nodes[j] + "#" + lbIP.String()))
 
 		return bytes.Compare(hi[:], hj[:]) < 0
 	})

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -267,7 +267,7 @@ func (c *controller) SetBalancer(l log.Logger, name string, svc *v1.Service, eps
 		return c.deleteBalancer(l, name, "internalError")
 	}
 
-	if deleteReason := handler.ShouldAnnounce(l, name, svc, eps); deleteReason != "" {
+	if deleteReason := handler.ShouldAnnounce(l, name, svc, eps, lbIP); deleteReason != "" {
 		return c.deleteBalancer(l, name, deleteReason)
 	}
 
@@ -370,7 +370,7 @@ func (c *controller) SetNode(l log.Logger, node *v1.Node) k8s.SyncState {
 // A Protocol can advertise an IP address.
 type Protocol interface {
 	SetConfig(log.Logger, *config.Config) error
-	ShouldAnnounce(log.Logger, string, *v1.Service, k8s.EpsOrSlices) string
+	ShouldAnnounce(log.Logger, string, *v1.Service, k8s.EpsOrSlices, net.IP) string
 	SetBalancer(log.Logger, string, net.IP, *config.Pool) error
 	DeleteBalancer(log.Logger, string, string) error
 	SetNode(log.Logger, *v1.Node) error


### PR DESCRIPTION
This PR implements the changes purposed by @liuyuan10 in https://github.com/metallb/metallb/pull/562 and adapt them for latest version `v0.10.2`
We're using this patch in production for a few month, it works perfectly.

```
When IP is shared by two services, it may be annonced from different
nodes causing conflicting arp responses.

This commit fixes by using service IP in the hash instead of service
name so that service sharing the same IP will have the same master.

For traffic cluster services, all nodes should be usable instead of
those running pods, so that services sharing IPs have the same set of
usable nodes.
```
Fixes #558

docker images prepared:

```
ghcr.io/kvaps/metallb-controller:v0.10.2-fix558
ghcr.io/kvaps/metallb-speaker:v0.10.2-fix558
```