### PR TITLE
CI: extend the kind logs with the deployment type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,5 +129,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: kind-logs-${{ matrix.ip-family }}-${{ matrix.bgp-type }}
+          name: kind-logs-${{ matrix.ip-family }}-${{ matrix.bgp-type }}-${{ matrix.deployment}}
           path: /tmp/kind_logs/


### PR DESCRIPTION
Now that we have also the deployment as another dimension for lanes, we need to embed it into the names of the logs otherwise they get overwritten.
