### PR TITLE
E2E: Delete multi-hop-net only when host-network isn't used

### DIFF
--- a/e2etest/bgp_test.go
+++ b/e2etest/bgp_test.go
@@ -203,9 +203,11 @@ func tearDownContainers(containers []*frrcontainer.FRR) error {
 		return err
 	}
 
-	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "rm", multiHopNetwork)
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove %s: %s", multiHopNetwork, out)
+	if containersNetwork != "host" {
+		out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "rm", multiHopNetwork)
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove %s: %s", multiHopNetwork, out)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Deleting the multi-hop-net makes sense only if we created
it earlier, meaning when we're using a network other than
host for our containers.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>