### PR TITLE
Add config flag to disable usage of endpointslices

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -122,13 +122,14 @@ func (c *controller) MarkSynced(l log.Logger) {
 
 func main() {
 	var (
-		port       = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
-		config     = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
-		namespace  = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config / memberlist secret namespace")
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
-		mlSecret   = flag.String("ml-secret-name", os.Getenv("METALLB_ML_SECRET_NAME"), "name of the memberlist secret to create")
-		deployName = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")
-		logLevel   = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", strings.Join(logging.Levels, ", ")))
+		port            = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
+		config          = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+		namespace       = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config / memberlist secret namespace")
+		kubeconfig      = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
+		mlSecret        = flag.String("ml-secret-name", os.Getenv("METALLB_ML_SECRET_NAME"), "name of the memberlist secret to create")
+		deployName      = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")
+		logLevel        = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", strings.Join(logging.Levels, ", ")))
+		disableEpSlices = flag.Bool("disable-epslices", false, "Disable the usage of EndpointSlices and default to Endpoints instead of relying on the autodiscovery mechanism")
 	)
 	flag.Parse()
 
@@ -154,12 +155,13 @@ func main() {
 	}
 
 	client, err := k8s.New(&k8s.Config{
-		ProcessName:   "metallb-controller",
-		ConfigMapName: *config,
-		ConfigMapNS:   *namespace,
-		MetricsPort:   *port,
-		Logger:        logger,
-		Kubeconfig:    *kubeconfig,
+		ProcessName:     "metallb-controller",
+		ConfigMapName:   *config,
+		ConfigMapNS:     *namespace,
+		MetricsPort:     *port,
+		Logger:          logger,
+		Kubeconfig:      *kubeconfig,
+		DisableEpSlices: *disableEpSlices,
 
 		ServiceChanged: c.SetBalancer,
 		ConfigChanged:  c.SetConfig,

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -72,15 +72,16 @@ const (
 // Config specifies the configuration of the Kubernetes
 // client/watcher.
 type Config struct {
-	ProcessName   string
-	ConfigMapName string
-	ConfigMapNS   string
-	NodeName      string
-	MetricsHost   string
-	MetricsPort   int
-	ReadEndpoints bool
-	Logger        log.Logger
-	Kubeconfig    string
+	ProcessName     string
+	ConfigMapName   string
+	ConfigMapNS     string
+	NodeName        string
+	MetricsHost     string
+	MetricsPort     int
+	ReadEndpoints   bool
+	Logger          log.Logger
+	Kubeconfig      string
+	DisableEpSlices bool
 
 	ServiceChanged func(log.Logger, string, *v1.Service, EpsOrSlices) SyncState
 	ConfigChanged  func(log.Logger, *config.Config) SyncState
@@ -164,7 +165,8 @@ func New(cfg *Config) (*Client, error) {
 		c.syncFuncs = append(c.syncFuncs, c.svcInformer.HasSynced)
 
 		if cfg.ReadEndpoints {
-			if !UseEndpointSlices(c.client) {
+			// use DisableEpSlices to skip the autodiscovery mechanism. Useful if EndpointSlices are enabled in the cluster but disabled in kube-proxy
+			if cfg.DisableEpSlices || !UseEndpointSlices(c.client) {
 				epHandlers := cache.ResourceEventHandlerFuncs{
 					AddFunc: func(obj interface{}) {
 						key, err := cache.MetaNamespaceKeyFunc(obj)

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -61,17 +61,18 @@ func main() {
 	prometheus.MustRegister(announcing)
 
 	var (
-		config     = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
-		namespace  = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config file and speakers namespace")
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
-		host       = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
-		mlBindAddr = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
-		mlBindPort = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
-		mlLabels   = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
-		mlSecret   = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
-		myNode     = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
-		port       = flag.Int("port", 7472, "HTTP listening port")
-		logLevel   = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", strings.Join(logging.Levels, ", ")))
+		config          = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+		namespace       = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config file and speakers namespace")
+		kubeconfig      = flag.String("kubeconfig", "", "absolute path to the kubeconfig file (only needed when running outside of k8s)")
+		host            = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
+		mlBindAddr      = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
+		mlBindPort      = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
+		mlLabels        = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
+		mlSecret        = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
+		myNode          = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
+		port            = flag.Int("port", 7472, "HTTP listening port")
+		logLevel        = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", strings.Join(logging.Levels, ", ")))
+		disableEpSlices = flag.Bool("disable-epslices", false, "Disable the usage of EndpointSlices and default to Endpoints instead of relying on the autodiscovery mechanism")
 	)
 	flag.Parse()
 
@@ -125,12 +126,13 @@ func main() {
 	}
 
 	client, err := k8s.New(&k8s.Config{
-		ProcessName:   "metallb-speaker",
-		ConfigMapName: *config,
-		ConfigMapNS:   *namespace,
-		NodeName:      *myNode,
-		Logger:        logger,
-		Kubeconfig:    *kubeconfig,
+		ProcessName:     "metallb-speaker",
+		ConfigMapName:   *config,
+		ConfigMapNS:     *namespace,
+		NodeName:        *myNode,
+		Logger:          logger,
+		Kubeconfig:      *kubeconfig,
+		DisableEpSlices: *disableEpSlices,
 
 		MetricsHost:   *host,
 		MetricsPort:   *port,


### PR DESCRIPTION
As discussed in https://github.com/metallb/metallb/issues/936 there are certain scenarios where endpointslices are technical available but should not be used by metallb.

This PR adds a config flag to disable the usage of endpointslices completely. If the flag is not provided the behaviour is the same as before.