### PR TITLE
E2E: wait for daemons to be available in external frrs

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.universe.tf/metallb/e2etest/pkg/executor"
@@ -34,6 +35,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	dto "github.com/prometheus/client_model/go"
 	"go.universe.tf/metallb/e2etest/pkg/frr"
@@ -43,6 +45,7 @@ import (
 	bgpfrr "go.universe.tf/metallb/internal/bgp/frr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
@@ -857,16 +860,41 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily str
 }
 
 func createFRRContainers(c []containerConfig) ([]*frrcontainer.FRR, error) {
+	m := sync.Mutex{}
 	frrContainers = make([]*frrcontainer.FRR, 0)
 	g := new(errgroup.Group)
 	for _, conf := range c {
 		conf := conf
 		g.Go(func() error {
+			toFind := map[string]bool{
+				"zebra":    true,
+				"watchfrr": true,
+				"bgpd":     true,
+				"bfdd":     true,
+			}
 			c, err := frrcontainer.Start(conf.name, conf.nc, conf.rc, containersNetwork, hostIPv4, hostIPv6)
 			if c != nil {
+				err = wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
+					daemons, err := frr.Daemons(c)
+					if err != nil {
+						return false, err
+					}
+					for _, d := range daemons {
+						delete(toFind, d)
+					}
+					if len(toFind) > 0 {
+						return false, nil
+					}
+					return true, nil
+				})
+				m.Lock()
+				defer m.Unlock()
 				frrContainers = append(frrContainers, c)
 			}
-			return err
+			if err != nil {
+				return errors.Wrapf(err, "Failed to wait for daemons %v", toFind)
+			}
+			return nil
 		})
 	}
 	err := g.Wait()

--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -110,6 +110,9 @@ var _ = ginkgo.Describe("BGP", func() {
 
 			speakerPods := getSpeakerPods(cs)
 			for _, pod := range speakerPods {
+				if len(pod.Spec.Containers) == 1 { // we bump only in case of frr
+					continue
+				}
 				podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
 				dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
 				framework.Logf("External frr dump for pod %s\n%s %v", pod.Name, dump, err)

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -109,5 +109,11 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 	}
 	res = res + out
 
+	res = res + "####### Daemons \n"
+	out, err = exec.Exec("vtysh", "-c", "show daemons")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed exec show daemons %s", res)
+	}
+	res = res + out
 	return res, nil
 }

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -20,6 +20,9 @@ import (
 const bgpConfigTemplate = `
 password zebra
 
+debug bgp updates
+debug bgp neighbor
+
 log file /tmp/frr.log debugging
 log timestamp precision 3
 

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -142,6 +142,12 @@ func (c *FRR) UpdateBGPConfigFile(bgpConfig string) error {
 		return errors.Wrapf(err, "Failed to reload BGP config file")
 	}
 
+	out, err := c.Exec("vtysh", "-c", "show running-config")
+	if err != nil {
+		errors.Wrapf(err, "Failed exec show running config %s", out)
+	}
+	fmt.Println("DEBUG", out)
+
 	return nil
 }
 

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -211,6 +211,7 @@ func reloadFRRConfig(configFile string, exec executor.Executor) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to apply configuration file. %s", string(out))
 	}
+	fmt.Println("DEBUG RELOAD", out)
 
 	return nil
 }

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -142,11 +142,13 @@ func (c *FRR) UpdateBGPConfigFile(bgpConfig string) error {
 		return errors.Wrapf(err, "Failed to reload BGP config file")
 	}
 
-	out, err := c.Exec("vtysh", "-c", "show running-config")
-	if err != nil {
-		errors.Wrapf(err, "Failed exec show running config %s", out)
-	}
-	fmt.Println("DEBUG", out)
+	/*
+		out, err := c.Exec("vtysh", "-c", "show running-config")
+		if err != nil {
+			errors.Wrapf(err, "Failed exec show running config %s", out)
+		}
+		fmt.Println("DEBUG", out)
+	*/
 
 	return nil
 }

--- a/e2etest/pkg/frr/daemons.go
+++ b/e2etest/pkg/frr/daemons.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package frr
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+)
+
+// Daemons returns informations for the all the neighbors in the given
+// executor.
+func Daemons(exec executor.Executor) ([]string, error) {
+	res, err := exec.Exec("vtysh", "-c", "show daemons")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to query neighbours")
+	}
+	res = strings.TrimSuffix(res, "\n")
+	daemons := strings.Split(res, " ")
+	for i := range daemons {
+		daemons[i] = strings.TrimPrefix(daemons[i], " ")
+		daemons[i] = strings.TrimSuffix(daemons[i], " ")
+	}
+	return daemons, nil
+}


### PR DESCRIPTION
Some tests fails for not having FRR loading the right configuration right after starting the container. Here we check for the daemons to be ready before giving it away.