### PR TITLE
E2Etests fix: Use configMapName variable in configmap updater

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		}
 		framework.ExpectNoError(err)
 		cs = f.ClientSet
-		configUpdater = config.UpdaterForConfigMap(cs, testNameSpace)
+		configUpdater = config.UpdaterForConfigMap(cs, configMapName, testNameSpace)
 		if useOperator {
 			clientconfig := f.ClientConfig()
 			configUpdater, err = config.UpdaterForOperator(clientconfig, testNameSpace)

--- a/e2etest/layer2_test.go
+++ b/e2etest/layer2_test.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("L2", func() {
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
 		loadBalancerCreateTimeout = e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
-		configUpdater = config.UpdaterForConfigMap(cs, testNameSpace)
+		configUpdater = config.UpdaterForConfigMap(cs, configMapName, testNameSpace)
 		if useOperator {
 			clientconfig := f.ClientConfig()
 			configUpdater, err = config.UpdaterForOperator(clientconfig, testNameSpace)

--- a/e2etest/pkg/config/update.go
+++ b/e2etest/pkg/config/update.go
@@ -30,10 +30,10 @@ type configmapUpdater struct {
 	namespace string
 }
 
-func UpdaterForConfigMap(c clientset.Interface, ns string) *configmapUpdater {
+func UpdaterForConfigMap(c clientset.Interface, cmName string, ns string) *configmapUpdater {
 	return &configmapUpdater{
 		Interface: c,
-		name:      "config",
+		name:      cmName,
 		namespace: ns,
 	}
 }


### PR DESCRIPTION
We should use the configMapName variable instead of hardcoding the configmap name, so we will be able to run the E2E tests
using different MetalLB configmap names.
