### PR TITLE
Add support to generate bgpd corefile for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
           if [ "<< parameters.deployment-method >>" = "helm" ]; then FLAGS="--helm-install"; fi
           inv dev-env -i  << parameters.ip-family >> -b  << parameters.bgp-type >> -l all $FLAGS
       - run: |
+          echo '/etc/frr/core-%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern
           SKIP="none"
           FLAGS=""
           if [ "<< parameters.bgp-type >>" = "native" ]; then SKIP="$SKIP\|FRR\|BFD\|DUALSTACK"; fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,7 @@ jobs:
 
       - name: E2E
         run: |
+          echo '/etc/frr/core-%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern
           SKIP="none"
           if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP\|FRR\|BFD\|DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP\|IPV6\|DUALSTACK"; fi

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -111,6 +111,15 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 	}
 	res = res + out
 
+	res = res + "####### Check for any crashinfo files\n"
+	if crashInfo, err := exec.Exec("bash", "-c", "ls /var/tmp/frr/bgpd.*/crashlog | head -n 1"); err == nil {
+		crashInfo = strings.TrimSuffix(crashInfo, "\n")
+		out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s", crashInfo))
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed to cat bgpd crashinfo file %s, err %s", crashInfo, err)
+		}
+		res = res + out
+	}
 	return res, nil
 }
 

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -113,7 +113,7 @@ func startContainer(cfg Config, testDirName string) error {
 	}
 
 	volume := fmt.Sprintf("%s:%s", testDirName, frrMountPath)
-	args := []string{"run", "-d", "--privileged", "--network", cfg.Network, "--rm", "--name", cfg.Name, "--volume", volume, frrImage}
+	args := []string{"run", "-d", "--privileged", "--network", cfg.Network, "--rm", "--ulimit", "core=-1", "--name", cfg.Name, "--volume", volume, frrImage}
 	if cfg.IPv4Address != "" {
 		args = append(args, "--ip", cfg.IPv4Address)
 	}

--- a/tasks.py
+++ b/tasks.py
@@ -427,7 +427,7 @@ def bgp_dev_env(ip_family):
     run('for frr in $(docker ps -a -f name=frr --format {{.Names}}) ; do '
         '    docker rm -f $frr ; '
         'done', echo=True)
-    run("docker run -d --privileged --network kind --rm --name frr --volume %s:/etc/frr "
+    run("docker run -d --privileged --network kind --rm --ulimit core=-1 --name frr --volume %s:/etc/frr "
             "quay.io/frrouting/frr:stable_7.5" % frr_volume_dir, echo=True)
 
     if ip_family == "ipv4":


### PR DESCRIPTION
Modify circle config.yaml to allow core file generation at /tmp folder and modify rawDump to check if there is any core is created 
Unit-test
```
bash-5.1# pkill -SIGSEGV bgpd
bash-5.1# ls -l /tmp/
total 5832
-rw-------    1 root     frr      107610112 Dec  7 01:31 core-bgpd.74.f874d0073cc1.1638840711
 gdb -q -n -ex bt /usr/lib/frr/bgpd /tmp/core-bgpd.74.f874d0073cc1.1638840711
[New LWP 74]
[New LWP 77]
[New LWP 75]
[New LWP 76]
Missing separate debuginfo for the main executable file
Try: dnf --enablerepo='*debug*' install /usr/lib/debug/.build-id/c2/5fc6b15e6584ebfa378da6575ef7ea76a495d3
Core was generated by `/usr/lib/frr/bgpd -d -F traditional -A 127.0.0.1'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f6f6422ef98 in ?? ()
[Current thread is 1 (LWP 74)]
#0  0x00007f6f6422ef98 in ?? ()
#1  0x00007ffd41cb1520 in ?? ()
#2  0x0000000000000020 in ?? ()
#3  0x0000000000000000 in ?? ()
(gdb) 
```