### PR TITLE
Remove NextHop from advertisements

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -16,8 +16,6 @@ import (
 type Advertisement struct {
 	// The prefix being advertised to the peer.
 	Prefix *net.IPNet
-	// The address of the router to which the peer should forward traffic.
-	NextHop net.IP
 	// The local preference of this route. Only propagated to IBGP
 	// peers (i.e. where the peer ASN matches the local ASN).
 	LocalPref uint32
@@ -28,9 +26,6 @@ type Advertisement struct {
 // Equal returns true if a and b are equivalent advertisements.
 func (a *Advertisement) Equal(b *Advertisement) bool {
 	if a.Prefix.String() != b.Prefix.String() {
-		return false
-	}
-	if !a.NextHop.Equal(b.NextHop) {
 		return false
 	}
 	if a.LocalPref != b.LocalPref {

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -57,18 +57,6 @@ func sessionName(myAddr string, myAsn uint32, addr string, asn uint32) string {
 }
 
 func validate(adv *bgp.Advertisement) error {
-	if adv.Prefix.IP.To4() != nil {
-		if adv.NextHop != nil && adv.NextHop.To4() == nil {
-			return fmt.Errorf("next-hop must be IPv4, got %q", adv.NextHop)
-		}
-	} else if adv.Prefix.IP.To16() != nil {
-		if adv.NextHop != nil && adv.NextHop.To16() == nil {
-			return fmt.Errorf("next-hop must be IPv6, got %q", adv.NextHop)
-		}
-	} else {
-		return fmt.Errorf("unable to validate IP address")
-	}
-
 	if len(adv.Communities) > 63 {
 		return fmt.Errorf("max supported communities is 63, got %d", len(adv.Communities))
 	}

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -241,7 +241,6 @@ func TestSingleAdvertisement(t *testing.T) {
 	communities = append(communities, community)
 	adv := &bgp.Advertisement{
 		Prefix:      prefix,
-		NextHop:     net.ParseIP("10.1.1.1"),
 		Communities: communities,
 		LocalPref:   300,
 	}
@@ -272,40 +271,12 @@ func TestSingleAdvertisementNoRouterID(t *testing.T) {
 	}
 
 	adv := &bgp.Advertisement{
-		Prefix:  prefix,
-		NextHop: net.ParseIP("10.1.1.1"),
+		Prefix: prefix,
 	}
 
 	err = session.Set(adv)
 	if err != nil {
 		t.Fatalf("Could not advertise prefix: %s", err)
-	}
-
-	testCheckConfigFile(t)
-}
-
-func TestSingleAdvertisementInvalidPrefix(t *testing.T) {
-	testSetup(t)
-
-	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
-	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true)
-	if err != nil {
-		t.Fatalf("Could not create session: %s", err)
-	}
-	defer session.Close()
-
-	prefix := &net.IPNet{}
-
-	adv := &bgp.Advertisement{
-		Prefix:  prefix,
-		NextHop: net.ParseIP("10.1.1.1"),
-	}
-
-	err = session.Set(adv)
-	if err == nil {
-		t.Fatalf("Set should return error")
 	}
 
 	testCheckConfigFile(t)
@@ -326,36 +297,6 @@ func TestSingleAdvertisementInvalidNoPort(t *testing.T) {
 	// Not checking the file since this test won't create it
 }
 
-func TestSingleAdvertisementInvalidNextHop(t *testing.T) {
-	t.Skip("TODO: bgp.Validate() incorrectly(?) returns err == nil")
-	testSetup(t)
-
-	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
-	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true)
-	if err != nil {
-		t.Fatalf("Could not create session: %s", err)
-	}
-	defer session.Close()
-
-	prefix := &net.IPNet{
-		IP:   net.ParseIP("172.16.1.10"),
-		Mask: classCMask,
-	}
-
-	adv := &bgp.Advertisement{
-		Prefix: prefix,
-	}
-
-	err = session.Set(adv)
-	if err != nil {
-		t.Fatalf("Could not advertise prefix: %s", err)
-	}
-
-	testCheckConfigFile(t)
-}
-
 func TestSingleAdvertisementStop(t *testing.T) {
 	testSetup(t)
 
@@ -374,8 +315,7 @@ func TestSingleAdvertisementStop(t *testing.T) {
 	}
 
 	adv := &bgp.Advertisement{
-		Prefix:  prefix,
-		NextHop: net.ParseIP("10.1.1.1"),
+		Prefix: prefix,
 	}
 
 	err = session.Set(adv)
@@ -409,8 +349,7 @@ func TestSingleAdvertisementChange(t *testing.T) {
 	}
 
 	adv := &bgp.Advertisement{
-		Prefix:  prefix,
-		NextHop: net.ParseIP("10.1.1.1"),
+		Prefix: prefix,
 	}
 
 	err = session.Set(adv)
@@ -424,8 +363,7 @@ func TestSingleAdvertisementChange(t *testing.T) {
 	}
 
 	adv = &bgp.Advertisement{
-		Prefix:  prefix,
-		NextHop: net.ParseIP("10.1.1.1"),
+		Prefix: prefix,
 	}
 
 	err = session.Set(adv)
@@ -457,7 +395,6 @@ func TestTwoAdvertisements(t *testing.T) {
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,
-		NextHop:     net.ParseIP("10.1.1.1"),
 		Communities: communities,
 	}
 
@@ -467,8 +404,7 @@ func TestTwoAdvertisements(t *testing.T) {
 	}
 
 	adv2 := &bgp.Advertisement{
-		Prefix:  prefix2,
-		NextHop: net.ParseIP("10.1.1.1"),
+		Prefix: prefix2,
 	}
 
 	err = session.Set(adv1, adv2)
@@ -506,7 +442,6 @@ func TestTwoAdvertisementsTwoSessions(t *testing.T) {
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,
-		NextHop:     net.ParseIP("10.1.1.1"),
 		Communities: communities,
 	}
 
@@ -517,7 +452,6 @@ func TestTwoAdvertisementsTwoSessions(t *testing.T) {
 
 	adv2 := &bgp.Advertisement{
 		Prefix:      prefix2,
-		NextHop:     net.ParseIP("10.1.1.2"),
 		Communities: communities,
 		LocalPref:   2,
 	}

--- a/internal/bgp/native/native_test.go
+++ b/internal/bgp/native/native_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier:Apache-2.0
 
+//go:build disabled
 // +build disabled
 
 package native
@@ -94,7 +95,6 @@ func TestInterop(t *testing.T) {
 
 	adv := &Advertisement{
 		Prefix:      ipnet("1.2.3.0/24"),
-		NextHop:     net.ParseIP("10.20.30.40"),
 		LocalPref:   42,
 		Communities: []uint32{1234, 2345},
 	}
@@ -134,7 +134,6 @@ func TestTCPMD5(t *testing.T) {
 
 	adv := &Advertisement{
 		Prefix:      ipnet("1.2.3.0/24"),
-		NextHop:     net.ParseIP("10.20.30.40"),
 		LocalPref:   42,
 		Communities: []uint32{1234, 2345},
 	}
@@ -178,7 +177,6 @@ func checkPath(path *api.Path, adv *Advertisement) error {
 			if err := ptypes.UnmarshalAny(attr, &nh); err != nil {
 				return err
 			}
-			nexthop = nh.NextHop
 		case ptypes.Is(attr, &api.LocalPrefAttribute{}):
 			var lp api.LocalPrefAttribute
 			if err := ptypes.UnmarshalAny(attr, &lp); err != nil {
@@ -194,9 +192,6 @@ func checkPath(path *api.Path, adv *Advertisement) error {
 		}
 	}
 
-	if nexthop != adv.NextHop.String() {
-		return fmt.Errorf("wrong nexthop, got %s, want %s", nexthop, adv.NextHop)
-	}
 	if localpref != adv.LocalPref {
 		return fmt.Errorf("wrong localpref, got %d, want %d", localpref, adv.LocalPref)
 	}

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -73,9 +73,6 @@ func sortAds(ads map[string][]*bgp.Advertisement) {
 			if a.LocalPref != b.LocalPref {
 				return a.LocalPref < b.LocalPref
 			}
-			if a.NextHop.String() != b.NextHop.String() {
-				return a.NextHop.String() < b.NextHop.String()
-			}
 			if len(a.Communities) != len(b.Communities) {
 				return len(a.Communities) < len(b.Communities)
 			}


### PR DESCRIPTION
The NextHop field is not used anymore, and it's misleading keeping it in the code. Here we remove it from the codebase and from the tests.
