### PR TITLE
commitlint: Allow body lines longer than 72

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,8 +2,9 @@ module.exports = {
     rules: {
         // Ensure we have a blank line between the header and the body.
        'body-leading-blank': [2, 'always'],
-       // Ensure we don't have lines longer than 72 chars.
-       'body-max-line-length': [2, 'always', 72],
+       // Warn on lines longer than 72 chars. We usually don't want them for
+       // text, but links are fine if they exceed. So, just warn.
+       'body-max-line-length': [1, 'always', 72],
        // Ensure the header line doesn't end with a period.
        'header-full-stop': [2, 'never'],
     },


### PR DESCRIPTION
This way, we allow using links in the commit msg.

We will warn if this happens, as a way to not completely remove this
check. If we see that this is usually ignored, we can remove this check
in a future commit.

cc @johananl 

I run into this when creating these PRs:
 https://github.com/metallb/metallb/pull/982#issuecomment-936531399
 https://github.com/metallb/metallb/pull/983

It is super painful not being able to paste links or verbatim errors (like I found on hugo)