### PR TITLE
Add AddressPool validation check for invalid ranges where first address of the range is after the second

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@
 package config // import "go.universe.tf/metallb/internal/config"
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -456,6 +457,10 @@ func parseCIDR(cidr string) ([]*net.IPNet, error) {
 	end := net.ParseIP(strings.TrimSpace(fs[1]))
 	if end == nil {
 		return nil, fmt.Errorf("invalid IP range %q: invalid end IP %q", cidr, fs[1])
+	}
+
+	if bytes.Compare(start, end) >= 0 {
+		return nil, fmt.Errorf("invalid IP range %q: start IP %q is after the end IP %q", cidr, start, end)
 	}
 
 	var ret []*net.IPNet

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -415,6 +415,16 @@ address-pools:
 		},
 
 		{
+			desc: "invalid pool CIDR, first address of the range is after the second",
+			raw: `
+address-pools:
+- name: pool1
+  addresses:
+  - 1.2.3.10-1.2.3.1
+`,
+		},
+
+		{
 			desc: "simple advertisement",
 			raw: `
 address-pools:


### PR DESCRIPTION
An AddressPool where the first address of the range is after the second
should be an invalid range. In such case the LoadBalancer service is
unable to get an IP.

The service is not getting an ip with the following error:
`{"caller":"level.go:63","error":"no available IPs","level":"error","msg":"IP allocation failed","op":"allocateIP","service":"default/nginx","ts":"2021-09-13T08:40:02.487727369Z"}`

```
$ kubectl get service -A
NAMESPACE     NAME         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                  AGE
default       nginx        LoadBalancer   10.96.240.166   <pending>     80:32319/TCP             53s
```