### PR TITLE
Update issue page with Weave NO_MASQ_LOCAL default

### DIFF
--- a/website/content/configuration/weave.md
+++ b/website/content/configuration/weave.md
@@ -11,3 +11,5 @@ If you want to use the local traffic policy, you need to use Weave
 version 2.4.0 or later, and enable the `NO_MASQ_LOCAL` flag, as
 described in [Weave's
 documentation](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#configuration-options).
+
+In version [2.7.0](https://github.com/weaveworks/weave/releases/tag/v2.7.0) and later, the `NO_MASQ_LOCAL` flag is enabled by default.


### PR DESCRIPTION
`NO_MASQ_LOCAL` is enabled by default (https://github.com/weaveworks/weave/pull/3756) as of weave 2.7, so update the docs to reflect this change