### PR TITLE
FRR: Allow nexthop tracking to resolve via the default route

### DIFF
--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -30,6 +30,8 @@ const configTemplate = `
 log file /etc/frr/frr.log {{.Loglevel}}
 log timestamp precision 3
 hostname {{.Hostname}}
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 {{- range .Routers }}
 {{- range $n := .Neighbors }}

--- a/internal/bgp/frr/testdata/TestBFDProfileAllDefault.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileAllDefault.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 
 bfd

--- a/internal/bgp/frr/testdata/TestBFDProfileCornerCases.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileCornerCases.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 
 bfd

--- a/internal/bgp/frr/testdata/TestBFDProfileNoSessions.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileNoSessions.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 
 bfd

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 route-map 10.2.2.254-out permit 10
   set community 1111:2222 additive
   set community 3333:4444 additive

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleSession.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleSessionClose.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionClose.golden
@@ -2,4 +2,6 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 route-map 10.2.2.254-out permit 10
   set community 1111:2222 additive
 route-map 10.2.2.254-in deny 20

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -2,6 +2,8 @@
 log file /etc/frr/frr.log informational
 log timestamp precision 3
 hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
 
 router bgp 100
   no bgp ebgp-requires-policy


### PR DESCRIPTION
The native implementation could use the default route to peer with
routers outside its network that couldn't be reached otherwise.
We should enable it in FRR as well to support peering with these routers.
https://docs.frrouting.org/en/latest/zebra.html#clicmd-ip-nht-resolve-via-default

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>