### PR TITLE
website: Documents new steps when adding maintainers

### DIFF
--- a/website/content/community/maintainers.md
+++ b/website/content/community/maintainers.md
@@ -40,10 +40,13 @@ maintainers should support the addition of the new person, and no single
 maintainer should object to adding the new maintainer.
 
 When adding a new maintainer, we should:
-* Add to CODEOWNERS in the metallb repo
-* Open a PR to github.com/cncf/foundation adding the maintainer there. You can
-  use [this PR](https://github.com/cncf/foundation/pull/258/files) as an example
-  of what needs to be done
+
+* Add to CODEOWNERS in the metallb repo.
+
+* Open a PR to [github.com/cncf/foundation](https://github.com/cncf/foundation/)
+  adding the maintainer there. You can use [this PR](https://github.com/cncf/foundation/pull/258/files)
+  as an example of what needs to be done.
+
 * The new maintainer should subscribe to the CNCF maintainers mailing list. For
   this, send an email to cncf-MetalLB-maintainers+subscribe@lists.cncf.io and
   link the merged PR that added you to the metallb CODEOWNERS.


### PR DESCRIPTION
Try number two to do this: https://github.com/metallb/metallb/pull/1082

I consider the previous LGTM still valid for this PR so I'll merge this ASAP, let me know otherwise and I can change this in the future and fix what you think in a follow-up PR.

It is a simple step documentation, that hopefully now renders fine with the hugo version used by the server.