### PR TITLE
Enable merge with parent in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 # -*- mode: yaml -*-
 
 version: 2.1
+orbs:
+  build-tools: circleci/build-tools@3.0.0
 commands:
   setup_ci_image:
     description: "Install dependencies"
     steps:
       - checkout
+      - build-tools/merge-with-parent
       - run: sudo apt-get update
       - run: sudo apt-get install python3-pip
       - run: sudo pip3 install invoke semver pyyaml
@@ -57,6 +60,7 @@ jobs:
       - image: quay.io/helmpack/chart-testing:v3.0.0
     steps:
       - checkout
+      - build-tools/merge-with-parent
       - run: ct lint
   # FIXME: instrumenta/helm-conftest does not yet support helm v3, v2 causes tests to fail.
   #        Switch to it once https://github.com/instrumenta/helm-conftest/pull/8 is merged
@@ -68,6 +72,7 @@ jobs:
       - run: apk add --update --no-cache git curl bash
       - run: helm plugin install --debug https://github.com/instrumenta/helm-conftest
       - checkout
+      - build-tools/merge-with-parent
       - run: helm conftest charts/metallb/ -p charts/metallb/policy/ --fail-on-warn
   publish-images:
     docker:


### PR DESCRIPTION
This tests the PR after a merge against master, instead of using the
content of the PR itself.

From the docs:
Simulate a git merge command against a parent repository, either to
investigate merge conflicts or run integration
testing against the result.
https://circleci.com/developer/orbs/orb/circleci/build-tools#usage-merge-with-parent
