### PR TITLE
Skip Nodes with LabelNodeExcludeBalancers label

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -54,6 +54,11 @@ type bgpController struct {
 	svcAds         map[string][]*bgp.Advertisement
 	bgpType        bgpImplementation
 	sessionManager bgp.SessionManager
+	service        service
+}
+
+func (c *bgpController) setService(svc service) {
+	c.service = svc
 }
 
 func (c *bgpController) SetConfig(l log.Logger, cfg *config.Config) error {
@@ -183,10 +188,12 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 		// First, determine if the peering should be active for this
 		// node.
 		shouldRun := false
-		for _, ns := range p.cfg.NodeSelectors {
-			if ns.Matches(c.nodeLabels) {
-				shouldRun = true
-				break
+		if ok, _ := c.service.HasExcludeLBLabel(c.myNode); !ok {
+			for _, ns := range p.cfg.NodeSelectors {
+				if ns.Matches(c.nodeLabels) {
+					shouldRun = true
+					break
+				}
 			}
 		}
 

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -197,6 +197,10 @@ func (s *testK8S) UpdateStatus(svc *v1.Service) error {
 	panic("never called")
 }
 
+func (s *testK8S) HasExcludeLBLabel(nodeName string) (bool, error) {
+	return false, nil
+}
+
 func (s *testK8S) Infof(_ *v1.Service, evtType string, msg string, args ...interface{}) {
 	s.t.Logf("k8s Info event %q: %s", evtType, fmt.Sprintf(msg, args...))
 }

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -31,6 +31,11 @@ type layer2Controller struct {
 	announcer *layer2.Announce
 	myNode    string
 	sList     SpeakerList
+	service   service
+}
+
+func (c *layer2Controller) setService(svc service) {
+	c.service = svc
 }
 
 func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {


### PR DESCRIPTION
Have an option to skip peering with Nodes that are labeled by `node.kubernetes.io/exclude-from-external-load-balancers`.

[Service controller](https://github.com/kubernetes/kubernetes/blob/72da0b1bb06607f3f3e067f1bb5ce329ec861e1b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L670-L672) that is used by each Cloud Provider Interface implementer use this logic, I'd like to have it integrated into MetalLB as well.

The dependency injection part of the submitter code looks ugly. If you've got ideas on how to improve, I'll do them in a heartbeat.