### PR TITLE
Helm chart namespace fixes

### DIFF
--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -71,7 +71,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "metallb.fullname" . }}-prometheus
-  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -86,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}-prometheus
-  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -91,6 +91,6 @@ roleRef:
   name: {{ template "metallb.fullname" . }}-prometheus
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.prometheus.serviceAccount }}
-    namespace: {{ .Values.prometheus.namespace }}
+    name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.serviceAccount }}
+    namespace: {{ required ".Values.prometheus.namespace must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.namespace }}
 {{- end }}

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -49,7 +49,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "metallb.fullname" . }}-config-watcher
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
 rules:
@@ -61,7 +60,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "metallb.fullname" . }}-pod-lister
-  namespace: {{ .Release.Namespace }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
@@ -73,7 +71,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "metallb.fullname" . }}-controller
-  namespace: {{ .Release.Namespace }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
@@ -123,7 +120,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}-config-watcher
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
 subjects:
@@ -140,7 +136,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "metallb.fullname" . }}-pod-lister
-  namespace: {{ .Release.Namespace }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -155,7 +150,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "metallb.fullname" . }}-controller
-  namespace: {{ .Release.Namespace }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -46,10 +46,12 @@ prometheus:
   metricsPort: 7472
 
   # the service account used by prometheus
-  serviceAccount: prometheus-k8s
+  # required when .Values.prometheus.podMonitor.enabled == true
+  serviceAccount: ""
 
   # the namespace where prometheus is deployed
-  namespace: monitoring
+  # required when .Values.prometheus.podMonitor.enabled == true
+  namespace: ""
 
   # Prometheus Operator PodMonitors
   podMonitor:


### PR DESCRIPTION
Addresses namespace issues raised in #1048

1. Remove `.metadata.namespace` from resources, helm should generate thes
2. Remove default values of `.Values.prometheus.serviceAccount` and `.Values.prometheus.namespace`, we should not assume what users default values of these are.  Validate them with the `required` function instead.
```
$ helm lint .
==> Linting .

1 chart(s) linted, 0 chart(s) failed
$ helm lint . --set prometheus.podMonitor.enabled=true
engine.go:167: [INFO] Missing required value: .Values.prometheus.serviceAccount must be defined when .Values.prometheus.podMonitor.enabled == true
engine.go:167: [INFO] Missing required value: .Values.prometheus.namespace must be defined when .Values.prometheus.podMonitor.enabled == true
==> Linting .

1 chart(s) linted, 0 chart(s) failed
$ helm lint . --set prometheus.podMonitor.enabled=true --set prometheus.namespace=monitoring --set prometheus.serviceAccount=kube-prometheus
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```