### PR TITLE
Refactor Metallb svc controller and speaker to support dual-stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           SKIP="none"
           if [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|FRR\|BFD\|DUALSTACK"; fi
           if [ "<< parameters.ip-family >>" = "ipv4" ]; then SKIP="$SKIP\|IPV6\|DUALSTACK"; fi
-          if [ "<< parameters.ip-family >>" = "dual" ]; then SKIP="$SKIP\|IPV6\|DUALSTACK"; fi # TODO: until DUALSTACK stack is supported, we can't run the ipv6 / dual stack tests against the cluster
+          if [ "<< parameters.ip-family >>" = "dual" ]; then SKIP="$SKIP\|IPV6"; fi
           if [ "<< parameters.ip-family >>" = "ipv6" ]; then SKIP="$SKIP\|IPV4\|DUALSTACK"; fi
           if [ "<< parameters.ip-family >>" = "ipv6" ] && [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|BGP"; fi # we are skipping BGP for ipv6 for native bgp stack
           echo "Skipping $SKIP"

--- a/controller/service.go
+++ b/controller/service.go
@@ -23,11 +23,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"go.universe.tf/metallb/internal/allocator/k8salloc"
+	"go.universe.tf/metallb/internal/ipfamily"
+)
+
+const (
+	annotationAddressPool = "metallb.universe.tf/address-pool"
 )
 
 func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service) bool {
-	var lbIP net.IP
-
+	lbIPs := []net.IP{}
+	var err error
 	// Not a LoadBalancer, early exit. It might have been a balancer
 	// in the past, so we still need to clear LB state.
 	if svc.Spec.Type != "LoadBalancer" {
@@ -38,85 +43,106 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		return true
 	}
 
-	// If the ClusterIP is malformed or not set we can't determine the
+	// If the ClusterIPs is malformed or not set we can't determine the
 	// ipFamily to use.
-	clusterIP := net.ParseIP(svc.Spec.ClusterIP)
-	if clusterIP == nil {
-		level.Info(l).Log("event", "clearAssignment", "reason", "noClusterIP", "msg", "No ClusterIP")
+	if len(svc.Spec.ClusterIPs) == 0 {
+		level.Info(l).Log("event", "clearAssignment", "reason", "noClusterIPs", "msg", "No ClusterIPs")
 		c.clearServiceState(key, svc)
 		return true
 	}
 
-	// The assigned LB IP is the end state of convergence. If there's
+	// The assigned LB IP(s) is the end state of convergence. If there's
 	// none or a malformed one, nuke all controlled state so that we
 	// start converging from a clean slate.
-	if len(svc.Status.LoadBalancer.Ingress) == 1 {
-		lbIP = net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
-	}
-	if lbIP == nil {
-		c.clearServiceState(key, svc)
+	for i := range svc.Status.LoadBalancer.Ingress {
+		ip := svc.Status.LoadBalancer.Ingress[i].IP
+		if len(ip) != 0 {
+			lbIPs = append(lbIPs, net.ParseIP(ip))
+		}
 	}
 
-	// Clear the lbIP if it has a different ipFamily compared to the clusterIP.
-	// (this should not happen since the "ipFamily" of a service is immutable)
-	if (clusterIP.To4() == nil) != (lbIP.To4() == nil) {
+	lbIPsIPFamily := ipfamily.Unknown
+	if len(lbIPs) == 0 {
 		c.clearServiceState(key, svc)
-		lbIP = nil
+	} else {
+		lbIPsIPFamily, err = ipfamily.ForAddressesIPs(lbIPs)
+		if err != nil {
+			level.Error(l).Log("event", "clearAssignment", "reason", "nolbIPsIPFamily", "msg", "Failed to retrieve lbIPs family")
+			c.client.Errorf(svc, "nolbIPsIPFamily", "Failed to retrieve LBIPs IPFamily for %q: %s", lbIPs, err)
+			return true
+		}
+		clusterIPsIPFamily, err := ipfamily.ForAddresses(svc.Spec.ClusterIPs)
+		if err != nil {
+			level.Error(l).Log("event", "clearAssignment", "reason", "noclusterIPsIPFamily", "msg", "Failed to retrieve clusterIPs family")
+			c.client.Errorf(svc, "noclusterIPsIPFamily", "Failed to retrieve ClusterIPs IPFamily for %q: %s", svc.Spec.ClusterIPs, err)
+			return true
+		}
+		// Clear the lbIP if it has a different ipFamily compared to the clusterIP.
+		// (this should not happen since the "ipFamily" of a service is immutable)
+		if lbIPsIPFamily != clusterIPsIPFamily {
+			c.clearServiceState(key, svc)
+			lbIPs = []net.IP{}
+		}
 	}
 
 	// It's possible the config mutated and the IP we have no longer
 	// makes sense. If so, clear it out and give the rest of the logic
 	// a chance to allocate again.
-	if lbIP != nil {
+	if len(lbIPs) != 0 {
 		// This assign is idempotent if the config is consistent,
 		// otherwise it'll fail and tell us why.
-		if err := c.ips.Assign(key, lbIP, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
-			level.Info(l).Log("event", "clearAssignment", "reason", "notAllowedByConfig", "msg", "current IP not allowed by config, clearing")
+		if err = c.ips.Assign(key, lbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+			level.Info(l).Log("event", "clearAssignment", "error", err, "msg", "current IP not allowed by config, clearing")
 			c.clearServiceState(key, svc)
-			lbIP = nil
+			lbIPs = []net.IP{}
 		}
 
 		// The user might also have changed the pool annotation, and
 		// requested a different pool than the one that is currently
 		// allocated.
-		desiredPool := svc.Annotations["metallb.universe.tf/address-pool"]
-		if lbIP != nil && desiredPool != "" && c.ips.Pool(key) != desiredPool {
+		desiredPool := svc.Annotations[annotationAddressPool]
+		if len(lbIPs) != 0 && desiredPool != "" && c.ips.Pool(key) != desiredPool {
 			level.Info(l).Log("event", "clearAssignment", "reason", "differentPoolRequested", "msg", "user requested a different pool than the one currently assigned")
 			c.clearServiceState(key, svc)
-			lbIP = nil
+			lbIPs = []net.IP{}
 		}
-	}
-
-	// User set or changed the desired LB IP, nuke the
-	// state. allocateIP will pay attention to LoadBalancerIP and try
-	// to meet the user's demands.
-	if svc.Spec.LoadBalancerIP != "" && svc.Spec.LoadBalancerIP != lbIP.String() {
-		level.Info(l).Log("event", "clearAssignment", "reason", "differentIPRequested", "msg", "user requested a different IP than the one currently assigned")
-		c.clearServiceState(key, svc)
-		lbIP = nil
+		// User set or changed the desired LB IP, nuke the
+		// state. allocateIP will pay attention to LoadBalancerIP and try
+		// to meet the user's demands.
+		if svc.Spec.LoadBalancerIP != "" {
+			if lbIPsIPFamily == ipfamily.DualStack {
+				level.Error(l).Log("event", "loadbalancerIP", "error", "DualStack", "msg", "user requested loadbalancer IP for dualstack address family")
+				c.client.Errorf(svc, "LoadBalancerFailed", "Failed loadbalancer IP for dual-stack")
+				return true
+			}
+			if svc.Spec.LoadBalancerIP != lbIPs[0].String() {
+				level.Info(l).Log("event", "clearAssignment", "reason", "differentIPRequested", "msg", "user requested a different IP than the one currently assigned")
+				c.clearServiceState(key, svc)
+				lbIPs = []net.IP{}
+			}
+		}
 	}
 
 	// If lbIP is still nil at this point, try to allocate.
-	if lbIP == nil {
+	if len(lbIPs) == 0 {
 		if !c.synced {
-			level.Error(l).Log("op", "allocateIP", "error", "controller not synced", "msg", "controller not synced yet, cannot allocate IP; will retry after sync")
+			level.Error(l).Log("op", "allocateIPs", "error", "controller not synced", "msg", "controller not synced yet, cannot allocate IP; will retry after sync")
 			return false
 		}
-		ip, err := c.allocateIP(key, svc)
+		lbIPs, err = c.allocateIPs(key, svc)
 		if err != nil {
-			level.Error(l).Log("op", "allocateIP", "error", err, "msg", "IP allocation failed")
+			level.Error(l).Log("op", "allocateIPs", "error", err, "msg", "IP allocation failed")
 			c.client.Errorf(svc, "AllocationFailed", "Failed to allocate IP for %q: %s", key, err)
 			// The outer controller loop will retry converging this
 			// service when another service gets deleted, so there's
 			// nothing to do here but wait to get called again later.
 			return true
 		}
-		lbIP = ip
-		level.Info(l).Log("event", "ipAllocated", "ip", lbIP, "msg", "IP address assigned by controller")
-		c.client.Infof(svc, "IPAllocated", "Assigned IP %q", lbIP)
+		level.Info(l).Log("event", "ipAllocated", "ip", lbIPs, "msg", "IP address assigned by controller")
+		c.client.Infof(svc, "IPAllocated", "Assigned IP %q", lbIPs)
 	}
 
-	if lbIP == nil {
+	if len(lbIPs) == 0 {
 		level.Error(l).Log("bug", "true", "msg", "internal error: failed to allocate an IP, but did not exit convergeService early!")
 		c.client.Errorf(svc, "InternalError", "didn't allocate an IP but also did not fail")
 		c.clearServiceState(key, svc)
@@ -125,7 +151,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 
 	pool := c.ips.Pool(key)
 	if pool == "" || c.config.Pools[pool] == nil {
-		level.Error(l).Log("bug", "true", "ip", lbIP, "msg", "internal error: allocated IP has no matching address pool")
+		level.Error(l).Log("bug", "true", "ip", lbIPs, "msg", "internal error: allocated IP has no matching address pool")
 		c.client.Errorf(svc, "InternalError", "allocated an IP that has no pool")
 		c.clearServiceState(key, svc)
 		return true
@@ -133,7 +159,11 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 
 	// At this point, we have an IP selected somehow, all that remains
 	// is to program the data plane.
-	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: lbIP.String()}}
+	lbIngressIPs := []v1.LoadBalancerIngress{}
+	for _, lbIP := range lbIPs {
+		lbIngressIPs = append(lbIngressIPs, v1.LoadBalancerIngress{IP: lbIP.String()})
+	}
+	svc.Status.LoadBalancer.Ingress = lbIngressIPs
 	return true
 }
 
@@ -144,13 +174,16 @@ func (c *controller) clearServiceState(key string, svc *v1.Service) {
 	svc.Status.LoadBalancer = v1.LoadBalancerStatus{}
 }
 
-func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
-	clusterIP := net.ParseIP(svc.Spec.ClusterIP)
-	if clusterIP == nil {
+func (c *controller) allocateIPs(key string, svc *v1.Service) ([]net.IP, error) {
+	if len(svc.Spec.ClusterIPs) == 0 {
 		// (we should never get here because the caller ensured that Spec.ClusterIP != nil)
 		return nil, fmt.Errorf("invalid ClusterIP [%s], can't determine family", svc.Spec.ClusterIP)
 	}
-	isIPv6 := clusterIP.To4() == nil
+
+	serviceIPFamily, err := ipfamily.ForAddresses(svc.Spec.ClusterIPs)
+	if err != nil {
+		return nil, err
+	}
 
 	// If the user asked for a specific IP, try that.
 	if svc.Spec.LoadBalancerIP != "" {
@@ -158,25 +191,26 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 		if ip == nil {
 			return nil, fmt.Errorf("invalid spec.loadBalancerIP %q", svc.Spec.LoadBalancerIP)
 		}
-		if (ip.To4() == nil) != isIPv6 {
+		lbipFamily := ipfamily.ForAddress(ip)
+		if serviceIPFamily != lbipFamily {
 			return nil, fmt.Errorf("requested spec.loadBalancerIP %q does not match the ipFamily of the service", svc.Spec.LoadBalancerIP)
 		}
-		if err := c.ips.Assign(key, ip, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+		lbIPs := []net.IP{ip}
+		if err := c.ips.Assign(key, lbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
 			return nil, err
 		}
-		return ip, nil
+		return lbIPs, nil
 	}
-
 	// Otherwise, did the user ask for a specific pool?
-	desiredPool := svc.Annotations["metallb.universe.tf/address-pool"]
+	desiredPool := svc.Annotations[annotationAddressPool]
 	if desiredPool != "" {
-		ip, err := c.ips.AllocateFromPool(key, isIPv6, desiredPool, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+		ips, err := c.ips.AllocateFromPool(key, serviceIPFamily, desiredPool, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 		if err != nil {
 			return nil, err
 		}
-		return ip, nil
+		return ips, nil
 	}
 
 	// Okay, in that case just bruteforce across all pools.
-	return c.ips.Allocate(key, isIPv6, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+	return c.ips.Allocate(key, serviceIPFamily, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 }

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package ipfamily // import "go.universe.tf/metallb/internal/ipfamily"
+
+import (
+	"fmt"
+	"net"
+)
+
+// IP family helps identifying single stack IPv4/IPv6 vs Dual-stack ["IPv4", "IPv6"] or ["IPv6", "Ipv4"].
+type Family string
+
+const (
+	IPv4      Family = "ipv4"
+	IPv6      Family = "ipv6"
+	DualStack Family = "dual"
+	Unknown   Family = "unknown"
+)
+
+// ForAddresses returns the address family given list of addresses strings.
+func ForAddresses(ips []string) (Family, error) {
+	switch len(ips) {
+	case 1:
+		ip := net.ParseIP(ips[0])
+		if ip.To4() != nil {
+			return IPv4, nil
+		} else {
+			return IPv6, nil
+		}
+	case 2:
+		ip1 := net.ParseIP(ips[0])
+		ip2 := net.ParseIP(ips[1])
+		if ip1 == nil || ip2 == nil {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips)
+		}
+		if (ip1.To4() == nil) == (ip2.To4() == nil) {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: same address family %q", ips)
+		}
+		return DualStack, nil
+	default:
+		return Unknown, fmt.Errorf("IPFamilyForAddresses: invalid ips length %d %q", len(ips), ips)
+	}
+}
+
+// ForAddressesIPs returns the address family from a given list of addresses IPs.
+func ForAddressesIPs(ips []net.IP) (Family, error) {
+	ipsStrings := []string{}
+
+	for _, ip := range ips {
+		ipsStrings = append(ipsStrings, ip.String())
+	}
+	return ForAddresses(ipsStrings)
+}
+
+// ForCIDR returns the address family from a given CIDR.
+func ForCIDR(cidr *net.IPNet) Family {
+	if cidr.IP.To4() == nil {
+		return IPv6
+	}
+	return IPv4
+}
+
+// ForAddress returns the address family for a given address.
+func ForAddress(ip net.IP) Family {
+	if ip.To4() == nil {
+		return IPv6
+	}
+	return IPv4
+}

--- a/internal/ipfamily/ipfamily_test.go
+++ b/internal/ipfamily/ipfamily_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package ipfamily
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIPFamilyForAddresses(t *testing.T) {
+	tests := []struct {
+		desc    string
+		ips     []string
+		family  Family
+		wantErr bool
+	}{
+		{
+			desc:   "ipv4 address",
+			ips:    []string{"1.1.1.1"},
+			family: IPv4,
+		},
+		{
+			desc:   "ipv6 address",
+			ips:    []string{"100::1"},
+			family: IPv6,
+		},
+		{
+			desc:   "ipv4 and ipv6 addresse",
+			ips:    []string{"1.2.3.4", "100::1"},
+			family: DualStack,
+		},
+		{
+			desc:    "dual stack with same address family",
+			ips:     []string{"1.2.3.4", "5.6.7.8"},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "dual stack with empty address",
+			ips:     []string{"", ""},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "more than 2 addresses",
+			ips:     []string{"1.1.1.1", "100::1", "2.2.2.2"},
+			family:  Unknown,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			family, err := ForAddresses(test.ips)
+			if test.wantErr && err == nil {
+				t.Fatalf("Expected error for %s", test.desc)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("Not expected error %s for %s", err, test.desc)
+			}
+			if family != test.family {
+				t.Fatalf("Incorrect IPFamily returned %s expected %s", family, test.family)
+			}
+		})
+	}
+}
+
+func TestIPFamilyForAddressesIPs(t *testing.T) {
+	tests := []struct {
+		desc    string
+		ips     []net.IP
+		family  Family
+		wantErr bool
+	}{
+		{
+			desc:   "ipv4 address",
+			ips:    []net.IP{net.ParseIP("1.2.4.0")},
+			family: IPv4,
+		},
+		{
+			desc:   "ipv6 address",
+			ips:    []net.IP{net.ParseIP("100::1")},
+			family: IPv6,
+		},
+		{
+			desc:   "ipv4 and ipv6 addresse",
+			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("100::1")},
+			family: DualStack,
+		},
+		{
+			desc:    "dual stack with same address family",
+			ips:     []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "dual stack with empty address",
+			ips:     []net.IP{net.ParseIP(""), net.ParseIP("")},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "more than 2 addresses",
+			ips:     []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("100::1"), net.ParseIP("2.2.2.2")},
+			family:  Unknown,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			family, err := ForAddressesIPs(test.ips)
+			if test.wantErr && err == nil {
+				t.Fatalf("Expected error for %s", test.desc)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("Not expected error %s for %s", err, test.desc)
+			}
+			if family != test.family {
+				t.Fatalf("Incorrect IPFamily returned %s expected %s", family, test.family)
+			}
+		})
+	}
+}
+
+func TestIPFamilyForCIDR(t *testing.T) {
+	tests := []struct {
+		desc   string
+		cidr   *net.IPNet
+		family Family
+	}{
+		{
+			desc:   "ipv4 cidr",
+			cidr:   ipnet("1.2.3.4/30"),
+			family: IPv4,
+		},
+		{
+			desc:   "ipv6 cidr",
+			cidr:   ipnet("100::/96"),
+			family: IPv6,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			family := ForCIDR(test.cidr)
+			if family != test.family {
+				t.Fatalf("Incorrect IPFamily returned %s expected %s", family, test.family)
+			}
+		})
+	}
+}
+
+func TestIPFamilyForAddress(t *testing.T) {
+	tests := []struct {
+		desc   string
+		ip     net.IP
+		family Family
+	}{
+		{
+			desc:   "ipv4 address",
+			ip:     net.ParseIP("1.2.3.4"),
+			family: IPv4,
+		},
+		{
+			desc:   "ipv6 address",
+			ip:     net.ParseIP("100::"),
+			family: IPv6,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			family := ForAddress(test.ip)
+			if family != test.family {
+				t.Fatalf("Incorrect IPFamily returned %s expected %s", family, test.family)
+			}
+		})
+	}
+}
+
+func ipnet(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 	announce := &Announce{
-		ips:      map[string]net.IP{},
+		ips:      map[string][]net.IP{},
 		ipRefcnt: map[string]int{},
 		spamCh:   make(chan net.IP, 1),
 	}
@@ -21,6 +21,10 @@ func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 		{
 			name: "foo",
 			ip:   net.IPv4(192, 168, 1, 20),
+		},
+		{
+			name: "foo",
+			ip:   net.ParseIP("1000::1"),
 		},
 		{
 			name: "bar",

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -1101,9 +1101,9 @@ func TestShouldAnnounce(t *testing.T) {
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
-			pool := c1.config.Pools[poolFor(c1.config.Pools, lbIP)]
-			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", lbIP, svc, test.eps[lbIP_s])
-			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", lbIP, svc, test.eps[lbIP_s])
+			pool := c1.config.Pools[poolFor(c1.config.Pools, []net.IP{lbIP})]
+			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, svc, test.eps[lbIP_s])
+			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -2103,9 +2103,9 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
-			pool := c1.config.Pools[poolFor(c1.config.Pools, lbIP)]
-			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "test1", lbIP, svc, test.eps[lbIP_s])
-			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "test1", lbIP, svc, test.eps[lbIP_s])
+			pool := c1.config.Pools[poolFor(c1.config.Pools, []net.IP{lbIP})]
+			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc, test.eps[lbIP_s])
+			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -2236,11 +2236,11 @@ func TestClusterPolicy(t *testing.T) {
 		}
 
 		lbIP := net.ParseIP(ip)
-		response1svc1 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc1, eps1)
-		response2svc1 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc1, eps1)
+		response1svc1 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc1, eps1)
+		response2svc1 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc1, eps1)
 
-		response1svc2 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc2, eps2)
-		response2svc2 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc2, eps2)
+		response1svc2 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc2, eps2)
+		response2svc2 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, svc2, eps2)
 
 		// We check that only one speaker announces the service, so their response must be different
 		if response1svc1 == response2svc1 {


### PR DESCRIPTION
Refactor Metallb service controller to support dual stack, this PR is continuation of the effort started by 
PR #727 while trying to share most of the code between single stack and dual stack services, also it modifies to speaker code to return more than one address instead of one Loadbalancer IP.

### - Testing 

 - bring up kind dual-stack cluster 
 - create metallb configmap
 ```
  k -n metallb-system get configmap config -o yaml
 apiVersion: v1
 data:
   config: |
     peers:
     - peer-address: fc00:f853:ccd:e793::5
       peer-asn: 64512
       my-asn: 64512
     address-pools:
     - name: dev-env-bgp
       protocol: bgp
       addresses:
       - 192.168.10.0/24
       - fc00:f853:0ccd:e799::/124
 kind: ConfigMap
 ```
 - create dual-stack svc
 ```
  k create -f dev-env/testsvc_dualstack.yaml 
 ```
 - loadbalancer svc
 ```
  k get svc nginx 
 NAME    TYPE           CLUSTER-IP   EXTERNAL-IP                         PORT(S)        AGE
 nginx   LoadBalancer   10.96.6.42   192.168.10.0,fc00:f853:ccd:e799::   80:30253/TCP   18s
 ```
