### PR TITLE
E2E: Dump the frr configuration in case of test failures

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.universe.tf/metallb/e2etest/pkg/executor"
 	"go.universe.tf/metallb/e2etest/pkg/metrics"
 	"go.universe.tf/metallb/e2etest/pkg/routes"
 
@@ -680,7 +681,8 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily str
 		if ipFamily == "ipv6" {
 			address = n.Ipv6
 		}
-		toParse, err := framework.RunKubectl(testNameSpace, "exec", pods.Items[0].Name, "-c", "frr", "--", "vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", address))
+		podExecutor := executor.ForPod(testNameSpace, pods.Items[0].Name, "frr")
+		toParse, err := podExecutor.Exec("vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", address))
 		if err != nil {
 			return err
 		}

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -66,8 +66,8 @@ type containerConfig struct {
 }
 
 var _ = ginkgo.Describe("BGP", func() {
-	f := framework.NewDefaultFramework("bgp")
 	var cs clientset.Interface
+	var f *framework.Framework
 	containersConf := []containerConfig{
 		{
 			name: frrIBGP,
@@ -94,6 +94,36 @@ var _ = ginkgo.Describe("BGP", func() {
 			},
 		},
 	}
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentGinkgoTestDescription().Failed {
+			for _, c := range frrContainers {
+				dump, err := frr.RawDump(c, "/etc/frr/bgpd.conf", "/tmp/frr.log")
+				framework.Logf("External frr dump for %s:\n%s %v", c.Name, dump, err)
+			}
+
+			speakerPods := getSpeakerPods(cs)
+			for _, pod := range speakerPods {
+				podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
+				dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
+				framework.Logf("External frr dump for pod %s\n%s %v", pod.Name, dump, err)
+			}
+			DescribeSvc(f.Namespace.Name)
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Clearing the previous configuration")
+		// Clean previous configuration.
+		err := updateConfigMap(cs, configFile{})
+		framework.ExpectNoError(err)
+
+		err = stopFRRContainers(frrContainers)
+		framework.ExpectNoError(err)
+	})
+
+	f = framework.NewDefaultFramework("bgp")
+
 	ginkgo.BeforeEach(func() {
 		var err error
 		if containersNetwork == "host" {
@@ -107,20 +137,6 @@ var _ = ginkgo.Describe("BGP", func() {
 		cs = f.ClientSet
 		frrContainers, err = createFRRContainers(containersConf)
 		framework.ExpectNoError(err)
-
-	})
-
-	ginkgo.AfterEach(func() {
-		// Clean previous configuration.
-		err := updateConfigMap(cs, configFile{})
-		framework.ExpectNoError(err)
-
-		err = stopFRRContainers(frrContainers)
-		framework.ExpectNoError(err)
-
-		if ginkgo.CurrentGinkgoTestDescription().Failed {
-			DescribeSvc(f.Namespace.Name)
-		}
 	})
 
 	table.DescribeTable("A service of protocol load balancer should work with", func(ipFamily string, setProtocoltest string) {
@@ -209,16 +225,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(len(pods.Items), 1, "More than one controller found")
 			controllerPod = &pods.Items[0]
-
-			speakers, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
-				LabelSelector: "component=speaker",
-			})
-			framework.ExpectNoError(err)
-			speakerPods = make([]*corev1.Pod, 0)
-			for _, item := range speakers.Items {
-				i := item
-				speakerPods = append(speakerPods, &i)
-			}
+			speakerPods = getSpeakerPods(cs)
 		})
 
 		table.DescribeTable("should be exposed by the controller", func(ipFamily string) {
@@ -676,12 +683,13 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily str
 		LabelSelector: "component=speaker",
 	})
 	framework.ExpectNoError(err)
+	podExecutor := executor.ForPod(testNameSpace, pods.Items[0].Name, "frr")
+
 	Eventually(func() error {
 		address := n.Ipv4
 		if ipFamily == "ipv6" {
 			address = n.Ipv6
 		}
-		podExecutor := executor.ForPod(testNameSpace, pods.Items[0].Name, "frr")
 		toParse, err := podExecutor.Exec("vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", address))
 		if err != nil {
 			return err
@@ -773,6 +781,19 @@ func checkBFDConfigPropagated(nodeConfig bfdProfile, peerConfig bgpfrr.BFDPeer) 
 		return fmt.Errorf("EchoInterval: expecting %d, got %d", *nodeConfig.EchoInterval, peerConfig.RemoteEchoInterval)
 	}
 	return nil
+}
+
+func getSpeakerPods(cs clientset.Interface) []*corev1.Pod {
+	speakers, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "component=speaker",
+	})
+	framework.ExpectNoError(err)
+	speakerPods := make([]*corev1.Pod, 0)
+	for _, item := range speakers.Items {
+		i := item
+		speakerPods = append(speakerPods, &i)
+	}
+	return speakerPods
 }
 
 func uint32Ptr(n uint32) *uint32 {

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -75,3 +75,39 @@ func NeighborConnected(neighborJson string) (bool, error) {
 	}
 	return n.Connected, nil
 }
+
+// RawDump dumps all the low level info as a single string.
+// To be used for debugging in order to print the status of the frr instance.
+func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
+	res := "####### Show running config\n"
+	out, err := exec.Exec("vtysh", "-c", "show running-config")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed exec show bgp neighbor %s", res)
+	}
+	res = res + out
+
+	for _, file := range filesToDump {
+		res = res + fmt.Sprintf("####### Dumping file %s\n", file)
+		out, err = exec.Exec("cat", file)
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed to cat %s file %s", file, res)
+		}
+		res = res + out
+	}
+
+	res = res + "####### BGP Neighbors\n"
+	out, err = exec.Exec("vtysh", "-c", "show bgp neighbor")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed exec show bgp neighbor %s", res)
+	}
+	res = res + out
+
+	res = res + "####### BFD Peers\n"
+	out, err = exec.Exec("vtysh", "-c", "show bfd peer")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed exec show bfd peer %s", res)
+	}
+	res = res + out
+
+	return res, nil
+}

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -20,6 +20,9 @@ const bgpConfigTemplate = `
 hostname bgpd
 #password zebra
 
+log file /tmp/frr.log informational
+log timestamp precision 3
+
 route-map RMAP permit 10
 set ipv6 next-hop prefer-global
 router bgp {{.ASN}}

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -18,7 +18,7 @@ import (
 )
 
 // MetricsForPod returns the parsed metrics for the given pod, scraping them
-// from the executor pod.
+// from the source pod.
 func ForPod(source, target *corev1.Pod, namespace string) ([]map[string]*dto.MetricFamily, error) {
 	ports := make([]int, 0)
 	allMetrics := make([]map[string]*dto.MetricFamily, 0)
@@ -30,9 +30,9 @@ func ForPod(source, target *corev1.Pod, namespace string) ([]map[string]*dto.Met
 		}
 	}
 
+	podExecutor := executor.ForPod(namespace, source.Name, source.Spec.Containers[0].Name)
 	for _, p := range ports {
 		metricsUrl := path.Join(net.JoinHostPort(target.Status.PodIP, strconv.Itoa(p)), "metrics")
-		podExecutor := executor.ForPod(namespace, source.Name, source.Spec.Containers[0].Name)
 		metrics, err := podExecutor.Exec("wget", "-qO-", metricsUrl)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to scrape metrics for %s", target.Name)


### PR DESCRIPTION
In order to ease debugging, we dump the state of the external frr container in case of failure.

We also invert the order of beforeEach / afterEach and the framework creation so that our afterEach is registered before the framework's one and the namespace is not deleted when we bump.