### PR TITLE
Add ipv6 / dual stack lanes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,26 +23,22 @@ jobs:
       - setup_ci_image
       - run: inv test
       - run: cp manifests/metallb.yaml manifests/metallb.yaml.prev
-  e2etest-bgp:
+  e2etest:
+    parameters:
+      ip-family:
+        type: string
+      protocol:
+        type: string
     machine:
       image: ubuntu-2004:202104-01
     steps:
       - setup_ci_image
       - setup_kind
       - run: inv build
-      - run: inv dev-env -p bgp
-      - run: inv e2etest -e /tmp/kind_logs
-      - store_artifacts:
-          path: /tmp/kind_logs
-  e2etest-layer2:
-    machine:
-      image: ubuntu-2004:202104-01
-    steps:
-      - setup_ci_image
-      - setup_kind
-      - run: inv build
-      - run: inv dev-env -p layer2
-      - run: inv e2etest -e /tmp/kind_logs
+      - run: inv dev-env -p << parameters.protocol >> -i  << parameters.ip-family >>
+      - run: |
+          if [ "<< parameters.protocol >>" = "layer2" ]; then FOCUS=L2; else FOCUS=BGP; fi
+          inv e2etest -f $FOCUS -e /tmp/kind_logs
       - store_artifacts:
           path: /tmp/kind_logs
   lint-1-16:
@@ -122,14 +118,17 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - e2etest-bgp:
+      - e2etest:
           filters:
             tags:
               only: /.*/
-      - e2etest-layer2:
-          filters:
-            tags:
-              only: /.*/
+          matrix:
+            parameters:
+              protocol: [layer2, bgp]
+              ip-family: [ipv4, ipv6, dual]
+            exclude:
+              - protocol: bgp
+                ip-family: ipv6
       - publish-images:
           filters:
             branches:

--- a/dev-env/bgp/config.yaml.tmpl
+++ b/dev-env/bgp/config.yaml.tmpl
@@ -16,3 +16,4 @@ data:
       protocol: bgp
       addresses:
       - 192.168.10.0/24
+      - fc00:f853:0ccd:e799::/64

--- a/dev-env/layer2/config.yaml.tmpl
+++ b/dev-env/layer2/config.yaml.tmpl
@@ -10,3 +10,4 @@ data:
       protocol: layer2
       addresses:
       - SERVICE_V4_RANGE
+      - SERVICE_V6_RANGE

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -75,10 +75,10 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		useDocker := true
 		if skipDockerCmd {
-			ginkgo.By("checking connectivity to its external VIP")
+			ginkgo.By(fmt.Sprintf("checking connectivity to %s", address))
 			useDocker = false
 		} else {
-			ginkgo.By("checking connectivity to its external VIP with docker")
+			ginkgo.By(fmt.Sprintf("checking connectivity to %s with docker", address))
 		}
 		err = wgetRetry(useDocker, address)
 		framework.ExpectNoError(err)

--- a/tasks.py
+++ b/tasks.py
@@ -59,7 +59,7 @@ def _docker_build_cmd():
     if cmd:
         out = cmd
     else:
-        out = run("docker buildx ls "
+        out = run("docker buildx ls >/dev/null"
                   "&& echo 'docker buildx build --load' "
                   "|| echo 'docker build'", hide=True).stdout.strip()
     return out

--- a/tasks.py
+++ b/tasks.py
@@ -228,8 +228,6 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None, nod
         }
 
         networking_config = {}
-        if protocol == "layer2":
-            networking_config["podSubnet"] = "10.240.0.0/17"
         if cni:
             networking_config["disableDefaultCNI"] = True
         if ip_family != "ipv4":

--- a/tasks.py
+++ b/tasks.py
@@ -199,9 +199,11 @@ def validate_kind_version():
     "protocol": "Pre-configure MetalLB with the specified protocol. "
                 "Unconfigured by default. Supported: 'bgp','layer2'",
     "node_img": "Optional node image to use for the kind cluster (e.g. kindest/node:v1.18.19)."
-                "The node image drives the kubernetes version used in kind."
+                "The node image drives the kubernetes version used in kind.",
+    "ip_family": "Optional ipfamily of the cluster."
+                 "Default: ipv4, supported families are 'ipv6' and 'dual'."
 })
-def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None, node_img=None):
+def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None, node_img=None, ip_family="ipv4"):
     """Build and run MetalLB in a local Kind cluster.
 
     If the cluster specified by --name (default "kind") doesn't exist,
@@ -224,14 +226,18 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None, nod
                       {"role": "worker"},
             ],
         }
+
+        networking_config = {}
         if protocol == "layer2":
-            config["networking"] = {
-                "podSubnet": "10.240.0.0/17"
-            }
+            networking_config["podSubnet"] = "10.240.0.0/17"
         if cni:
-            config["networking"] = {
-                "disableDefaultCNI": True,
-            }
+            networking_config["disableDefaultCNI"] = True
+        if ip_family != "ipv4":
+            networking_config["ipFamily"] = ip_family
+
+        if len(networking_config) > 0:
+            config["networking"] = networking_config
+
         extra_options = ""
         if node_img != None:
             extra_options = "--image={}".format(node_img)


### PR DESCRIPTION
Here we add an option to specify the ipfamily of the kind cluster, we use it for CI and we adjust the tests / configuration to run against ipv6 only clusters.
