### PR TITLE
E2E tests: Fix MetalLB configmap exist check in BeforeSuite

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -145,17 +145,19 @@ var _ = ginkgo.BeforeSuite(func() {
 	cs, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
 
-	_, err = cs.CoreV1().ConfigMaps(testNameSpace).Get(context.TODO(), configMapName, metav1.GetOptions{})
-	framework.ExpectEqual(errors.IsNotFound(err), true)
+	if !useOperator {
+		_, err = cs.CoreV1().ConfigMaps(testNameSpace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		framework.ExpectEqual(errors.IsNotFound(err), true)
 
-	// Init empty MetalLB ConfigMap.
-	_, err = cs.CoreV1().ConfigMaps(testNameSpace).Create(context.TODO(), &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: testNameSpace,
-		},
-	}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+		// Init empty MetalLB ConfigMap.
+		_, err = cs.CoreV1().ConfigMaps(testNameSpace).Create(context.TODO(), &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: testNameSpace,
+			},
+		}, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+	}
 })
 
 var _ = ginkgo.AfterSuite(func() {


### PR DESCRIPTION
If we are running in operator mode the MetalLB configmap can be found in the cluster because the operator is managing it
and not the tests. In such case BeforeSuite shouldn't fail.

This change allows us running the E2E tests more than once in a cluster where MetalLB was deploying through operator.
With the previous validation method a second run of the tests was failing as the configmap exist.