### PR TITLE
fix invalid IP range check for exactly one IP

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -459,7 +459,7 @@ func ParseCIDR(cidr string) ([]*net.IPNet, error) {
 		return nil, fmt.Errorf("invalid IP range %q: invalid end IP %q", cidr, fs[1])
 	}
 
-	if bytes.Compare(start, end) >= 0 {
+	if bytes.Compare(start, end) > 0 {
 		return nil, fmt.Errorf("invalid IP range %q: start IP %q is after the end IP %q", cidr, start, end)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,7 @@ address-pools:
   - 40.0.0.0/25
   - 40.0.0.150-40.0.0.200
   - 40.0.0.210 - 40.0.0.240
+  - 40.0.0.250 - 40.0.0.250
 - name: pool4
   protocol: layer2
   addresses:
@@ -162,6 +163,7 @@ address-pools:
 							ipnet("40.0.0.216/29"),
 							ipnet("40.0.0.224/28"),
 							ipnet("40.0.0.240/32"),
+							ipnet("40.0.0.250/32"),
 						},
 						AutoAssign: true,
 					},
@@ -401,6 +403,7 @@ address-pools:
 			raw: `
 address-pools:
 - name: pool1
+  protocol: bgp
   addresses:
   - 100.200.300.400/24
 `,
@@ -411,6 +414,7 @@ address-pools:
 			raw: `
 address-pools:
 - name: pool1
+  protocol: bgp
   addresses:
   - 1.2.3.0/33
 `,
@@ -421,6 +425,7 @@ address-pools:
 			raw: `
 address-pools:
 - name: pool1
+  protocol: bgp
   addresses:
   - 1.2.3.10-1.2.3.1
 `,


### PR DESCRIPTION
Hi, the check introduced in 0.11.0 leads to a problem if you specifiy exactly one IP in your metallb IP pool

`{"caller":"level.go:63","configmap":"metallb-system/metallb","error":"parsing address pool #1: invalid CIDR \"192.168.1.210-192.168.1.210\" in pool \"default\": invalid IP range \"192.168.1.210-192.168.1.210\": start IP \"192.168.1.210\" is after the end IP \"192.168.1.210\"","event":"configStale","level":"error","msg":"config (re)load failed, config marked stale","ts":"2021-10-29T17:54:47.659792734Z"}`