### PR TITLE
Fix e2etests to use the namespace variable

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -217,14 +217,14 @@ var _ = ginkgo.Describe("BGP", func() {
 		var speakerPods []*corev1.Pod
 
 		ginkgo.BeforeEach(func() {
-			pods, err := cs.CoreV1().Pods("metallb-system").List(context.Background(), metav1.ListOptions{
+			pods, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: "component=controller",
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(len(pods.Items), 1, "More than one controller found")
 			controllerPod = &pods.Items[0]
 
-			speakers, err := cs.CoreV1().Pods("metallb-system").List(context.Background(), metav1.ListOptions{
+			speakers, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: "component=speaker",
 			})
 			framework.ExpectNoError(err)
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 			ginkgo.By("checking the metrics when no service is added")
 			Eventually(func() error {
-				controllerMetrics, err := metrics.ForPod(controllerPod, controllerPod)
+				controllerMetrics, err := metrics.ForPod(controllerPod, controllerPod, testNameSpace)
 				if err != nil {
 					return err
 				}
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				ginkgo.By(fmt.Sprintf("checking speaker %s", speaker.Name))
 
 				Eventually(func() error {
-					speakerMetrics, err := metrics.ForPod(controllerPod, speaker)
+					speakerMetrics, err := metrics.ForPod(controllerPod, speaker, testNameSpace)
 					if err != nil {
 						return err
 					}
@@ -332,7 +332,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 			ginkgo.By("checking the metrics when a service is added")
 			Eventually(func() error {
-				controllerMetrics, err := metrics.ForPod(controllerPod, controllerPod)
+				controllerMetrics, err := metrics.ForPod(controllerPod, controllerPod, testNameSpace)
 				if err != nil {
 					return err
 				}
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				ginkgo.By(fmt.Sprintf("checking speaker %s", speaker.Name))
 
 				Eventually(func() error {
-					speakerMetrics, err := metrics.ForPod(controllerPod, speaker)
+					speakerMetrics, err := metrics.ForPod(controllerPod, speaker, testNameSpace)
 					if err != nil {
 						return err
 					}
@@ -590,7 +590,7 @@ func validateService(cs clientset.Interface, svc *corev1.Service, nodes []corev1
 }
 
 func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily string) {
-	pods, err := cs.CoreV1().Pods("metallb-system").List(context.Background(), metav1.ListOptions{
+	pods, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "component=speaker",
 	})
 	framework.ExpectNoError(err)
@@ -599,7 +599,7 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily str
 		if ipFamily == "ipv6" {
 			address = n.Ipv6
 		}
-		toParse, err := framework.RunKubectl("metallb-system", "exec", pods.Items[0].Name, "-c", "frr", "--", "vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", address))
+		toParse, err := framework.RunKubectl(testNameSpace, "exec", pods.Items[0].Name, "-c", "frr", "--", "vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", address))
 		if err != nil {
 			return err
 		}

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -19,7 +19,7 @@ import (
 
 // MetricsForPod returns the parsed metrics for the given pod, scraping them
 // from the executor pod.
-func ForPod(executor, target *corev1.Pod) ([]map[string]*dto.MetricFamily, error) {
+func ForPod(executor, target *corev1.Pod, namespace string) ([]map[string]*dto.MetricFamily, error) {
 	ports := make([]int, 0)
 	allMetrics := make([]map[string]*dto.MetricFamily, 0)
 	for _, c := range target.Spec.Containers {
@@ -32,7 +32,7 @@ func ForPod(executor, target *corev1.Pod) ([]map[string]*dto.MetricFamily, error
 
 	for _, p := range ports {
 		metricsUrl := path.Join(net.JoinHostPort(target.Status.PodIP, strconv.Itoa(p)), "metrics")
-		metrics, err := framework.RunKubectl("metallb-system", "exec", executor.Name, "--", "wget", "-qO-", metricsUrl)
+		metrics, err := framework.RunKubectl(namespace, "exec", executor.Name, "--", "wget", "-qO-", metricsUrl)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to scrape metrics for %s", target.Name)
 		}


### PR DESCRIPTION
We should use the testNameSpace variable all over the tests code to run the tests in the right namesapce.
