### PR TITLE
Speaker: Fix: Remove items from work queue after sync 

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -443,8 +443,7 @@ func (c *Client) Run(stopCh <-chan struct{}) error {
 		updates.Inc()
 		st := c.sync(key)
 		switch st {
-		case SyncStateSuccess:
-		case SyncStateErrorNoRetry:
+		case SyncStateErrorNoRetry, SyncStateSuccess:
 			c.queue.Forget(key)
 		case SyncStateError:
 			updateErrors.Inc()


### PR DESCRIPTION
After doing a successful sync of an item it should be removed from the work queue.

Doing this mainly for deleted services. So far, after deleting a service the service item was left in the queue
(because "SyncStateSuccess" is not doing anything) and once created again (for example in the E2E tests), each update
was taking longer and longer time based on the exponential rate limiter.