### PR TITLE
Remove unwanted debug log

### DIFF
--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -239,7 +239,6 @@ func reloadFRRConfig(configFile string, exec executor.Executor) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to apply configuration file. %s", string(out))
 	}
-	fmt.Println("DEBUG RELOAD", out)
 
 	return nil
 }


### PR DESCRIPTION
A leftover that sneaked through reviews.
