### PR TITLE
E2E: Fix operator mode

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -144,9 +144,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	var updater testsconfig.Updater
 	updater = testsconfig.UpdaterForConfigMap(cs, metallb.ConfigMapName, metallb.Namespace)
 	if useOperator {
-		f := framework.NewDefaultFramework("suite")
-		clientconfig := f.ClientConfig()
-		var err error
+		clientconfig, err := framework.LoadConfig()
+		framework.ExpectNoError(err)
+
 		updater, err = testsconfig.UpdaterForOperator(clientconfig, metallb.Namespace)
 		framework.ExpectNoError(err)
 	}


### PR DESCRIPTION
Calling framework.NewDefaultFramework() inside BeforeSuite results in:
```
You may only call BeforeEach from within a Describe, Context or When
```
Changing that to get the ClientConfig in a different way.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>