### PR TITLE
Controller: custom annotation for pinning ips (single and dual stack)

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -127,6 +127,8 @@ var _ = ginkgo.Describe("BGP", func() {
 			svc, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
 			defer testservice.Delete(cs, svc)
 
+			validateDesiredLB(svc)
+
 			for _, c := range FRRContainers {
 				validateService(cs, svc, allNodes.Items, c)
 			}
@@ -173,6 +175,17 @@ var _ = ginkgo.Describe("BGP", func() {
 			func(svc *corev1.Service) {
 				testservice.TrafficPolicyCluster(svc)
 				testservice.ForceV6(svc)
+			}),
+		table.Entry("IPV4 - ExternalTrafficPolicyCluster - request IPv4 via custom annotation", ipfamily.IPv4, "ExternalTrafficPolicyCluster", []string{v4PoolAddresses},
+			func(svc *corev1.Service) {
+				testservice.TrafficPolicyCluster(svc)
+				testservice.WithSpecificIPs(svc, "192.168.10.100")
+			}),
+		table.Entry("DUALSTACK - ExternalTrafficPolicyCluster - request Dual Stack via custom annotation", ipfamily.DualStack, "ExternalTrafficPolicyCluster", []string{v4PoolAddresses, v6PoolAddresses},
+			func(svc *corev1.Service) {
+				testservice.TrafficPolicyCluster(svc)
+				testservice.DualStack(svc)
+				testservice.WithSpecificIPs(svc, "192.168.10.100", "fc00:f853:ccd:e799::")
 			}),
 	)
 

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -131,4 +132,20 @@ func checkBFDConfigPropagated(nodeConfig config.BfdProfile, peerConfig bgpfrr.BF
 		return fmt.Errorf("EchoInterval: expecting %d, got %d", *nodeConfig.EchoInterval, peerConfig.RemoteEchoInterval)
 	}
 	return nil
+}
+
+func validateDesiredLB(svc *corev1.Service) {
+	desiredLbIPs := svc.Annotations["metallb.universe.tf/loadBalancerIPs"]
+	if desiredLbIPs == "" {
+		return
+	}
+	framework.ExpectEqual(desiredLbIPs, strings.Join(getIngressIPs(svc.Status.LoadBalancer.Ingress), ","))
+}
+
+func getIngressIPs(ingresses []corev1.LoadBalancerIngress) []string {
+	var ips []string
+	for _, ingress := range ingresses {
+		ips = append(ips, ingress.IP)
+	}
+	return ips
 }

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -2,7 +2,11 @@
 
 package service
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 type Tweak func(svc *corev1.Service)
 
@@ -24,4 +28,13 @@ func DualStack(svc *corev1.Service) {
 
 func TrafficPolicyCluster(svc *corev1.Service) {
 	svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+}
+
+func WithSpecificIPs(svc *corev1.Service, ips ...string) {
+	if len(ips) == 0 {
+		return
+	}
+	svc.Annotations = map[string]string{
+		"metallb.universe.tf/loadBalancerIPs": strings.Join(ips, ","),
+	}
 }

--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -20,6 +20,12 @@ address, or if the address is already in use by another service,
 assignment will fail and MetalLB will log a warning event visible in
 `kubectl describe service <service name>`.
 
+MetalLB supports `spec.loadBalancerIP` and a custom `metallb.universe.tf/loadBalancerIPs`
+annotation. The annotation also supports a comma separated list of IPs to be used in case of
+Dual Stack services.
+
+Please note that `spec.LoadBalancerIP` is planned to be deprecated in [k8s apis](https://github.com/kubernetes/kubernetes/pull/107235).
+
 MetalLB also supports requesting a specific address pool, if you want
 a certain kind of address but don't care which one exactly. To request
 assignment from a specific pool, add the


### PR DESCRIPTION
This PR aims to fix #1155 issue by adding new custom annotation field `metallb.universe.tf/loadBalancerIPs `which can be used to request specific IPs (single and dual stack). For now this would coexist with `svc.Spec.LoadBalancerIP `field. when both fieds are specified, then annotation field takes higher precedence than spec field.