### PR TITLE
E2E: Combine FRR dump errors

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		if ginkgo.CurrentGinkgoTestDescription().Failed {
 			for _, c := range frrContainers {
 				dump, err := frr.RawDump(c, "/etc/frr/bgpd.conf", "/tmp/frr.log", "/etc/frr/daemons")
-				framework.Logf("External frr dump for %s:\n%s %v", c.Name, dump, err)
+				framework.Logf("External frr dump for %s:\n%s\nerrors:%v", c.Name, dump, err)
 			}
 
 			speakerPods := getSpeakerPods(cs)

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -80,10 +80,12 @@ func NeighborConnected(neighborJson string) (bool, error) {
 // RawDump dumps all the low level info as a single string.
 // To be used for debugging in order to print the status of the frr instance.
 func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
+	allerrs := errors.New("")
+
 	res := "####### Show running config\n"
 	out, err := exec.Exec("vtysh", "-c", "show running-config")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed exec show bgp neighbor %s", res)
+		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bgp neighbor: %v", err)
 	}
 	res = res + out
 
@@ -92,7 +94,7 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 		// limiting the output to 500 lines:
 		out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s | tail -n 500", file))
 		if err != nil {
-			return "", errors.Wrapf(err, "Failed to cat %s file %s", file, res)
+			allerrs = errors.Wrapf(allerrs, "\nFailed to cat file %s: %v", file, err)
 		}
 		res = res + out
 	}
@@ -100,14 +102,14 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 	res = res + "####### BGP Neighbors\n"
 	out, err = exec.Exec("vtysh", "-c", "show bgp neighbor")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed exec show bgp neighbor %s", res)
+		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bgp neighbor: %v", err)
 	}
 	res = res + out
 
 	res = res + "####### BFD Peers\n"
 	out, err = exec.Exec("vtysh", "-c", "show bfd peer")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed exec show bfd peer %s", res)
+		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bfd peer: %v", err)
 	}
 	res = res + out
 
@@ -119,12 +121,17 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 			res = res + fmt.Sprintf("####### Dumping crash file %s\n", file)
 			out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s", file))
 			if err != nil {
-				return "", errors.Wrapf(err, "Failed to cat bgpd crashinfo file %s, err %s, %s", crashInfo, err, res)
+				allerrs = errors.Wrapf(allerrs, "\nFailed to cat bgpd crashinfo file %s: %v", file, err)
 			}
 			res = res + out
 		}
 	}
-	return res, nil
+
+	if allerrs.Error() == "" {
+		allerrs = nil
+	}
+
+	return res, allerrs
 }
 
 // ContainsCommunity check if the passed in community string exists in show bgp community.


### PR DESCRIPTION
This change will enable all dumping steps
to finish before returning from the func,
which will give us more logs in case some
step fails before the others.