### PR TITLE
Export MetallB FRR logging as envvar in FRR manifest

### DIFF
--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -168,8 +168,12 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 
 	config := &frrConfig{
 		Hostname: hostname,
-		Loglevel: "informational", // TODO - make loglevel configurable via envvar.
+		Loglevel: "informational",
 		Routers:  make(map[string]*routerConfig),
+	}
+	frrLogLevel, found := os.LookupEnv("FRR_LOGGING_LEVEL")
+	if found {
+		config.Loglevel = frrLogLevel
 	}
 
 	for _, s := range sm.sessions {

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -497,6 +497,11 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
+            # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
+            # Possible settings are :-
+            #  informational, warning, errors and debugging.
+            - name: FRR_LOGGING_LEVEL
+              value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
user can overwrite the default logging level if needed via envvar settings
