### PR TITLE
FRR: fix communities and local preferences

### DIFF
--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -465,3 +465,58 @@ func TestTwoAdvertisements(t *testing.T) {
 
 	testCheckConfigFile(t)
 }
+
+func TestTwoAdvertisementsTwoSessions(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true)
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	session1, err := sessionManager.NewSession(l, "10.2.2.255:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true)
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	adv1 := &bgp.Advertisement{
+		Prefix:      prefix1,
+		NextHop:     net.ParseIP("10.1.1.1"),
+		Communities: communities,
+	}
+
+	prefix2 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix:      prefix2,
+		NextHop:     net.ParseIP("10.1.1.2"),
+		Communities: communities,
+		LocalPref:   2,
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+	err = session1.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -4,11 +4,21 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
-route-map 10.2.2.254-out permit 10
-  set community 1111:2222 additive
-  set community 3333:4444 additive
-  set local-preference 300
+ip prefix-list 1111:2222-v4prefixes permit 172.16.1.10/24
+ip prefix-list 3333:4444-v4prefixes permit 172.16.1.10/24
+ip prefix-list 300-v4localpref-prefixes permit 172.16.1.10/24
 route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 300-v4localpref-prefixes
+  set local-preference 300
+route-map 10.2.2.254-out permit 2
+  match ip address prefix-list 1111:2222-v4prefixes
+  set community 1111:2222 additive
+route-map 10.2.2.254-out permit 3
+  match ip address prefix-list 3333:4444-v4prefixes
+  set community 3333:4444 additive
+route-map 10.2.2.254-out permit 4
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 127.0.0.2-in deny 20
 
+route-map 127.0.0.2-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -4,9 +4,13 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
-route-map 10.2.2.254-out permit 10
-  set community 1111:2222 additive
+ip prefix-list 1111:2222-v4prefixes permit 172.16.1.10/24
 route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 1111:2222-v4prefixes
+  set community 1111:2222 additive
+route-map 10.2.2.254-out permit 2
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -1,0 +1,73 @@
+
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+ip prefix-list 1111:2222-v4prefixes permit 172.16.1.10/24
+ip prefix-list 1111:2222-v4prefixes permit 172.16.1.11/24
+ip prefix-list 2-v4localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 2-v4localpref-prefixes
+  set local-preference 2
+route-map 10.2.2.254-out permit 2
+  match ip address prefix-list 1111:2222-v4prefixes
+  set community 1111:2222 additive
+route-map 10.2.2.254-out permit 3
+route-map 10.2.2.255-in deny 20
+
+route-map 10.2.2.255-out permit 1
+  match ip address prefix-list 2-v4localpref-prefixes
+  set local-preference 2
+route-map 10.2.2.255-out permit 2
+  match ip address prefix-list 1111:2222-v4prefixes
+  set community 1111:2222 additive
+route-map 10.2.2.255-out permit 3
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+  neighbor 10.2.2.255 remote-as 200
+  neighbor 10.2.2.255 ebgp-multihop
+  neighbor 10.2.2.255 port 179
+  neighbor 10.2.2.255 timers 1 1
+  neighbor 10.2.2.255 password password
+  neighbor 10.2.2.255 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    network 172.16.1.10/24
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    network 172.16.1.11/24
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-in in
+    network 172.16.1.10/24
+    neighbor 10.2.2.255 route-map 10.2.2.255-out out
+  exit-address-family
+  address-family ipv4 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-in in
+    network 172.16.1.11/24
+    neighbor 10.2.2.255 route-map 10.2.2.255-out out
+  exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -5,7 +5,11 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
 route-map 10.4.4.255-in deny 20
+
+route-map 10.4.4.255-out permit 1
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -6,6 +6,8 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
+route-map 10.2.2.254-out permit 1
+
 router bgp 100
   no bgp ebgp-requires-policy
   no bgp network import-check

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -5,7 +5,11 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
 route-map 10.4.4.255-in deny 20
+
+route-map 10.4.4.255-out permit 1
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -10,6 +10,10 @@ import (
 // IP family helps identifying single stack IPv4/IPv6 vs Dual-stack ["IPv4", "IPv6"] or ["IPv6", "Ipv4"].
 type Family string
 
+func (f Family) String() string {
+	return string(f)
+}
+
 const (
 	IPv4      Family = "ipv4"
 	IPv6      Family = "ipv6"


### PR DESCRIPTION
The current communities / local pref handling suffers of two issues:

- the route-map is added always with the same id, basically overriding
  all the communities and leaving the last one as the only available
- the route-map is not filtered per prefix. MetalLB api bounds the community and the local preference to the address pool, which means that they must be a property of the announcement.

Here we make a change in the template so that every route-map entry with the same name gets a different id, with the extra complication that we can't bind a route-map entry to a given ip, so it's necessary to collect the ips related to a community (or to a local pref) under a prefix-list.

E2E tests are modified to validate that only the ips coming from the right pool are advertised with the given community / local preference.

This is how the config starting from pools look like before the fix:

```
 address-pools:
    - protocol: bgp
      name: bgp-with-community
      addresses:
      - 192.168.10.0/24
      bgp-advertisements:
      - communities:
        - 65535:65282
    - protocol: bgp
      name: bgp-with-no-community
      addresses:
      - 192.168.16.0/24
    bfd-profiles: []
```

```
Current configuration:
!
frr version 7.5.1_git
frr defaults traditional
hostname kind-worker
log file /etc/frr/frr.log informational
log timestamp precision 3
no ipv6 forwarding
service integrated-vtysh-config
!
router bgp 64512
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 neighbor 172.18.0.6 remote-as 64513
 neighbor 172.18.0.6 timers 60 180
 neighbor 172.18.0.7 remote-as 64512
 neighbor 172.18.0.7 password ibgp-test
 neighbor 172.18.0.7 timers 120 360
 neighbor 172.30.0.2 remote-as 64513
 neighbor 172.30.0.2 password ebgp-test
 neighbor 172.30.0.2 port 180
 neighbor 172.30.0.2 ebgp-multihop 255
 neighbor 172.30.0.2 timers 30 90
 neighbor 172.30.0.3 remote-as 64512
 neighbor 172.30.0.3 password ibgp-test
 neighbor 172.30.0.3 port 180
 neighbor 172.30.0.3 timers 180 540
 !
 address-family ipv4 unicast
  network 192.168.10.0/32
  network 192.168.10.1/32
  network 192.168.16.0/32
  neighbor 172.18.0.6 activate
  neighbor 172.18.0.6 route-map 172.18.0.6-in in
  neighbor 172.18.0.6 route-map 172.18.0.6-out out
  neighbor 172.18.0.7 activate
  neighbor 172.18.0.7 route-map 172.18.0.7-in in
  neighbor 172.18.0.7 route-map 172.18.0.7-out out
  neighbor 172.30.0.2 activate
  neighbor 172.30.0.2 route-map 172.30.0.2-in in
  neighbor 172.30.0.2 route-map 172.30.0.2-out out
  neighbor 172.30.0.3 activate
  neighbor 172.30.0.3 route-map 172.30.0.3-in in
  neighbor 172.30.0.3 route-map 172.30.0.3-out out
 exit-address-family
!
route-map 172.18.0.7-in deny 20
!
route-map 172.30.0.3-in deny 20
!
route-map 172.18.0.6-in deny 20
!
route-map 172.30.0.2-in deny 20
!
route-map 172.18.0.7-out permit 10
 set community no-advertise additive
!
route-map 172.30.0.3-out permit 10
 set community no-advertise additive
!
route-map 172.18.0.6-out permit 10
 set community no-advertise additive
!
route-map 172.30.0.2-out permit 10
 set community no-advertise additive
!
ip nht resolve-via-default
!
ipv6 nht resolve-via-default
!
line vty
!
end
```
