### PR TITLE
E2E: wait for daemons to be available in external frrs

### DIFF
--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -239,6 +239,7 @@ func reloadFRRConfig(configFile string, exec executor.Executor) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to apply configuration file. %s", string(out))
 	}
+	fmt.Println("DEBUG RELOAD", out)
 
 	return nil
 }

--- a/e2etest/pkg/frr/daemons.go
+++ b/e2etest/pkg/frr/daemons.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package frr
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+)
+
+// Daemons returns informations for the all the neighbors in the given
+// executor.
+func Daemons(exec executor.Executor) ([]string, error) {
+	res, err := exec.Exec("vtysh", "-c", "show daemons")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to query neighbours")
+	}
+	res = strings.TrimSuffix(res, "\n")
+	daemons := strings.Split(res, " ")
+	for i := range daemons {
+		daemons[i] = strings.TrimPrefix(daemons[i], " ")
+		daemons[i] = strings.TrimSuffix(daemons[i], " ")
+	}
+	return daemons, nil
+}


### PR DESCRIPTION
Some tests fails for not having FRR loading the right configuration right after starting the container. Here we check for the daemons to be ready before giving it away.
