### PR TITLE
Add E2E configuration changes tests

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -171,7 +171,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		framework.ExpectNoError(err)
 
 		if setProtocoltest == "ExternalTrafficPolicyCluster" {
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, tweak)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
 
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		}
 
 		if setProtocoltest == "ExternalTrafficPolicyLocal" {
-			svc, jig := createServiceWithBackend(cs, f.Namespace.Name, tweak)
+			svc, jig := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
 			err = jig.Scale(2)
 			framework.ExpectNoError(err)
 
@@ -324,7 +324,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			}
 
 			ginkgo.By("creating a service")
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, testservice.TrafficPolicyCluster) // Is a sleep required here?
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyCluster) // Is a sleep required here?
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
 				framework.ExpectNoError(err)
@@ -407,7 +407,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				validateFRRPeeredWithNodes(cs, c)
 			}
 
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, tweak)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
 
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
@@ -511,7 +511,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				})
 			}
 
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, tweak)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
 				framework.ExpectNoError(err)
@@ -614,14 +614,116 @@ var _ = ginkgo.Describe("BGP", func() {
 				}),
 		)
 	})
+
+	ginkgo.Context("validate configuration changes", func() {
+		table.DescribeTable("should work after subsequent configuration updates", func(addressRange string, ipFamily string) {
+			var services []*corev1.Service
+			var servicesIngressIP []string
+			var pools []addressPool
+
+			for _, c := range frrContainers {
+				c.RouterConfig.IPFamily = ipFamily
+				c.NeighborConfig.IPFamily = ipFamily
+			}
+
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+
+			for i := 0; i < 2; i++ {
+				ginkgo.By(fmt.Sprintf("configure addresspool number %d", i+1))
+				firstIP, err := getIPFromRangeByIndex(addressRange, i*10+1)
+				framework.ExpectNoError(err)
+				lastIP, err := getIPFromRangeByIndex(addressRange, i*10+10)
+				framework.ExpectNoError(err)
+				addressesRange := fmt.Sprintf("%s-%s", firstIP, lastIP)
+				pool := addressPool{
+					Name:     fmt.Sprintf("test-addresspool%d", i+1),
+					Protocol: BGP,
+					Addresses: []string{
+						addressesRange,
+					},
+				}
+				pools = append(pools, pool)
+
+				configData := configFile{
+					Pools: pools,
+					Peers: peersForContainers(frrContainers, ipFamily),
+				}
+
+				for _, c := range frrContainers {
+					pairExternalFRRWithNodes(cs, c)
+				}
+
+				err = updateConfigMap(cs, configData)
+				framework.ExpectNoError(err)
+
+				for _, c := range frrContainers {
+					validateFRRPeeredWithNodes(cs, c)
+				}
+
+				ginkgo.By(fmt.Sprintf("configure service number %d", i+1))
+				svc, _ := createServiceWithBackend(cs, f.Namespace.Name, fmt.Sprintf("svc%d", i+1), testservice.TrafficPolicyCluster, func(svc *corev1.Service) {
+					svc.Annotations = map[string]string{"metallb.universe.tf/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
+				})
+
+				defer func() {
+					err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+					framework.ExpectNoError(err)
+				}()
+
+				ginkgo.By("validate LoadBalancer IP is in the AddressPool range")
+				ingressIP := e2eservice.GetIngressPoint(
+					&svc.Status.LoadBalancer.Ingress[0])
+				err = validateIPInRange([]addressPool{pool}, ingressIP)
+				framework.ExpectNoError(err)
+
+				services = append(services, svc)
+				servicesIngressIP = append(servicesIngressIP, ingressIP)
+
+				for j := 0; j <= i; j++ {
+					ginkgo.By(fmt.Sprintf("validate service %d IP didn't change", j+1))
+					ip := e2eservice.GetIngressPoint(&services[j].Status.LoadBalancer.Ingress[0])
+					framework.ExpectEqual(ip, servicesIngressIP[j])
+
+					ginkgo.By(fmt.Sprintf("checking connectivity of service %d to its external VIP", j+1))
+					for _, c := range frrContainers {
+						validateService(cs, svc, allNodes.Items, c)
+					}
+				}
+			}
+		},
+			table.Entry("IPV4", "192.168.10.0/24", "ipv4"),
+			table.Entry("IPV6", "fc00:f853:0ccd:e799::/116", "ipv6"))
+
+		table.DescribeTable("configure peers one by one and validate FRR paired with nodes", func(ipFamily string) {
+			for i, c := range frrContainers {
+				ginkgo.By("configure peer")
+				c.RouterConfig.IPFamily = ipFamily
+				c.NeighborConfig.IPFamily = ipFamily
+
+				configData := configFile{
+					Peers: peersForContainers([]*frrcontainer.FRR{c}, ipFamily),
+				}
+				err := updateConfigMap(cs, configData)
+				framework.ExpectNoError(err)
+
+				pairExternalFRRWithNodes(cs, c)
+
+				for j := 0; j <= i; j++ {
+					validateFRRPeeredWithNodes(cs, frrContainers[j])
+				}
+			}
+		},
+			table.Entry("IPV4", "ipv4"),
+			table.Entry("IPV6", "ipv6"))
+	})
 })
 
-func createServiceWithBackend(cs clientset.Interface, namespace string, tweak ...func(svc *corev1.Service)) (*corev1.Service, *e2eservice.TestJig) {
+func createServiceWithBackend(cs clientset.Interface, namespace string, jigName string, tweak ...func(svc *corev1.Service)) (*corev1.Service, *e2eservice.TestJig) {
 	var svc *corev1.Service
 	var err error
 
-	serviceName := "external-local-lb"
-	jig := e2eservice.NewTestJig(cs, namespace, serviceName)
+	jig := e2eservice.NewTestJig(cs, namespace, jigName)
 	timeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
 	svc, err = jig.CreateLoadBalancerService(timeout, func(svc *corev1.Service) {
 		tweakServicePort(svc)

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/gomega"
+	pkgerrors "github.com/pkg/errors"
 	"go.universe.tf/metallb/e2etest/pkg/executor"
 	"go.universe.tf/metallb/e2etest/pkg/mac"
 	"go.universe.tf/metallb/e2etest/pkg/metrics"
@@ -214,7 +215,8 @@ var _ = ginkgo.Describe("L2", func() {
 
 		jig1 := e2eservice.NewTestJig(cs, namespace, "svca")
 
-		ip := firstIPFromRange(*ipRange)
+		ip, err := getIPFromRangeByIndex(*ipRange, 0)
+		framework.ExpectNoError(err)
 		svc1, err := jig1.CreateLoadBalancerService(loadBalancerCreateTimeout, func(svc *corev1.Service) {
 			svc.Spec.Ports[0].TargetPort = intstr.FromInt(servicePodPort)
 			svc.Spec.Ports[0].Port = int32(servicePodPort)
@@ -434,13 +436,100 @@ var _ = ginkgo.Describe("L2", func() {
 			table.Entry("IPV4 - Checking service", "ipv4"),
 			table.Entry("IPV6 - Checking service", "ipv6"))
 	})
+
+	table.DescribeTable("validate requesting a specific address pool for Loadbalancer service", func(ipRange *string) {
+		var services []*corev1.Service
+		var servicesIngressIP []string
+		var pools []addressPool
+
+		namspace := f.Namespace.Name
+
+		for i := 0; i < 2; i++ {
+			ginkgo.By(fmt.Sprintf("configure addresspool number %d", i+1))
+			ip, err := getIPFromRangeByIndex(*ipRange, i)
+			framework.ExpectNoError(err)
+			addressesRange := fmt.Sprintf("%s-%s", ip, ip)
+			pool := addressPool{
+				Name:     fmt.Sprintf("test-addresspool%d", i+1),
+				Protocol: Layer2,
+				Addresses: []string{
+					addressesRange,
+				},
+			}
+			pools = append(pools, pool)
+
+			configData := configFile{
+				Pools: pools,
+			}
+			err = updateConfigMap(cs, configData)
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("configure service number %d", i+1))
+			jig := e2eservice.NewTestJig(cs, namspace, fmt.Sprintf("test-service%d", i+1))
+			timeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
+			svc, err := jig.CreateLoadBalancerService(timeout, func(svc *corev1.Service) {
+				tweakServicePort(svc)
+				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+				svc.Annotations = map[string]string{"metallb.universe.tf/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
+			})
+			framework.ExpectNoError(err)
+
+			_, err = jig.Run(func(rc *corev1.ReplicationController) {
+				tweakRCPort(rc)
+			})
+			framework.ExpectNoError(err)
+
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			ginkgo.By("validate LoadBalancer IP is in the AddressPool range")
+			ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
+			err = validateIPInRange([]addressPool{pool}, ingressIP)
+			framework.ExpectNoError(err)
+
+			services = append(services, svc)
+			servicesIngressIP = append(servicesIngressIP, ingressIP)
+
+			for j := 0; j <= i; j++ {
+				ginkgo.By(fmt.Sprintf("validate service %d IP didn't change", j+1))
+				ip := e2eservice.GetIngressPoint(&services[j].Status.LoadBalancer.Ingress[0])
+				framework.ExpectEqual(ip, servicesIngressIP[j])
+
+				ginkgo.By(fmt.Sprintf("checking connectivity of service %d to its external VIP", j+1))
+				port := strconv.Itoa(int(services[j].Spec.Ports[0].Port))
+				hostport := net.JoinHostPort(ip, port)
+				address := fmt.Sprintf("http://%s/", hostport)
+				err = wgetRetry(address, executor.Host)
+				framework.ExpectNoError(err)
+			}
+		}
+	},
+		table.Entry("IPV4", &ipv4ServiceRange),
+		table.Entry("IPV6", &ipv6ServiceRange))
 })
 
-func firstIPFromRange(ipRange string) string {
-	cidr, err := internalconfig.ParseCIDR(ipRange)
-	framework.ExpectNoError(err)
-	c := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr[0])})
-	return c.First().IP.String()
+func getIPFromRangeByIndex(ipRange string, index int) (string, error) {
+	cidrs, err := internalconfig.ParseCIDR(ipRange)
+	if err != nil {
+		return "", pkgerrors.Wrapf(err, "Failed to parse CIDR while getting IP from range by index")
+	}
+
+	i := 0
+	var c *ipaddr.Cursor
+	for _, cidr := range cidrs {
+		c = ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})
+		for i < index && c.Next() != nil {
+			i++
+		}
+		if i == index {
+			return c.Pos().IP.String(), nil
+		}
+		i++
+	}
+
+	return "", fmt.Errorf("failed to get IP in index %d from range %s", index, ipRange)
 }
 
 // Relies on the endpoint being an agnhost netexec pod.

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("L2", func() {
 
 	ginkgo.Context("type=Loadbalancer", func() {
 		ginkgo.It("should work for ExternalTrafficPolicy=Cluster", func() {
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, testservice.TrafficPolicyCluster)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyCluster)
 
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("L2", func() {
 		})
 
 		ginkgo.It("should work for ExternalTrafficPolicy=Local", func() {
-			svc, jig := createServiceWithBackend(cs, f.Namespace.Name, testservice.TrafficPolicyLocal)
+			svc, jig := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyLocal)
 			err := jig.Scale(5)
 			framework.ExpectNoError(err)
 
@@ -149,7 +149,7 @@ var _ = ginkgo.Describe("L2", func() {
 			err := updateConfigMap(cs, configData)
 			framework.ExpectNoError(err)
 
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, testservice.TrafficPolicyCluster)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyCluster)
 
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
@@ -353,7 +353,7 @@ var _ = ginkgo.Describe("L2", func() {
 			}, 2*time.Minute, 1*time.Second).Should(gomega.BeNil())
 
 			ginkgo.By("creating a service")
-			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, testservice.TrafficPolicyCluster)
+			svc, _ := createServiceWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyCluster)
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
 				framework.ExpectNoError(err)


### PR DESCRIPTION
Create two address pools and request a specific address pool for each Loadbalancer service. Validate functionality.

Create two peers and validate each FRR container is paired with the cluster nodes.