### PR TITLE
FRR: block incoming routes

### DIFF
--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -32,6 +32,7 @@ route-map RMAP permit 10
 set ipv6 next-hop prefer-global
 router bgp {{.ASN}}
   bgp router-id {{.RouterID}}
+  no bgp network import-check
   no bgp ebgp-requires-policy
   no bgp default ipv4-unicast
 {{range .Neighbors }}
@@ -48,6 +49,9 @@ router bgp {{.ASN}}
 {{range .V4Neighbors }}
     neighbor {{.Addr}} next-hop-self
     neighbor {{.Addr}} activate
+    {{- if .ToAdvertise}}
+    network {{.ToAdvertise}}
+    {{- end }}
 {{- end }}
   exit-address-family
 {{- end }}
@@ -57,6 +61,9 @@ router bgp {{.ASN}}
     neighbor {{.Addr}} next-hop-self
     neighbor {{.Addr}} activate
     neighbor {{.Addr}} route-map RMAP in
+    {{- if .ToAdvertise}}
+    network {{.ToAdvertise}}
+    {{- end }}
 {{- end }}
 exit-address-family
 {{- end }}
@@ -74,11 +81,12 @@ type RouterConfig struct {
 }
 
 type NeighborConfig struct {
-	ASN        uint32
-	Addr       string
-	Password   string
-	IPFamily   string
-	BFDEnabled bool
+	ASN         uint32
+	Addr        string
+	Password    string
+	IPFamily    string
+	BFDEnabled  bool
+	ToAdvertise string
 }
 
 // Set the IP of each node in the cluster in the BGP router configuration.

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -19,9 +19,11 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
 
 bfd

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -2,9 +2,10 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
-route-map 10.2.2.254-map permit 10
+route-map 10.2.2.254-out permit 10
   set community 1111:2222 additive
   set community 3333:4444 additive
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy
@@ -21,6 +22,7 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
     network 172.16.1.10/24
-    neighbor 10.2.2.254 route-map 10.2.2.254-map out
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
   exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -18,5 +18,6 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
     network 172.16.1.11/24
   exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -18,7 +18,9 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -17,5 +17,6 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
     network 172.16.1.10/24
   exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -18,7 +18,9 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleSession.golden
@@ -18,7 +18,9 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -2,8 +2,9 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
-route-map 10.2.2.254-map permit 10
+route-map 10.2.2.254-out permit 10
   set community 1111:2222 additive
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy
@@ -20,10 +21,12 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
     network 172.16.1.10/24
-    neighbor 10.2.2.254 route-map 10.2.2.254-map out
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
   exit-address-family
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
     network 172.16.1.11/24
   exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -18,9 +18,11 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
 router bgp 300
   no bgp ebgp-requires-policy
@@ -37,7 +39,9 @@ router bgp 300
 
   address-family ipv4 unicast
     neighbor 10.4.4.254 activate
+    neighbor 10.4.4.254 route-map 10.4.4.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.4.4.254 activate
+    neighbor 10.4.4.254 route-map 10.4.4.254-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -18,7 +18,9 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -23,14 +23,18 @@ router bgp 100
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
   exit-address-family
 
   address-family ipv4 unicast
     neighbor 10.4.4.254 activate
+    neighbor 10.4.4.254 route-map 10.4.4.254-in in
   exit-address-family
   address-family ipv6 unicast
     neighbor 10.4.4.254 activate
+    neighbor 10.4.4.254 route-map 10.4.4.254-in in
   exit-address-family


### PR DESCRIPTION
BGP routes must only be published. We should not accept incoming routes, as FRR is host networked and that would result in unwanted routes at host level of the cluster.

We use prefix-list to block the routes.