### PR TITLE
Add bgp metrics tests

### DIFF
--- a/dev-env/bgp/config.yaml.tmpl
+++ b/dev-env/bgp/config.yaml.tmpl
@@ -16,4 +16,4 @@ data:
       protocol: bgp
       addresses:
       - 192.168.10.0/24
-      - fc00:f853:0ccd:e799::/64
+      - fc00:f853:0ccd:e799::/124

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"path"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/pkg/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// MetricsForPod returns the parsed metrics for the given pod, scraping them
+// from the executor pod.
+func ForPod(executor, target *corev1.Pod) (map[string]*dto.MetricFamily, error) {
+	metricsUrl := path.Join(net.JoinHostPort(target.Status.PodIP, "7472"), "metrics")
+	metrics, err := framework.RunKubectl("metallb-system", "exec", executor.Name, "--", "wget", "-qO-", metricsUrl)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to scrape metrics for %s", target.Name)
+	}
+	res, err := metricsFromString(metrics)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// GaugeForLabels retrieves the value of the Gauge matching the given set of labels.
+func GaugeForLabels(metricName string, labels map[string]string, metrics map[string]*dto.MetricFamily) (int, error) {
+	return metricForLabels(metricName, labels, metrics, func(m *dto.Metric) int {
+		return int(m.GetGauge().GetValue())
+	})
+}
+
+// CounterForLabels retrieves the value of the Counter matching the given set of labels.
+func CounterForLabels(metricName string, labels map[string]string, metrics map[string]*dto.MetricFamily) (int, error) {
+	return metricForLabels(metricName, labels, metrics, func(m *dto.Metric) int {
+		return int(m.GetCounter().GetValue())
+	})
+}
+
+func metricForLabels(metricName string, labels map[string]string, metrics map[string]*dto.MetricFamily, getValue func(m *dto.Metric) int) (int, error) {
+	mf, ok := metrics[metricName]
+	if !ok {
+		return 0, fmt.Errorf("metric %s not in metrics", metricName)
+	}
+	mm := mf.GetMetric()
+	for _, m := range mm {
+		toMatch := len(labels)
+		label := m.GetLabel()
+		for _, l := range label {
+			v, ok := labels[l.GetName()]
+			if !ok {
+				continue
+			}
+			if v != l.GetValue() {
+				continue
+			}
+			toMatch--
+		}
+		if toMatch == 0 {
+			return getValue(m), nil
+		}
+	}
+	return 0, fmt.Errorf("label %s not found in metrics for %s", labels, metricName)
+}
+
+func metricsFromString(metrics string) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(strings.NewReader(metrics))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse metrics %s", metrics)
+	}
+	return mf, nil
+}

--- a/e2etest/pkg/metrics/metrics_test.go
+++ b/e2etest/pkg/metrics/metrics_test.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"testing"
+)
+
+const sample = `# HELP metallb_bgp_announced_prefixes_total Number of prefixes currently being advertised on the BGP session
+# TYPE metallb_bgp_announced_prefixes_total gauge
+metallb_bgp_announced_prefixes_total{peer="172.18.0.5:179"} 1
+# HELP metallb_bgp_pending_prefixes_total Number of prefixes that should be advertised on the BGP session
+# TYPE metallb_bgp_pending_prefixes_total gauge
+metallb_bgp_pending_prefixes_total{peer="172.18.0.5:179"} 1
+# HELP metallb_bgp_session_up BGP session state (1 is up, 0 is down)
+# TYPE metallb_bgp_session_up gauge
+metallb_bgp_session_up{peer="172.18.0.5:179"} 1
+# HELP metallb_bgp_updates_total Number of BGP UPDATE messages sent
+# TYPE metallb_bgp_updates_total counter
+metallb_bgp_updates_total{peer="172.18.0.5:179"} 7
+# HELP metallb_k8s_client_config_loaded_bool 1 if the MetalLB configuration was successfully loaded at least once.
+# TYPE metallb_k8s_client_config_loaded_bool gauge
+metallb_k8s_client_config_loaded_bool 1
+# HELP metallb_k8s_client_config_stale_bool 1 if running on a stale configuration, because the latest config failed to load.
+# TYPE metallb_k8s_client_config_stale_bool gauge
+metallb_k8s_client_config_stale_bool 0
+# HELP metallb_k8s_client_update_errors_total Number of k8s object updates that failed for some reason.
+# TYPE metallb_k8s_client_update_errors_total counter
+metallb_k8s_client_update_errors_total 0
+# HELP metallb_k8s_client_updates_total Number of k8s object updates that have been processed.
+# TYPE metallb_k8s_client_updates_total counter
+metallb_k8s_client_updates_total 56
+# HELP metallb_speaker_announced Services being announced from this node. This is desired state, it does not guarantee that the routing protocols have converged.
+# TYPE metallb_speaker_announced gauge
+metallb_speaker_announced{ip="192.168.10.0",node="kind-worker",protocol="bgp",service="bgp-8081/external-local-lb"} 1
+`
+
+func TestParsing(t *testing.T) {
+	m, err := metricsFromString(sample)
+	if err != nil {
+		t.Fail()
+	}
+	updatesTotal, err := CounterForLabels("metallb_bgp_updates_total", map[string]string{"peer": "172.18.0.5:179"}, m)
+	if err != nil {
+		t.Fail()
+	}
+	if updatesTotal != 7 {
+		t.Fatalf("expected value was 7, got %d", updatesTotal)
+	}
+	speakerAnnounced, err := GaugeForLabels("metallb_speaker_announced", map[string]string{
+		"ip":       "192.168.10.0",
+		"node":     "kind-worker",
+		"protocol": "bgp",
+		"service":  "bgp-8081/external-local-lb",
+	}, m)
+	if err != nil {
+		t.Fail()
+	}
+	if speakerAnnounced != 1 {
+		t.Fatalf("expected speakerAnnounced was 1, got %d", speakerAnnounced)
+	}
+	_, err = GaugeForLabels("metallb_speaker_announced", map[string]string{
+		"ip":          "192.168.10.0",
+		"node":        "kind-worker",
+		"protocol":    "bgp",
+		"service":     "bgp-8081/external-local-lb",
+		"unnecessary": "label",
+	}, m)
+	if err == nil {
+		t.Fail()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,10 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/osrg/gobgp v2.0.0+incompatible
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
 	github.com/spf13/viper v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
We extend the e2e tests with one test that validates the presence of the current metrics, create a service and checks the service announcement metrics.

This may require some rework when https://github.com/metallb/metallb/pull/931 lands.