### PR TITLE
Extend the frr enhancement proposal with the list of tests

### DIFF
--- a/design/0001-frr.md
+++ b/design/0001-frr.md
@@ -310,3 +310,60 @@ releases is proposed:
    MetalLB is deprecated from this point onwards. FRR is no longer
    limitied by feature parity with the current native implementation of BGP and
    additional functionality may be developed.
+
+## Test Coverage
+
+The current e2e tests set up a bgp peer to all the nodes inside an FRR container, and try to hit the service.
+
+In order to guarantee parity between the two implementations, the coverage of the e2e tests must be
+extended.
+
+### Test strategy
+
+Every time we test an exposed service, we must verify that:
+
+* the service is reacheable from outside
+* the nodes advertising the service ip are the expected ones
+* all the nodes are paired with the expected bgp peers
+
+#### Changing configuration
+
+Every time the configuration is changed before testing the new scenario, we
+may need to wait an arbitrary time or to run the checks in an eventually loop,
+since there is no feedback of what configuration is being consumed.
+
+Another possible option is to remove the configuration completely and
+verify that hitting the service does not work anymore. This should ensure that
+it's possible to apply a new configuration.
+
+#### Coverage
+
+We must cover the following scenarios:
+
+* Cluster Traffic Policy
+* Local Traffic Policy
+* One Peer
+* Multiple Peers
+* Configuration Change (adding / removing new pools, adding / removing bgp peers)
+* Failover: killing one node and see that we are still able to reach the service
+* Different types of ranges (i.e. /24 CIDRs, /32 ranges)
+
+#### BGP Parameters
+
+We need to ensure that the [BGP parameters](https://github.com/metallb/metallb/blob/9126567db61017c15f732412bd04265a2c4a5031/manifests/example-config.yaml#L1) are correctly
+received by the peer.
+
+The following parameters must be covered:
+
+* node selector
+* source address
+* router-id
+* password (this may require another instance of frr / changing its configuration)
+* communities
+* local preferences
+* aggregation-length
+
+#### Metrics
+
+The current set of metrics must be covered by tests, in order to ensure that the
+new implementation does not regress from that perspective.


### PR DESCRIPTION
Sending this as discussed with @markdgray . 
The enhancement proposal mentions extending the current e2e test suite.
Here, we provide a list of the coverage needed to ensure compatibility between the old implementation and the new implementation.

This is meant to be a starting point for defining the list of our tests. I think it's a good start, and meant to start a discussion to understand if new scenarios need to be added.