### PR TITLE
Controller: fix panic in convergeBalancer

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -115,7 +115,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 				c.client.Errorf(svc, "LoadBalancerFailed", "Failed loadbalancer IP for dual-stack")
 				return true
 			}
-			if svc.Spec.LoadBalancerIP != lbIPs[0].String() {
+			if len(lbIPs) != 0 && svc.Spec.LoadBalancerIP != lbIPs[0].String() {
 				level.Info(l).Log("event", "clearAssignment", "reason", "differentIPRequested", "msg", "user requested a different IP than the one currently assigned")
 				c.clearServiceState(key, svc)
 				lbIPs = []net.IP{}


### PR DESCRIPTION
The controller can panic if a user updated a service by specifying
a different IP than the one currently assigned and changing another
field that causes the controller to clear the service's state.

For example, updating the address pool of a service and specifying
spec.loadBalancerIP from the new address pool results in:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.(*controller).convergeBalancer(0xc0001205a0, {0x15cf500, 0xc0001bbc20}, {0xc0002b8730, 0xf}, 0xc000132c80)
        /home/obraunsh/projects/metallb/controller/service.go:118 +0x2306
```

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>