### PR TITLE
Add keepalivetime configuration option to metallb

### DIFF
--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -45,13 +45,14 @@ log stdout debugging
 `
 
 type RouterConfig struct {
-	ASN       uint32
-	Neighbors []*NeighborConfig
-	BGPPort   uint16
-	RouterID  string
-	Password  string
-	HoldTime  string
-	IPFamily  string
+	ASN           uint32
+	Neighbors     []*NeighborConfig
+	BGPPort       uint16
+	RouterID      string
+	Password      string
+	HoldTime      string
+	KeepaliveTime string
+	IPFamily      string
 }
 
 type NeighborConfig struct {

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -44,5 +44,5 @@ type Session interface {
 }
 
 type SessionManager interface {
-	NewSession(logger log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (Session, error)
+	NewSession(logger log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, keepalive time.Duration, password string, myNode string) (Session, error)
 }

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -27,6 +27,7 @@ type session struct {
 	srcAddr        net.IP
 	asn            uint32
 	holdTime       time.Duration
+	keepaliveTime  time.Duration
 	logger         log.Logger
 	password       string
 	advertised     []*bgp.Advertisement
@@ -108,7 +109,7 @@ func (s *session) Close() error {
 //
 // The session will immediately try to connect and synchronize its
 // local state with the peer.
-func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, holdTime time.Duration, password string, myNode string) (bgp.Session, error) {
+func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, holdTime time.Duration, keepaliveTime time.Duration, password string, myNode string) (bgp.Session, error) {
 	s := &session{
 		myASN:          myASN,
 		routerID:       routerID,
@@ -117,6 +118,7 @@ func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, 
 		srcAddr:        srcAddr,
 		asn:            asn,
 		holdTime:       holdTime,
+		keepaliveTime:  keepaliveTime,
 		logger:         log.With(l, "peer", addr, "localASN", myASN, "peerASN", asn),
 		password:       password,
 		advertised:     []*bgp.Advertisement{},
@@ -206,7 +208,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				Addr:           host,
 				Port:           uint16(portUint),
 				HoldTime:       uint64(s.holdTime / time.Second),
-				KeepaliveTime:  uint64(s.holdTime / (3 * time.Second)), // TODO use 1/3 of holdtime till we can configure it.
+				KeepaliveTime:  uint64(s.keepaliveTime / time.Second),
 				Password:       s.password,
 				Advertisements: make([]*advertisementConfig, 0),
 			}

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -82,7 +82,7 @@ func TestSingleSession(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -96,7 +96,7 @@ func TestSingleSessionClose(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -109,12 +109,12 @@ func TestTwoSessions(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, "password", "hostname")
+	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -128,12 +128,12 @@ func TestTwoSessionsDuplicate(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session2, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -147,12 +147,12 @@ func TestTwoSessionsDuplicateRouter(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 400, time.Second, "password", "hostname")
+	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 400, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -166,7 +166,7 @@ func TestSingleAdvertisement(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -195,7 +195,7 @@ func TestSingleAdvertisementNoRouterID(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, nil, 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, nil, 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -224,7 +224,7 @@ func TestSingleAdvertisementInvalidPrefix(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -250,7 +250,7 @@ func TestSingleAdvertisementInvalidNoPort(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err == nil {
 		session.Close()
 		t.Fatalf("Should not be able to create session")
@@ -265,7 +265,7 @@ func TestSingleAdvertisementInvalidNextHop(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -293,7 +293,7 @@ func TestSingleAdvertisementStop(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -327,7 +327,7 @@ func TestSingleAdvertisementChange(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -371,7 +371,7 @@ func TestTwoAdvertisements(t *testing.T) {
 
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager()
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, "password", "hostname")
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalid.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalid.golden
@@ -8,7 +8,7 @@ router bgp 100
   bgp router-id 10.1.1.254
 
   neighbor 10.2.2.254 remote-as 200
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -11,7 +11,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestSingleSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleSession.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 
@@ -32,7 +32,7 @@ router bgp 300
 
   neighbor 10.4.4.254 remote-as 400
   neighbor 10.4.4.254 port 179
-  neighbor 10.4.4.254 timers 0 1
+  neighbor 10.4.4.254 timers 1 1
   neighbor 10.4.4.254 password password
   neighbor 10.4.4.254 update-source 10.3.3.254
 

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -12,7 +12,7 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
 

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -12,12 +12,12 @@ router bgp 100
 
   neighbor 10.2.2.254 remote-as 200
   neighbor 10.2.2.254 port 179
-  neighbor 10.2.2.254 timers 0 1
+  neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
   neighbor 10.4.4.254 remote-as 400
   neighbor 10.4.4.254 port 179
-  neighbor 10.4.4.254 timers 0 1
+  neighbor 10.4.4.254 timers 1 1
   neighbor 10.4.4.254 password password
   neighbor 10.4.4.254 update-source 10.1.1.254
 

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -36,6 +36,7 @@ type session struct {
 	asn              uint32
 	peerFBASNSupport bool
 	holdTime         time.Duration
+	keepaliveTime    time.Duration
 	logger           log.Logger
 	password         string
 
@@ -64,19 +65,20 @@ func NewSessionManager() *sessionManager {
 //
 // The session will immediately try to connect and synchronize its
 // local state with the peer.
-func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, holdTime time.Duration, password string, myNode string) (bgp.Session, error) {
+func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, holdTime time.Duration, keepaliveTime time.Duration, password string, myNode string) (bgp.Session, error) {
 	ret := &session{
-		addr:        addr,
-		srcAddr:     srcAddr,
-		myASN:       myASN,
-		routerID:    routerID.To4(),
-		myNode:      myNode,
-		asn:         asn,
-		holdTime:    holdTime,
-		logger:      log.With(l, "peer", addr, "localASN", myASN, "peerASN", asn),
-		newHoldTime: make(chan bool, 1),
-		advertised:  map[string]*bgp.Advertisement{},
-		password:    password,
+		addr:          addr,
+		srcAddr:       srcAddr,
+		myASN:         myASN,
+		routerID:      routerID.To4(),
+		myNode:        myNode,
+		asn:           asn,
+		holdTime:      holdTime,
+		keepaliveTime: keepaliveTime,
+		logger:        log.With(l, "peer", addr, "localASN", myASN, "peerASN", asn),
+		newHoldTime:   make(chan bool, 1),
+		advertised:    map[string]*bgp.Advertisement{},
+		password:      password,
 	}
 	ret.cond = sync.NewCond(&ret.mu)
 	go ret.sendKeepalives()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,7 @@ address-pools:
 						SrcAddr:       net.ParseIP("10.20.30.40"),
 						Port:          1179,
 						HoldTime:      180 * time.Second,
+						KeepaliveTime: 60 * time.Second,
 						RouterID:      net.ParseIP("10.20.30.40"),
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
@@ -115,6 +116,7 @@ address-pools:
 						Addr:          net.ParseIP("2.3.4.5"),
 						Port:          179,
 						HoldTime:      90 * time.Second,
+						KeepaliveTime: 30 * time.Second,
 						NodeSelectors: []labels.Selector{selector("bar in (quux),foo=bar")},
 					},
 				},
@@ -196,6 +198,7 @@ peers:
 						Addr:          net.ParseIP("1.2.3.4"),
 						Port:          179,
 						HoldTime:      90 * time.Second,
+						KeepaliveTime: 30 * time.Second,
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
@@ -252,7 +255,6 @@ peers:
   hold-time: 1s
 `,
 		},
-
 		{
 			desc: "invalid router ID",
 			raw: `
@@ -280,6 +282,7 @@ peers:
 						Addr:          net.ParseIP("1.2.3.4"),
 						Port:          179,
 						HoldTime:      90 * time.Second,
+						KeepaliveTime: 30 * time.Second,
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -63,6 +63,10 @@ newPeers:
 			if ep == nil {
 				continue
 			}
+			if ep.cfg.KeepaliveTime != 0 && c.bgpType == bgpNative {
+				level.Error(l).Log("op", "setConfig", "peer", ep.cfg.Addr, "configuration ignored", "keep alive time configuration is not supported")
+				continue
+			}
 			if reflect.DeepEqual(p, ep.cfg) {
 				newPeers = append(newPeers, ep)
 				c.peers[i] = nil
@@ -201,7 +205,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := c.sessionManager.NewSession(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.SrcAddr, p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
+			s, err := c.sessionManager.NewSession(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.SrcAddr, p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.KeepaliveTime, p.cfg.Password, c.myNode)
 			if err != nil {
 				level.Error(l).Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -110,7 +110,7 @@ type fakeBGPSessionManager struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGPSessionManager) NewSession(_ log.Logger, addr string, _ net.IP, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (bgp.Session, error) {
+func (f *fakeBGPSessionManager) NewSession(_ log.Logger, addr string, _ net.IP, _ uint32, _ net.IP, _ uint32, _ time.Duration, _ time.Duration, _ string, _ string) (bgp.Session, error) {
 	f.Lock()
 	defer f.Unlock()
 


### PR DESCRIPTION
Added BGP peer keepalivetime configuration option
the current metallb stack assumes its always 1/3 of the holdtime while this the recommended default setting by rfc4271 but it doesn't have to stay like that, this change export the config option so FRR can make use of it while not changing the current
keepalive alg used by Metallb native stack.
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

