### PR TITLE
Fix typo on website

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -16,7 +16,7 @@ home = ["HTML", "RSS", "JSON"]
 
 [[menu.shortcuts]]
 pre = "<hr>"
-name = "<i class='fa fa-github'></i> Github repo"
+name = "<i class='fa fa-github'></i> GitHub repo"
 url = "https://github.com/metallb/metallb"
 weight = 10
 

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -10,7 +10,7 @@ We would love to hear from you! Here are some places you can find us.
 Our mailing list is
 [metallb-users@googlegroups.com](https://groups.google.com/forum/#!forum/metallb-users). It's
 for discussions around MetalLB usage, community support, and developer
-discussion (although for the latter we mostly use Github directly).
+discussion (although for the latter we mostly use GitHub directly).
 
 ## Slack
 


### PR DESCRIPTION
Github is more accurately referred to as GitHub.