### PR TITLE
Enable BFD debug command on the e2e test containers

### DIFF
--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -24,6 +24,7 @@ debug bgp updates
 debug bgp neighbor
 debug zebra nht
 debug bgp nht
+debug bfd peer
 
 log file /tmp/frr.log debugging
 log timestamp precision 3


### PR DESCRIPTION
Enable BFD debug peer on the FRR test containers to help debugging BFD peering issues
