### PR TITLE
E2E: dump frr containers in pods only if running in frr mode

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -84,6 +84,9 @@ var _ = ginkgo.Describe("BGP", func() {
 			speakerPods, err := metallb.SpeakerPods(cs)
 			framework.ExpectNoError(err)
 			for _, pod := range speakerPods {
+				if len(pod.Spec.Containers) == 1 { // we dump only in case of frr
+					break
+				}
 				podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
 				dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
 				framework.Logf("External frr dump for pod %s\n%s %v", pod.Name, dump, err)


### PR DESCRIPTION
When a test fails, trying to dump the frr information in native mode will result in an error. Here we check the len of containers and skip if there's only one container, assuming MetalLB is running in legacy mode.
