### PR TITLE
chart: add artifacthub-repo.yml

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,16 @@
+   
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: c57909b6-7856-4c74-8336-e0252dbff46c
+owners: # (optional, used to claim repository ownership)
+  - name: Graeme Lawes
+    email: graemelawes@gmail.com


### PR DESCRIPTION
Contains artifacthub.io metadata according to requirements here:
* https://artifacthub.io/docs/topics/repositories/#helm-charts-repositories
* https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml

I've included my own name/email on the owners list.  We should add other maintainers as well.

Fixed #875 