### PR TITLE
E2E: create the external containers only once

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -158,6 +158,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		}, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 	}
+
+	frrContainers = setupContainers()
 })
 
 var _ = ginkgo.AfterSuite(func() {
@@ -166,4 +168,6 @@ var _ = ginkgo.AfterSuite(func() {
 
 	err = cs.CoreV1().ConfigMaps(testNameSpace).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
 	framework.ExpectNoError(err)
+
+	tearDownContainers(frrContainers)
 })

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/onsi/ginkgo"
@@ -52,6 +53,8 @@ var (
 	skipDockerCmd     bool
 	ipv4ServiceRange  string
 	ipv6ServiceRange  string
+	ipv4ForContainers string
+	ipv6ForContainers string
 	testNameSpace     = defaultTestNameSpace
 	configMapName     = defaultConfigMapName
 	containersNetwork = defaultContainersNetwork
@@ -77,6 +80,8 @@ func handleFlags() {
 	flag.BoolVar(&skipDockerCmd, "skip-docker", false, "set this to true if the BGP daemon is running on the host instead of in a container")
 	flag.StringVar(&ipv4ServiceRange, "ipv4-service-range", "0", "a range of IPv4 addresses for MetalLB to use when running in layer2 mode")
 	flag.StringVar(&ipv6ServiceRange, "ipv6-service-range", "0", "a range of IPv6 addresses for MetalLB to use when running in layer2 mode")
+	flag.StringVar(&ipv4ForContainers, "ips-for-containers-v4", "0", "a comma separated list of IPv4 addresses available for containers")
+	flag.StringVar(&ipv6ForContainers, "ips-for-containers-v6", "0", "a comma separated list of IPv6 addresses available for containers")
 	flag.BoolVar(&useOperator, "use-operator", false, "set this to true to run the tests using operator custom resources")
 	flag.Parse()
 }
@@ -159,7 +164,10 @@ var _ = ginkgo.BeforeSuite(func() {
 		framework.ExpectNoError(err)
 	}
 
-	frrContainers = setupContainers()
+	framework.ExpectNoError(err)
+	v4Addresses := strings.Split(ipv4ForContainers, ",")
+	v6Addresses := strings.Split(ipv6ForContainers, ",")
+	frrContainers = setupContainers(v4Addresses, v6Addresses)
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -89,7 +89,8 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 
 	for _, file := range filesToDump {
 		res = res + fmt.Sprintf("####### Dumping file %s\n", file)
-		out, err = exec.Exec("cat", file)
+		// limiting the output to 500 lines:
+		out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s | tail -n 500", file))
 		if err != nil {
 			return "", errors.Wrapf(err, "Failed to cat %s file %s", file, res)
 		}

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -16,6 +16,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+const Empty = `password zebra
+log stdout debugging
+log file /tmp/frr.log debugging`
+
 // BGP router config.
 const bgpConfigTemplate = `
 password zebra


### PR DESCRIPTION
Instead of creating and destroying the containers after each run, we create them only once and we keep them for all the tests.

This has several benefits:
- Reduce the test run time since we don't have to pay the container
  creation each time
- The test suite will clean the container even when we block the test
  execution
- This is likely to reduce / remove the flake that happens at container
  start time