### PR TITLE
BFD metrics: Fix session up metrics determination method

### DIFF
--- a/frr-metrics/collector/bfd.go
+++ b/frr-metrics/collector/bfd.go
@@ -126,7 +126,7 @@ func (c *bfd) Collect(ch chan<- prometheus.Metric) {
 func updatePeersMetrics(ch chan<- prometheus.Metric, peers map[string]bgpfrr.BFDPeer) {
 	for _, p := range peers {
 		sessionUp := 1
-		if p.Status == "down" {
+		if p.Status != "up" {
 			sessionUp = 0
 		}
 


### PR DESCRIPTION
BFD peer has 4 states: up, down, init, or failing.
If we only check the "down" status we state that the session is up while it can be init or failing.

