### PR TITLE
E2E: write the config directly instead of using templates

### DIFF
--- a/e2etest/config/frr/bgpd.conf
+++ b/e2etest/config/frr/bgpd.conf
@@ -1,4 +1,0 @@
-hostname bgpd
-password zebra
-{{.BGPConfig}}
-log stdout debugging


### PR DESCRIPTION
Here we render directly the bgpd conf and write it removing one extra jump through templates.
