### PR TITLE
Enable bgpd debug on test failure

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("BGP", func() {
 	ginkgo.AfterEach(func() {
 		if ginkgo.CurrentGinkgoTestDescription().Failed {
 			for _, c := range frrContainers {
-				dump, err := frr.RawDump(c, "/etc/frr/bgpd.conf", "/tmp/frr.log")
+				dump, err := frr.RawDump(c, "/etc/frr/bgpd.conf", "/tmp/frr.log", "/etc/frr/daemons")
 				framework.Logf("External frr dump for %s:\n%s %v", c.Name, dump, err)
 			}
 

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -20,6 +20,11 @@ import (
 const bgpConfigTemplate = `
 password zebra
 
+debug bgp updates
+debug bgp neighbor
+debug zebra nht
+debug bgp nht
+
 log file /tmp/frr.log debugging
 log timestamp precision 3
 


### PR DESCRIPTION
Enable richer bgpd logs and dump the content of /etc/frr/daemons on failure.