### PR TITLE
WIP: Add log_level flag to dev-env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - setup_ci_image
       - setup_kind
       - run: inv build
-      - run: inv dev-env -i  << parameters.ip-family >> -b  << parameters.bgp-type >>
+      - run: inv dev-env -i  << parameters.ip-family >> -b  << parameters.bgp-type >> -l all
       - run: |
           SKIP="none"
           if [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|FRR"; fi

--- a/tasks.py
+++ b/tasks.py
@@ -263,10 +263,12 @@ def validate_kind_version():
     "ip_family": "Optional ipfamily of the cluster."
                  "Default: ipv4, supported families are 'ipv6' and 'dual'.",
     "bgp_type": "Type of BGP implementation to use."
-                "Supported: 'native' (default), 'frr'"
+                "Supported: 'native' (default), 'frr'",
+    "log_level": "Log level for the controller and the speaker."
+                "Default: info, Supported: 'all', 'debug', 'info', 'warn', 'error' or 'none'"
 })
 def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None,
-        node_img=None, ip_family="ipv4", bgp_type="native"):
+        node_img=None, ip_family="ipv4", bgp_type="native", log_level="info"):
     """Build and run MetalLB in a local Kind cluster.
 
     If the cluster specified by --name (default "kind") doesn't exist,
@@ -331,6 +333,7 @@ def dev_env(ctx, architecture="amd64", name="kind", cni=None, protocol=None,
         for image in binaries:
             manifest = re.sub("image: quay.io/metallb/{}:.*".format(image),
                           "image: quay.io/metallb/{}:dev-{}".format(image, architecture), manifest)
+            manifest = re.sub("--log-level=info", "--log-level={}".format(log_level), manifest)
         with open(tmpdir + "/metallb.yaml", "w") as f:
             f.write(manifest)
             f.flush()


### PR DESCRIPTION
Adding an option to set the log level for both the
speaker and the controller.
Setting the `all` level for CI should help us with debugging
failed tests.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>