### PR TITLE
Remove namespace from PodSecurityPolicy definitions

### DIFF
--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: metallb
   name: controller
-  namespace: metallb-system
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities: []
@@ -46,7 +45,6 @@ metadata:
   labels:
     app: metallb
   name: speaker
-  namespace: metallb-system
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: metallb
   name: controller
-  namespace: metallb-system
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities: []
@@ -46,7 +45,6 @@ metadata:
   labels:
     app: metallb
   name: speaker
-  namespace: metallb-system
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:


### PR DESCRIPTION
Remove namespace from PodSecurityPolicy definitions

PSP are cluster resources and the _namespace_ definition is ignored by the API anyway.