### PR TITLE
Set FRR version consistently across the manifests file

### DIFF
--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -404,7 +404,7 @@ data:
   vtysh.conf: |+
     service integrated-vtysh-config
   frr.conf: |+
-    frr version 8.0.1
+    frr version 7.5.1
     frr defaults traditional
     hostname Router
     line vty
@@ -448,7 +448,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: frrouting/frr:v8.0.1
+          image: frrouting/frr:v7.5.1
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup


### PR DESCRIPTION
We should use the same FRR version for all containers that
consume FRR as it is more effective (no need to pull multiple images/...).

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>