### PR TITLE
L2 E2E: Set service port based on service-pod-port flag

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	// Use ephemeral port for pod, instead of well-known port (tcp/80).
-	servicePodPort    uint
+	servicePodPort    int
 	skipDockerCmd     bool
 	ipv4ServiceRange  string
 	ipv6ServiceRange  string
@@ -61,7 +61,7 @@ func handleFlags() {
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
-	flag.UintVar(&servicePodPort, "service-pod-port", 80, "port number that pod opens, default: 80")
+	flag.IntVar(&servicePodPort, "service-pod-port", 80, "port number that pod opens, default: 80")
 	flag.BoolVar(&skipDockerCmd, "skip-docker", false, "set this to true if the BGP daemon is running on the host instead of in a container")
 	flag.StringVar(&ipv4ServiceRange, "ipv4-service-range", "0", "a range of IPv4 addresses for MetalLB to use when running in layer2 mode")
 	flag.StringVar(&ipv6ServiceRange, "ipv6-service-range", "0", "a range of IPv6 addresses for MetalLB to use when running in layer2 mode")

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -219,8 +219,8 @@ var _ = ginkgo.Describe("L2", func() {
 
 		ip := firstIPFromRange(*ipRange)
 		svc1, err := jig1.CreateLoadBalancerService(loadBalancerCreateTimeout, func(svc *corev1.Service) {
-			svc.Spec.Ports[0].TargetPort = intstr.FromInt(82)
-			svc.Spec.Ports[0].Port = 82
+			svc.Spec.Ports[0].TargetPort = intstr.FromInt(servicePodPort)
+			svc.Spec.Ports[0].Port = int32(servicePodPort)
 			svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
 			svc.Spec.LoadBalancerIP = ip
 		})
@@ -229,8 +229,8 @@ var _ = ginkgo.Describe("L2", func() {
 
 		jig2 := e2eservice.NewTestJig(cs, namespace, "svcb")
 		svc2, err := jig2.CreateLoadBalancerService(loadBalancerCreateTimeout, func(svc *corev1.Service) {
-			svc.Spec.Ports[0].TargetPort = intstr.FromInt(83)
-			svc.Spec.Ports[0].Port = 83
+			svc.Spec.Ports[0].TargetPort = intstr.FromInt(servicePodPort + 1)
+			svc.Spec.Ports[0].Port = int32(servicePodPort + 1)
 			svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
 			svc.Spec.LoadBalancerIP = ip
 		})
@@ -246,15 +246,15 @@ var _ = ginkgo.Describe("L2", func() {
 		framework.ExpectNoError(err)
 		_, err = jig1.Run(
 			func(rc *corev1.ReplicationController) {
-				rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", 82), fmt.Sprintf("--udp-port=%d", 82)}
-				rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(82)
+				rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", servicePodPort), fmt.Sprintf("--udp-port=%d", servicePodPort)}
+				rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(servicePodPort)
 				rc.Spec.Template.Spec.NodeName = nodes.Items[0].Name
 			})
 		framework.ExpectNoError(err)
 		_, err = jig2.Run(
 			func(rc *corev1.ReplicationController) {
-				rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", 83), fmt.Sprintf("--udp-port=%d", 83)}
-				rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(83)
+				rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", servicePodPort+1), fmt.Sprintf("--udp-port=%d", servicePodPort+1)}
+				rc.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port = intstr.FromInt(servicePodPort + 1)
 				rc.Spec.Template.Spec.NodeName = nodes.Items[1].Name
 			})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
Currently the ports are hard coded in the test and therefore it is
failing in clusters where this port is not allowed.

Doing this will allow running this test based on the passed base port
by the user, which should be open.
