### PR TITLE
FRR: Don't listen bgp port

### DIFF
--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -361,7 +361,7 @@ data:
     #
     vtysh_enable=yes
     zebra_options="  -A 127.0.0.1 -s 90000000"
-    bgpd_options="   -A 127.0.0.1"
+    bgpd_options="   -A 127.0.0.1 -p 0"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"
     ripd_options="   -A 127.0.0.1"


### PR DESCRIPTION
The native bgp implementation does not listen on a bgp port,
meaning it is always the side initiating the BGP connection.
We should mimic this behavior in FRR mode as it preserves some
of the peer's configuration by using:
https://docs.frrouting.org/en/latest/bgp.html#cmdoption-bgpd-p.
For example peer-port: without this change there is no guarantee
that it is actually used for the connection - the other side might
be initiating it hence the peer's port will be random from the speaker's side (TCP).

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>