### PR TITLE
Bump kind to v0.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
   setup_kind:
     description: "Install kind"
     steps:
-      - run: GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0
+      - run: GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
       - run: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       - run: sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 jobs:


### PR DESCRIPTION
MetalLB CI is currently pinned to install Kind v0.10.0, a release based on Kubernetes v1.20.2. Bumping to v0.11.1 (latest released as of today) based on Kubernetes v1.21.1.