### PR TITLE
Add tests for ExternalTrafficPolicy=Local services

### DIFF
--- a/e2etest/pkg/mac/mac.go
+++ b/e2etest/pkg/mac/mac.go
@@ -1,0 +1,98 @@
+package mac
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+	"go.universe.tf/metallb/e2etest/pkg/routes"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ForIP returns the MAC address of a given IP.
+func ForIP(ip string, exec executor.Executor) (net.HardwareAddr, error) {
+	macRe := regexp.MustCompile("([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})")
+
+	res, err := exec.Exec("ip", []string{"neigh", "show", ip}...)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := strings.Split(res, "\n")
+	for _, r := range rows {
+		m := macRe.FindString(r)
+		if m == "" {
+			continue
+		}
+		mac, err := net.ParseMAC(m)
+		if err != nil {
+			return nil, err
+		}
+		return mac, nil
+	}
+
+	return nil, fmt.Errorf("could not resolve MAC for ip %s", ip)
+}
+
+// MatchNode returns the node with the given MAC address.
+func MatchNode(nodes []corev1.Node, mac net.HardwareAddr, exec executor.Executor) (*corev1.Node, error) {
+	res, err := exec.Exec("ip", []string{"neigh", "show"}...)
+	if err != nil {
+		return nil, err
+	}
+
+	nodesIPs := map[string]corev1.Node{}
+	for _, n := range nodes {
+		for _, a := range n.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP {
+				nodesIPs[a.Address] = n
+			}
+		}
+	}
+
+	rows := strings.Split(res, "\n")
+	for _, r := range rows {
+		if !strings.Contains(r, mac.String()) {
+			continue
+		}
+
+		ip := routes.Ipv4Re.FindString(r)
+		if ip == "" {
+			ip = routes.Ipv6Re.FindString(r)
+		}
+
+		if ip == "" {
+			continue
+		}
+
+		netIP := net.ParseIP(ip)
+		if netIP == nil {
+			return nil, fmt.Errorf("failed to convert %s to net.IP", ip)
+		}
+
+		if n, ok := nodesIPs[netIP.String()]; ok {
+			return &n, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no node found for MAC: %s", mac)
+}
+
+// UpdateNodeCache pings all the nodes to update the address resolution cache.
+func UpdateNodeCache(nodes []corev1.Node, exec executor.Executor) error {
+	for _, n := range nodes {
+		for _, a := range n.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP {
+				_, err := exec.Exec("ping", []string{a.Address, "-c", "1"}...)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/e2etest/pkg/routes/routes.go
+++ b/e2etest/pkg/routes/routes.go
@@ -12,13 +12,13 @@ import (
 )
 
 var (
-	ipv4Re *regexp.Regexp
-	ipv6Re *regexp.Regexp
+	Ipv4Re *regexp.Regexp
+	Ipv6Re *regexp.Regexp
 )
 
 func init() {
-	ipv4Re = regexp.MustCompile(`(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|)){4})`)
-	ipv6Re = regexp.MustCompile(`(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))`)
+	Ipv4Re = regexp.MustCompile(`(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|)){4})`)
+	Ipv6Re = regexp.MustCompile(`(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])).`)
 }
 
 // For IP returns the list of routes in the given container
@@ -32,16 +32,24 @@ func ForIP(target string, exec executor.Executor) []net.IP {
 	dst := net.ParseIP(target)
 	framework.ExpectNotEqual(dst, nil, "Failed to convert", target, "to ip")
 
-	re := ipv4Re
+	re := Ipv4Re
 	if dst.To4() == nil { // assuming it's an ipv6 address
-		re = ipv6Re
+		re = Ipv6Re
 	}
 	rows := strings.Split(res, "\n")
+	// The output for a route with a single nexthop looks like: x.x.x.x via x.x.x.x dev x proto bgp metric x
+	// Route with multiple nexthops:
+	/*
+		x.x.x.x proto bgp metric x
+		    nexthop via x.x.x.x dev x weight 1
+		    nexthop via x.x.x.x dev x weight 1
+	*/
 	for _, r := range rows {
-		if !strings.Contains(r, "nexthop via") {
+		if !strings.Contains(r, "via") {
 			continue
 		}
-		ip := re.FindString(r)
+		via := strings.Split(r, "via")[1] // The IP should be after via
+		ip := re.FindString(via)
 		if ip == "" {
 			continue
 		}

--- a/e2etest/utils.go
+++ b/e2etest/utils.go
@@ -46,23 +46,17 @@ func wgetRetry(address string, exc executor.Executor) error {
 	return err
 }
 
-func tweakServicePort() func(svc *v1.Service) {
+func tweakServicePort(svc *v1.Service) {
 	if servicePodPort != 80 {
 		// if servicePodPort is non default, then change service spec.
-		return func(svc *v1.Service) {
-			svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(servicePodPort))
-		}
+		svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(servicePodPort))
 	}
-	return nil
 }
 
-func tweakRCPort() func(rc *v1.ReplicationController) {
+func tweakRCPort(rc *v1.ReplicationController) {
 	if servicePodPort != 80 {
-		return func(rc *v1.ReplicationController) {
-			// if servicePodPort is non default, then change pod's spec
-			rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", servicePodPort), fmt.Sprintf("--udp-port=%d", servicePodPort)}
-			rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(int(servicePodPort))
-		}
+		// if servicePodPort is non default, then change pod's spec
+		rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", servicePodPort), fmt.Sprintf("--udp-port=%d", servicePodPort)}
+		rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(int(servicePodPort))
 	}
-	return nil
 }


### PR DESCRIPTION
Layer2 and BGP both respect ExternalTrafficPolicy=Local, adding e2e tests
that validate that they work as intended.

* L2: As usual only one node can announce the service's IP but it should only route to its local pods.
The test checks that the service is reachable, finds its advertised MAC from the local arp table,
finds who's the node with that MAC = who's the advertising node, hits the service again multiple times
using wget http://svc/hostname and validates that all the pods that responded are on that node.

* BGP: Only the nodes with local endpoints should announce the service's IP.
The test checks that the service is reachable, validates the the external FRR container receives
advertisemnts for that IP only from these nodes and validates that ip route show matches only them.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>