### PR TITLE
Fix PodMonitor rbac

### DIFF
--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -66,4 +66,33 @@ spec:
     relabelings:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.prometheus.serviceAccount }}
+    namespace: {{ .Values.prometheus.namespace }}
 {{- end }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -183,6 +183,8 @@
       "properties": {
         "scrapeAnnotations": { "type": "boolean" },
         "metricsPort": { "type": "integer" },
+        "serviceAccount": { "type": "string" },
+        "namespace": { "type": "string" },
         "podMonitor": {
           "description": "Prometheus Operator PodMonitors",
           "type": "object",

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -45,6 +45,12 @@ prometheus:
   # port both controller and speaker will listen on for metrics
   metricsPort: 7472
 
+  # the service account used by prometheus
+  serviceAccount: prometheus-k8s
+
+  # the namespace where prometheus is deployed
+  namespace: monitoring
+
   # Prometheus Operator PodMonitors
   podMonitor:
 

--- a/manifests/prometheus-operator.yaml
+++ b/manifests/prometheus-operator.yaml
@@ -1,0 +1,58 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-controller
+spec:
+  selector:
+    matchLabels:
+      component: controller
+  namespaceSelector:
+    matchNames:
+      - metallb-system
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-speaker
+spec:
+  selector:
+    matchLabels:
+      component: speaker
+  namespaceSelector:
+    matchNames:
+      - metallb-system
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: metallb-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring


### PR DESCRIPTION
When using metallb in combination with the prometheus operator, we need to grant prometheus permission to read the pods.
Here, we fix that by creating the required role / rolebinding.

On top of that, a new `prometheus-operator.yaml` manifest is created under manifests to allow the same configuration when deploying from manifests.