### PR TITLE
gh-pages: Add empty circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.1
+
+# CircleCI reports an error if there's no config in this branch,
+# so we include a noop config.
+
+jobs:
+  noop:
+    docker:
+      - image: cimg/go:1.16
+    steps:
+      - checkout
+      - run: echo "noop"
+
+workflows:
+  version: 2
+  noop-workflow:
+    jobs:
+      - noop:
+          filters:
+            branches:
+              only: branchdoesnotexist
+


### PR DESCRIPTION
Add an empty circleci configuration to this branch to avoid circleci
reporting failures against this branch.