### PR TITLE
Run tests with multiple configurable FRR containers

### DIFF
--- a/e2etest/config/frr/daemons
+++ b/e2etest/config/frr/daemons
@@ -38,7 +38,7 @@ vrrpd=no
 #
 vtysh_enable=yes
 zebra_options="  -A 127.0.0.1 -s 90000000"
-bgpd_options="   -A 127.0.0.1"
+bgpd_options="   -A 127.0.0.1 -p {{.BGPPort}}"
 ospfd_options="  -A 127.0.0.1"
 ospf6d_options=" -A ::1"
 ripd_options="   -A 127.0.0.1"

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -40,20 +40,20 @@ import (
 )
 
 const (
-	defaultTestNameSpace    = "metallb-system"
-	defaultContainerNetwork = "kind"
+	defaultTestNameSpace     = "metallb-system"
+	defaultContainersNetwork = "kind"
 )
 
 var (
 	// Use ephemeral port for pod, instead of well-known port (tcp/80).
-	servicePodPort   uint
-	skipDockerCmd    bool
-	ipv4ServiceRange string
-	ipv6ServiceRange string
-	testNameSpace    = defaultTestNameSpace
-	containerNetwork = defaultContainerNetwork
-	hostIPv4         string
-	hostIPv6         string
+	servicePodPort    uint
+	skipDockerCmd     bool
+	ipv4ServiceRange  string
+	ipv6ServiceRange  string
+	testNameSpace     = defaultTestNameSpace
+	containersNetwork = defaultContainersNetwork
+	hostIPv4          string
+	hostIPv6          string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -104,7 +104,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	if _, res := os.LookupEnv("RUN_FRR_CONTAINER_ON_HOST_NETWORK"); res == true {
-		containerNetwork = "host"
+		containersNetwork = "host"
 	}
 
 	if ip := os.Getenv("PROVISIONING_HOST_EXTERNAL_IPV4"); len(ip) != 0 {

--- a/e2etest/pkg/frr/consts/consts.go
+++ b/e2etest/pkg/frr/consts/consts.go
@@ -5,4 +5,6 @@ package consts
 const (
 	// BGPConfigFile contains the BGP router configuration file.
 	BGPConfigFile = "bgpd.conf"
+	// DaemonsConfigFile contains the frr daemons configuration file.
+	DaemonsConfigFile = "daemons"
 )

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/viper v1.8.1 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.2

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -28,6 +28,7 @@ hostname {{.Hostname}}
 
 {{range .Routers -}}
 router bgp {{.MyASN}}
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 {{ if .RouterId }}

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestSingleSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleSession.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 
@@ -19,6 +20,7 @@ router bgp 100
   exit-address-family
 
 router bgp 300
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -3,6 +3,7 @@ log stdout
 hostname dummyhostname
 
 router bgp 100
+  no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
 


### PR DESCRIPTION
Currently the tests run using one external BGP peer.
Running multiple external BGP peers allows us to cover
more scenarios in parallel such as internal/external BGP
and multiple MyASNs. In addition, doing it in a configurable
way will allow us to extend the tests to cover more scenarios
in the future by shuffling configuration for the speaker
and the external containers that serve as BGP peers.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>