### PR TITLE
FRR config: deny is added only when announcing an address

### DIFF
--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -44,9 +44,9 @@ route-map {{$n.Addr}}-out permit 10
 {{- if ne $a.LocalPref 0 }}
   set local-preference {{$a.LocalPref}}
 {{- end }}
+{{- end }}
+{{- end }}
 route-map {{$n.Addr}}-in deny 20
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -126,7 +126,7 @@ func TestTwoSessions(t *testing.T) {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "")
+	session2, err := sessionManager.NewSession(l, "10.4.4.255:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -166,7 +166,7 @@ func TestTwoSessionsDuplicateRouter(t *testing.T) {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 400, time.Second, time.Second, "password", "hostname", "")
+	session2, err := sessionManager.NewSession(l, "10.4.4.255:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 400, time.Second, time.Second, "password", "hostname", "")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleSession.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -4,6 +4,8 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+route-map 10.4.4.255-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy
@@ -33,17 +35,17 @@ router bgp 300
 
   bgp router-id 10.3.3.254
 
-  neighbor 10.4.4.254 remote-as 400
-  neighbor 10.4.4.254 port 179
-  neighbor 10.4.4.254 timers 1 1
-  neighbor 10.4.4.254 password password
-  neighbor 10.4.4.254 update-source 10.3.3.254
+  neighbor 10.4.4.255 remote-as 400
+  neighbor 10.4.4.255 port 179
+  neighbor 10.4.4.255 timers 1 1
+  neighbor 10.4.4.255 password password
+  neighbor 10.4.4.255 update-source 10.3.3.254
 
   address-family ipv4 unicast
-    neighbor 10.4.4.254 activate
-    neighbor 10.4.4.254 route-map 10.4.4.254-in in
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-in in
   exit-address-family
   address-family ipv6 unicast
-    neighbor 10.4.4.254 activate
-    neighbor 10.4.4.254 route-map 10.4.4.254-in in
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-in in
   exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -4,6 +4,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -4,6 +4,8 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+route-map 10.4.4.255-in deny 20
 
 router bgp 100
   no bgp ebgp-requires-policy
@@ -17,11 +19,11 @@ router bgp 100
   neighbor 10.2.2.254 timers 1 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
-  neighbor 10.4.4.254 remote-as 400
-  neighbor 10.4.4.254 port 179
-  neighbor 10.4.4.254 timers 1 1
-  neighbor 10.4.4.254 password password
-  neighbor 10.4.4.254 update-source 10.1.1.254
+  neighbor 10.4.4.255 remote-as 400
+  neighbor 10.4.4.255 port 179
+  neighbor 10.4.4.255 timers 1 1
+  neighbor 10.4.4.255 password password
+  neighbor 10.4.4.255 update-source 10.1.1.254
 
   address-family ipv4 unicast
     neighbor 10.2.2.254 activate
@@ -33,10 +35,10 @@ router bgp 100
   exit-address-family
 
   address-family ipv4 unicast
-    neighbor 10.4.4.254 activate
-    neighbor 10.4.4.254 route-map 10.4.4.254-in in
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-in in
   exit-address-family
   address-family ipv6 unicast
-    neighbor 10.4.4.254 activate
-    neighbor 10.4.4.254 route-map 10.4.4.254-in in
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-in in
   exit-address-family


### PR DESCRIPTION
If we have a peer but no advertisements, the deny route map is not added and a peer may inject routes from outside.

