### PR TITLE
E2e tests code improvements

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -692,12 +692,8 @@ func validateService(cs clientset.Interface, svc *corev1.Service, nodes []corev1
 }
 
 func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily string) {
-	pods, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: "component=speaker",
-	})
-	framework.ExpectNoError(err)
-	framework.ExpectNotEqual(len(pods.Items), 0, "No speaker pods found")
-	podExecutor := executor.ForPod(testNameSpace, pods.Items[0].Name, "frr")
+	pods := getSpeakerPods(cs)
+	podExecutor := executor.ForPod(testNameSpace, pods[0].Name, "frr")
 
 	Eventually(func() error {
 		address := n.Ipv4

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -224,7 +224,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				LabelSelector: "component=controller",
 			})
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(len(pods.Items), 1, "More than one controller found")
+			framework.ExpectEqual(len(pods.Items), 1, "Expected one controller pod")
 			controllerPod = &pods.Items[0]
 			speakerPods = getSpeakerPods(cs)
 		})

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -696,6 +696,7 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily str
 		LabelSelector: "component=speaker",
 	})
 	framework.ExpectNoError(err)
+	framework.ExpectNotEqual(len(pods.Items), 0, "No speaker pods found")
 	podExecutor := executor.ForPod(testNameSpace, pods.Items[0].Name, "frr")
 
 	Eventually(func() error {
@@ -801,6 +802,7 @@ func getSpeakerPods(cs clientset.Interface) []*corev1.Pod {
 		LabelSelector: "component=speaker",
 	})
 	framework.ExpectNoError(err)
+	framework.ExpectNotEqual(len(speakers.Items), 0, "No speaker pods found")
 	speakerPods := make([]*corev1.Pod, 0)
 	for _, item := range speakers.Items {
 		i := item

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -302,6 +302,8 @@ var _ = ginkgo.Describe("L2", func() {
 				LabelSelector: "component=speaker",
 			})
 			framework.ExpectNoError(err)
+			framework.ExpectNotEqual(len(speakers.Items), 0, "No speaker pods found")
+
 			speakerPods = map[string]*corev1.Pod{}
 			for _, item := range speakers.Items {
 				i := item

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("L2", func() {
 				LabelSelector: "component=controller",
 			})
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(len(pods.Items), 1, "More than one controller found")
+			framework.ExpectEqual(len(pods.Items), 1, "Expected one controller pod")
 			controllerPod = &pods.Items[0]
 
 			speakers, err := cs.CoreV1().Pods(testNameSpace).List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
1. Fix the error message produced when no controller pod found.
2. Add a validation to check at least one speaker pod found.
3. Use getSpeakerPods function to avoid code duplication.