### PR TITLE
Fix FRR manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run: |
           SKIP="none"
           if [ "<< parameters.bgp-type >>" = "frr" ]; then SKIP="$SKIP\|metrics"; fi # TODO: enable metrics tests when implementing in FRR
+          if [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|FRR"; fi
           if [ "<< parameters.ip-family >>" = "ipv4" ]; then SKIP="$SKIP\|IPV6"; fi
           if [ "<< parameters.ip-family >>" = "dual" ]; then SKIP="$SKIP\|IPV6"; fi # TODO: until dual stack is supported, we can't run the ipv6 tests against the cluster
           if [ "<< parameters.ip-family >>" = "ipv6" ]; then SKIP="$SKIP\|IPV4\|BGP"; fi # TODO: we are currently skipping BGP for ipv6, re enable when we enable the support

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -149,6 +149,11 @@ var _ = ginkgo.Describe("BGP", func() {
 
 			validateService(cs, svc, epNodes)
 		})
+
+		ginkgo.It("would check that FRR is running in the speaker", func() {
+			paired := frrIsPairedOnPods(cs, frrContainerIPv4)
+			framework.ExpectEqual(paired, true)
+		})
 	})
 
 	ginkgo.Context("metrics", func() {
@@ -418,4 +423,16 @@ func validateService(cs clientset.Interface, svc *corev1.Service, nodes []corev1
 		}
 		return nil
 	}, 2*time.Minute, 1*time.Second).Should(BeNil())
+}
+
+func frrIsPairedOnPods(cs clientset.Interface, neighbor string) bool {
+	pods, err := cs.CoreV1().Pods("metallb-system").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "component=speaker",
+	})
+	framework.ExpectNoError(err)
+	toParse, err := framework.RunKubectl("metallb-system", "exec", pods.Items[0].Name, "-c", "frr", "--", "vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", neighbor))
+	framework.ExpectNoError(err)
+	res, err := frr.NeighborConnected(toParse)
+	framework.ExpectNoError(err)
+	return res
 }

--- a/e2etest/pkg/frr/parse.go
+++ b/e2etest/pkg/frr/parse.go
@@ -139,3 +139,13 @@ func parseRoutes(vtyshRes string) (map[string]Route, error) {
 	}
 	return res, nil
 }
+
+// NeighborConnected tells if the neighbor in the given
+// json format is connected.
+func NeighborConnected(neighborJson string) (bool, error) {
+	n, err := parseNeighbour(neighborJson)
+	if err != nil {
+		return false, err
+	}
+	return n.connected, nil
+}

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -401,31 +401,13 @@ data:
     # or you can use "all_wrap" for all daemons, e.g. to use perf record:
     #   all_wrap="/usr/bin/perf record --call-graph -"
     # the normal daemon command is added to this at the end.
-  vtysh.conf: ""
-  zebra.conf: |+
-    ! -*- zebra -*-
-    !
-    ! zebra sample configuration file
-    !
+  vtysh.conf: |+
+    service integrated-vtysh-config
+  frr.conf: |+
+    frr version 8.0.1
+    frr defaults traditional
     hostname Router
-    password zebra
-    enable password zebra
-    !
-    ! Interface's description.
-    !
-    !interface lo
-    ! description test of desc.
-    !
-    !interface sit0
-    ! multicast
-
-    !
-    ! Static default route sample.
-    !
-    !ip route 0.0.0.0/0 203.181.89.241
-    !
-
-    !log file zebra.log
+    line vty
 
 ---
 apiVersion: apps/v1
@@ -466,7 +448,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: frrouting/frr:v7.5.1
+          image: frrouting/frr:v8.0.1
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -485,7 +467,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: frrouting/frr:v7.5.1
+          image: frrouting/frr:v8.0.1
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -495,7 +477,7 @@ spec:
             - name: frr-conf
               mountPath: /etc/frr
         - name: reloader
-          image: frrouting/frr:v7.5.1
+          image: frrouting/frr:v8.0.1
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -509,6 +491,12 @@ spec:
             - --config=config
             - --log-level=info
           env:
+            - name: FRR_CONFIG_FILE
+              value: /etc/frr_reloader/frr.conf
+            - name: FRR_RELOADER_PID_FILE
+              value: /etc/frr_reloader/reloader.pid
+            - name: METALLB_BGP_TYPE
+              value: frr
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
While fixing comments in https://github.com/metallb/metallb/pull/1014 , I cherry-picked a wrong version of the frr manifest, with the result that CI is running legacy mode even on the CI lanes (this is what we call volkswagen test https://github.com/auchenberg/volkswagen)

Here, we fix the manifest and we add a test (running only on the frr lanes) that validates the FRR container in the pods is actually working.