### PR TITLE
E2E: throw vtysh command errors in the eventually loop

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -645,7 +645,9 @@ func validateFRRPeeredWithNodes(cs clientset.Interface, c *frrcontainer.FRR) {
 	ginkgo.By(fmt.Sprintf("checking all nodes are peered with the frr instance %s", c.Name))
 	Eventually(func() error {
 		neighbors, err := frr.NeighborsInfo(c)
-		framework.ExpectNoError(err)
+		if err != nil {
+			return err
+		}
 		err = frr.NeighborsMatchNodes(allNodes.Items, neighbors)
 		return err
 	}, 4*time.Minute, 1*time.Second).Should(BeNil())


### PR DESCRIPTION
We start the external container and start sending commands.
There was one flake where bgpd was not ready yet, and in that case we fail on the error. Here we return the error and handle it in the eventually loop, so if it is transient the test will pass.