### PR TITLE
E2E: Fix crashinfo dump

### DIFF
--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -112,13 +112,17 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 	res = res + out
 
 	res = res + "####### Check for any crashinfo files\n"
-	if crashInfo, err := exec.Exec("bash", "-c", "ls /var/tmp/frr/bgpd.*/crashlog | head -n 1"); err == nil {
+	if crashInfo, err := exec.Exec("bash", "-c", "ls /var/tmp/frr/bgpd.*/crashlog"); err == nil {
 		crashInfo = strings.TrimSuffix(crashInfo, "\n")
-		out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s", crashInfo))
-		if err != nil {
-			return "", errors.Wrapf(err, "Failed to cat bgpd crashinfo file %s, err %s", crashInfo, err)
+		files := strings.Split(crashInfo, "\n")
+		for _, file := range files {
+			res = res + fmt.Sprintf("####### Dumping crash file %s\n", file)
+			out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s", file))
+			if err != nil {
+				return "", errors.Wrapf(err, "Failed to cat bgpd crashinfo file %s, err %s, %s", crashInfo, err, res)
+			}
+			res = res + out
 		}
-		res = res + out
 	}
 	return res, nil
 }


### PR DESCRIPTION
Running `ls` and piping to `head -n 1` will always(?)
result in a 0 exit code.
Refactoring to check if crashlogs exist and iterating
over them one by one.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>
