### PR TITLE
FRR mode: allow setting routerid if all equal

### DIFF
--- a/e2etest/pkg/config/parse.go
+++ b/e2etest/pkg/config/parse.go
@@ -32,6 +32,7 @@ type Peer struct {
 	Password      string         `yaml:"password,omitempty"`
 	BFDProfile    string         `yaml:"bfd-profile,omitempty"`
 	EBGPMultiHop  bool           `yaml:"ebgp-multihop,omitempty"`
+	RouterID      string         `yaml:"router-id,omitempty"`
 }
 
 type NodeSelector struct {

--- a/e2etest/pkg/config/update.go
+++ b/e2etest/pkg/config/update.go
@@ -246,6 +246,7 @@ func (o operatorUpdater) peerToOperator(p Peer) (*operatorv1beta1.BGPPeer, error
 			NodeSelectors: nodeselectors,
 			Password:      p.Password,
 			BFDProfile:    p.BFDProfile,
+			RouterID:      p.RouterID,
 			EBGPMultiHop:  p.EBGPMultiHop,
 		},
 	}, nil

--- a/e2etest/pkg/metallb/config.go
+++ b/e2etest/pkg/metallb/config.go
@@ -65,3 +65,11 @@ func WithBFD(peers []config.Peer, bfdProfile string) []config.Peer {
 	}
 	return peers
 }
+
+// WithRouterID sets the given routerID to the peers.
+func WithRouterID(peers []config.Peer, routerID string) []config.Peer {
+	for i := range peers {
+		peers[i].RouterID = routerID
+	}
+	return peers
+}

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Neighbor struct {
-	Ip          net.IP
-	Connected   bool
-	LocalAS     string
-	RemoteAS    string
-	UpdatesSent int
-	PrefixSent  int
-	Port        int
+	Ip             net.IP
+	Connected      bool
+	LocalAS        string
+	RemoteAS       string
+	UpdatesSent    int
+	PrefixSent     int
+	Port           int
+	RemoteRouterID string
 }
 
 type Route struct {
@@ -30,12 +31,13 @@ type Route struct {
 const bgpConnected = "Established"
 
 type FRRNeighbor struct {
-	RemoteAs     int    `json:"remoteAs"`
-	LocalAs      int    `json:"localAs"`
-	BgpVersion   int    `json:"bgpVersion"`
-	BgpState     string `json:"bgpState"`
-	PortForeign  int    `json:"portForeign"`
-	MessageStats struct {
+	RemoteAs       int    `json:"remoteAs"`
+	LocalAs        int    `json:"localAs"`
+	RemoteRouterID string `json:"remoteRouterId"`
+	BgpVersion     int    `json:"bgpVersion"`
+	BgpState       string `json:"bgpState"`
+	PortForeign    int    `json:"portForeign"`
+	MessageStats   struct {
 		UpdatesSent int `json:"updatesSent"`
 	} `json:"messageStats"`
 	AddressFamilyInfo map[string]struct {
@@ -109,13 +111,14 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		return &Neighbor{
-			Ip:          ip,
-			Connected:   connected,
-			LocalAS:     strconv.Itoa(n.LocalAs),
-			RemoteAS:    strconv.Itoa(n.RemoteAs),
-			UpdatesSent: n.MessageStats.UpdatesSent,
-			PrefixSent:  prefixSent,
-			Port:        n.PortForeign,
+			Ip:             ip,
+			Connected:      connected,
+			LocalAS:        strconv.Itoa(n.LocalAs),
+			RemoteAS:       strconv.Itoa(n.RemoteAs),
+			UpdatesSent:    n.MessageStats.UpdatesSent,
+			PrefixSent:     prefixSent,
+			Port:           n.PortForeign,
+			RemoteRouterID: n.RemoteRouterID,
 		}, nil
 	}
 	return nil, errors.New("no peers were returned")
@@ -145,13 +148,14 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		res = append(res, &Neighbor{
-			Ip:          ip,
-			Connected:   connected,
-			LocalAS:     strconv.Itoa(n.LocalAs),
-			RemoteAS:    strconv.Itoa(n.RemoteAs),
-			UpdatesSent: n.MessageStats.UpdatesSent,
-			PrefixSent:  prefixSent,
-			Port:        n.PortForeign,
+			Ip:             ip,
+			Connected:      connected,
+			LocalAS:        strconv.Itoa(n.LocalAs),
+			RemoteAS:       strconv.Itoa(n.RemoteAs),
+			UpdatesSent:    n.MessageStats.UpdatesSent,
+			PrefixSent:     prefixSent,
+			Port:           n.PortForeign,
+			RemoteRouterID: n.RemoteRouterID,
 		})
 	}
 	return res, nil

--- a/internal/bgp/frr/parse_test.go
+++ b/internal/bgp/frr/parse_test.go
@@ -164,6 +164,9 @@ func TestNeighbour(t *testing.T) {
 			if tt.port != n.Port {
 				t.Fatal("Expected port", tt.port, "got", n.Port)
 			}
+			if n.RemoteRouterID != "0.0.0.0" {
+				t.Fatal("Expected remote routerid 0.0.0.0")
+			}
 		})
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -58,9 +58,10 @@ func DontValidate(c *configFile) error {
 func DiscardNativeOnly(c *configFile) error {
 	if len(c.Peers) > 0 {
 		myAsn := c.Peers[0].MyASN
+		routerID := c.Peers[0].RouterID
 		for _, p := range c.Peers {
-			if p.RouterID != "" {
-				return fmt.Errorf("peer %s has routerid set on frr mode", p.Addr)
+			if p.RouterID != routerID {
+				return fmt.Errorf("peer %s has RouterID different from %s, in FRR mode all RouterID must be equal", p.RouterID, c.Peers[0].RouterID)
 			}
 			if p.MyASN != myAsn {
 				return fmt.Errorf("peer %s has myAsn different from %s, in FRR mode all myAsn must be equal", p.Addr, c.Peers[0].Addr)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -121,6 +121,44 @@ func TestValidateFRR(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			desc: "routerid set, one different",
+			config: &configFile{
+				Peers: []peer{
+					{
+						Addr:     "1.2.3.4",
+						RouterID: "1.2.3.4",
+					},
+					{
+						Addr:     "1.2.3.5",
+						RouterID: "1.2.3.4",
+					},
+					{
+						Addr:     "1.2.3.6",
+						RouterID: "1.2.3.5",
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
+			desc: "routerid set, one not set",
+			config: &configFile{
+				Peers: []peer{
+					{
+						Addr:     "1.2.3.4",
+						RouterID: "1.2.3.4",
+					},
+					{
+						Addr:     "1.2.3.5",
+						RouterID: "1.2.3.4",
+					},
+					{
+						Addr: "1.2.3.6",
+					},
+				},
+			},
 			mustFail: true,
 		},
 		{


### PR DESCRIPTION
To overcome the current frr limitation, instead of failing if
routerid is set, we enable a more permissive logic to allow
setting routerid only if all the routerids are equal.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>
