### PR TITLE
Fix metrics listen and add test coverage for layer2 metrics

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -230,7 +230,8 @@ var _ = ginkgo.Describe("BGP", func() {
 			framework.ExpectNoError(err)
 			speakerPods = make([]*corev1.Pod, 0)
 			for _, item := range speakers.Items {
-				speakerPods = append(speakerPods, &item)
+				i := item
+				speakerPods = append(speakerPods, &i)
 			}
 		})
 

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"go.universe.tf/metallb/internal/config"
@@ -310,7 +311,7 @@ func New(cfg *Config) (*Client, error) {
 
 	http.Handle("/metrics", promhttp.Handler())
 	go func(l log.Logger) {
-		err := http.ListenAndServe(fmt.Sprintf("%s:%d", cfg.MetricsHost, cfg.MetricsPort), nil)
+		err := http.ListenAndServe(net.JoinHostPort(cfg.MetricsHost, fmt.Sprint(cfg.MetricsPort)), nil)
 		if err != nil {
 			level.Error(l).Log("op", "listenAndServe", "err", err, "msg", "cannot listen and serve", "host", cfg.MetricsHost, "port", cfg.MetricsPort)
 		}


### PR DESCRIPTION
The current method did not work properly for IPv6:
```
"err":"listen tcp: address fc00:f853:ccd:e793::4:7472: too many colons in address",
"host":"fc00:f853:ccd:e793::4","level":"error","msg":"cannot listen and serve",
"op":"listenAndServe","port":7472
```
Using net.JoinHostPort to handle both IPv6 and IPv4 solves this.

In addition this PR fixes a small bug in the BGP tests and adds metrics tests for L2.
Having coverage only for BGP metrics caused the CI
to miss the listen bug above +
We should also cover the L2 metrics anyways.