### PR TITLE
 E2E: Add an empty bgpd.conf file with zebra password

### DIFF
--- a/e2etest/config/frr/bgpd.conf
+++ b/e2etest/config/frr/bgpd.conf
@@ -1,0 +1,4 @@
+hostname bgpd
+password zebra
+log stdout debugging
+

--- a/e2etest/config/frr/bgpd.conf
+++ b/e2etest/config/frr/bgpd.conf
@@ -1,4 +1,4 @@
-hostname bgpd
 password zebra
 log stdout debugging
+log file /tmp/frr.log debugging
 

--- a/e2etest/config/frr/zebra.conf
+++ b/e2etest/config/frr/zebra.conf
@@ -1,3 +1,2 @@
-hostname Router
 password zebra
 enable password zebra

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -17,7 +17,6 @@ import (
 
 // BGP router config.
 const bgpConfigTemplate = `
-hostname bgpd
 password zebra
 
 log file /tmp/frr.log debugging
@@ -47,7 +46,6 @@ router bgp {{.ASN}}
 {{- end }}
   exit-address-family
 
-log stdout debugging
 `
 
 type RouterConfig struct {

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -18,9 +18,9 @@ import (
 // BGP router config.
 const bgpConfigTemplate = `
 hostname bgpd
-#password zebra
+password zebra
 
-log file /tmp/frr.log informational
+log file /tmp/frr.log debugging
 log timestamp precision 3
 
 route-map RMAP permit 10


### PR DESCRIPTION
Aims to fix a flake where BGP is not able to start, showing messages as
```
BGP: [EC 33554499] sendmsg_nexthop: zclient_send_message() failed
```

the current-config is as well empty, so it could be an issue related to the order in which bgp starts / the tests place a config under its hood. 
Here we start with a valid config that gets eventually overridden by the tests.