### PR TITLE
Allow running FRR container on host network when running e2e tests 

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -48,6 +48,7 @@ const frrContainer = "frr"
 var (
 	frrContainerIPv4 string
 	frrContainerIPv6 string
+	frrTestConfigDir string
 )
 
 var _ = ginkgo.Describe("BGP", func() {
@@ -58,20 +59,23 @@ var _ = ginkgo.Describe("BGP", func() {
 		cs = f.ClientSet
 
 		var err error
-		// If the FRR container is not running, start it on the local host.
-		if skipDockerCmd {
-			if len(frrTestConfigDir) == 0 {
-				framework.Fail("Missing FRR config directory.")
-			}
-		} else {
-			frrTestConfigDir, err = ioutil.TempDir("", "frr-conf")
-			framework.ExpectNoError(err)
-			err = frr.StartContainer(frrContainer, frrTestConfigDir)
+		frrTestConfigDir, err = ioutil.TempDir("", "frr-conf")
+		framework.ExpectNoError(err)
+		err = frr.StartContainer(frrContainer, frrTestConfigDir, containerNetwork)
+		framework.ExpectNoError(err)
+
+		frrContainerIPv4 = hostIPv4
+		frrContainerIPv6 = hostIPv6
+
+		if containerNetwork != "host" {
+			frrContainerIPv4, frrContainerIPv6, err = frr.GetContainerIPs(frrContainer)
 			framework.ExpectNoError(err)
 		}
 
-		frrContainerIPv4, frrContainerIPv6, err = frr.GetContainerIPs(frrContainer)
-		framework.ExpectNoError(err)
+		// TODO: When adding support for bgp + IPv6 need to validate frrContainerIPv6 as well
+		if net.ParseIP(frrContainerIPv4) == nil {
+			framework.Fail("Invalid frrContainerIPv4")
+		}
 
 		err = frr.UpdateContainerVolumePermissions(frrContainer)
 		framework.ExpectNoError(err)
@@ -82,10 +86,8 @@ var _ = ginkgo.Describe("BGP", func() {
 		err := updateConfigMap(cs, configFile{})
 		framework.ExpectNoError(err)
 
-		if !skipDockerCmd {
-			err = frr.StopContainer(frrContainer, frrTestConfigDir)
-			framework.ExpectNoError(err)
-		}
+		err = frr.StopContainer(frrContainer, frrTestConfigDir)
+		framework.ExpectNoError(err)
 
 		if ginkgo.CurrentGinkgoTestDescription().Failed {
 			DescribeSvc(f.Namespace.Name)
@@ -343,9 +345,6 @@ func pairExternalFRRWithNodes(cs clientset.Interface) {
 	framework.ExpectNoError(err)
 
 	exc := executor.ForContainer(frrContainer)
-	if skipDockerCmd {
-		exc = executor.Host
-	}
 
 	err = frr.UpdateBGPConfigFile(frrTestConfigDir, bgpConfig, exc)
 	framework.ExpectNoError(err)
@@ -355,9 +354,6 @@ func pairExternalFRRWithNodes(cs clientset.Interface) {
 
 func validateFRRPeeredWithNodes(cs clientset.Interface) {
 	exc := executor.ForContainer(frrContainer)
-	if skipDockerCmd {
-		exc = executor.Host
-	}
 
 	allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	framework.ExpectNoError(err)
@@ -386,9 +382,6 @@ func validateService(cs clientset.Interface, svc *corev1.Service, nodes []corev1
 	}
 
 	exc := executor.ForContainer(frrContainer)
-	if skipDockerCmd {
-		exc = executor.Host
-	}
 
 	Eventually(func() error {
 		err := wgetRetry(address, exc)

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -39,7 +39,10 @@ import (
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 )
 
-const defaultTestNameSpace = "metallb-system"
+const (
+	defaultTestNameSpace    = "metallb-system"
+	defaultContainerNetwork = "kind"
+)
 
 var (
 	// Use ephemeral port for pod, instead of well-known port (tcp/80).
@@ -48,7 +51,9 @@ var (
 	ipv4ServiceRange string
 	ipv6ServiceRange string
 	testNameSpace    = defaultTestNameSpace
-	frrTestConfigDir string
+	containerNetwork = defaultContainerNetwork
+	hostIPv4         string
+	hostIPv6         string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -98,8 +103,15 @@ var _ = ginkgo.BeforeSuite(func() {
 		testNameSpace = ns
 	}
 
-	if dir := os.Getenv("FRR_CONFIG_DIR"); len(dir) != 0 {
-		frrTestConfigDir = dir
+	if _, res := os.LookupEnv("RUN_FRR_CONTAINER_ON_HOST_NETWORK"); res == true {
+		containerNetwork = "host"
+	}
+
+	if ip := os.Getenv("PROVISIONING_HOST_EXTERNAL_IPV4"); len(ip) != 0 {
+		hostIPv4 = ip
+	}
+	if ip := os.Getenv("PROVISIONING_HOST_EXTERNAL_IPV6"); len(ip) != 0 {
+		hostIPv6 = ip
 	}
 
 	// Validate the IPv4 service range.

--- a/e2etest/pkg/frr/container.go
+++ b/e2etest/pkg/frr/container.go
@@ -46,7 +46,7 @@ func GetContainerIPs(containerName string) (ipv4 string, ipv6 string, err error)
 	containerIP, err := exec.Command("docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
 		containerName).CombinedOutput()
 	if err != nil {
-		return "", "", errors.Wrapf(err, "Failed to get FRR IP address")
+		return "", "", errors.Wrapf(err, "Failed to get FRR IPv4 address")
 	}
 
 	containerIPv4 := strings.TrimSuffix(string(containerIP), "\n")
@@ -54,10 +54,14 @@ func GetContainerIPs(containerName string) (ipv4 string, ipv6 string, err error)
 	containerIP, err = exec.Command("docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}",
 		containerName).CombinedOutput()
 	if err != nil {
-		return "", "", errors.Wrapf(err, "Failed to get FRR IP address")
+		return "", "", errors.Wrapf(err, "Failed to get FRR IPv6 address")
 	}
 
 	containerIPv6 := strings.TrimSuffix(string(containerIP), "\n")
+
+	if containerIPv4 == "" && containerIPv6 == "" {
+		return "", "", errors.Errorf("Failed to get FRR IP addresses")
+	}
 
 	return containerIPv4, containerIPv6, nil
 }

--- a/e2etest/pkg/frr/container.go
+++ b/e2etest/pkg/frr/container.go
@@ -24,7 +24,7 @@ const (
 )
 
 // Run a BGP router in a container.
-func StartContainer(containerName string, testDirName string) error {
+func StartContainer(containerName string, testDirName string, network string) error {
 	srcFiles := fmt.Sprintf("%s/.", frrConfigDir)
 	res, err := exec.Command("cp", "-r", srcFiles, testDirName).CombinedOutput()
 	if err != nil {
@@ -32,7 +32,7 @@ func StartContainer(containerName string, testDirName string) error {
 	}
 
 	volume := fmt.Sprintf("%s:%s", testDirName, frrMountPath)
-	out, err := exec.Command("docker", "run", "-d", "--privileged", "--network", "kind", "--rm", "--name", containerName,
+	out, err := exec.Command("docker", "run", "-d", "--privileged", "--network", network, "--rm", "--name", containerName,
 		"--volume", volume, frrImage).CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "Failed to start %s container. %s", containerName, out)


### PR DESCRIPTION
We want to be able to run the tests against a real cluster and not only against kind, and to use podman too to run the e2e tests.