### PR TITLE
Set RouterID in the external containers

### DIFF
--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -31,6 +31,7 @@ log timestamp precision 3
 route-map RMAP permit 10
 set ipv6 next-hop prefer-global
 router bgp {{.ASN}}
+  bgp router-id {{.RouterID}}
   no bgp ebgp-requires-policy
   no bgp default ipv4-unicast
 {{range .Neighbors }}
@@ -63,6 +64,7 @@ exit-address-family
 `
 
 type RouterConfig struct {
+	RouterID    string
 	ASN         uint32
 	Neighbors   []*NeighborConfig
 	V4Neighbors []*NeighborConfig

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -69,6 +69,9 @@ func Start(name string, nc config.NeighborConfig, rc config.RouterConfig, networ
 		}
 	}
 
+	// setting routerid after calculating ips
+	frr.RouterConfig.RouterID = frr.Ipv4
+
 	err = frr.updateVolumePermissions()
 	if err != nil {
 		return frr, err


### PR DESCRIPTION
This is probably the cause of the flakes we are experiencing in CI, as discussed with @ton31337 on slack.

Reference FRR issue https://github.com/FRRouting/frr/issues/10142
