### PR TITLE
Update FRR image URL to quay.io

### DIFF
--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -19,7 +19,7 @@ const (
 	// BGP configuration directory.
 	frrConfigDir = "config/frr"
 	// FRR routing image.
-	frrImage = "frrouting/frr:v7.5.1"
+	frrImage = "quay.io/frrouting/frr:stable_7.5"
 	// Host network name.
 	hostNetwork = "host"
 	// FRR container mount destination path.

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -452,7 +452,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:stable_7.5
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -478,7 +478,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:stable_7.5
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -502,7 +502,7 @@ spec:
               done
               tail -f /etc/frr/frr.log
         - name: reloader
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:stable_7.5
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -512,7 +512,7 @@ spec:
             - name: reloader
               mountPath: /etc/frr_reloader
         - name: frr-metrics
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:stable_7.5
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473

--- a/tasks.py
+++ b/tasks.py
@@ -424,7 +424,7 @@ def bgp_dev_env(ip_family):
         '    docker rm -f $frr ; '
         'done', echo=True)
     run("docker run -d --privileged --network kind --rm --name frr --volume %s:/etc/frr "
-            "frrouting/frr:v7.5.1" % frr_volume_dir, echo=True)
+            "quay.io/frrouting/frr:stable_7.5" % frr_volume_dir, echo=True)
 
     if ip_family == "ipv4":
         peer_address = run('docker inspect -f "{{ '


### PR DESCRIPTION
There is a rate limit in dockerhub. To avoid it we should pull the FRR image from quay.io.
