### PR TITLE
Fix L2 metrics tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
     steps:
       - checkout
       - run: sudo apt-get update
-      - run: sudo apt-get install python3-pip
+      - run: sudo apt-get install python3-pip arping ndisc6
       - run: sudo pip3 install invoke semver pyyaml
   setup_kind:
     description: "Install kind"
@@ -44,7 +44,9 @@ jobs:
           if [ "<< parameters.ip-family >>" = "ipv6" ]; then SKIP="$SKIP\|IPV4"; fi
           if [ "<< parameters.ip-family >>" = "ipv6" ] && [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|BGP"; fi # we are skipping BGP for ipv6 for native bgp stack
           echo "Skipping $SKIP"
-          inv e2etest --skip $SKIP -e /tmp/kind_logs
+          # `-E env "PATH=$PATH"` bypasses commands not found under sudo, `sudo` needed because arping requires CAP_NET_RAW
+          sudo -E env "PATH=$PATH" inv e2etest --skip $SKIP -e /tmp/kind_logs
+      - run: sudo chmod -R o+r /tmp/kind_logs # logs are exported under root (sudo), chmod required to upload the artifacts.
       - store_artifacts:
           path: /tmp/kind_logs
   lint-1-16:


### PR DESCRIPTION
Getting a lot of flakes in the CI:
```
      Expected
          <*errors.errorString | 0xc000695790>: {
              s: "metric metallb_layer2_requests_received not found",
          }
      to be nil
```
It is caused by the fact that this metric represents the amount
of ARP/NS that arrived to the speaker for the svc's ip, while the
test doesn't necessarily does one. That can happen because the speaker
sends a gratuitous message when he announces an IP.

Also added a check for the gratuitous_sent metric to cover that.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>