### PR TITLE
AddressPool validation: Add BGPAdvertisement validation to avoid duplication

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -589,7 +589,7 @@ func ParseCommunity(c string) (uint32, error) {
 	}
 	b, err := strconv.ParseUint(fs[1], 10, 16)
 	if err != nil {
-		return 0, fmt.Errorf("invalid second section of community %q: %s", fs[0], err)
+		return 0, fmt.Errorf("invalid second section of community %q: %s", fs[1], err)
 	}
 
 	return (uint32(a) << 16) + uint32(b), nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,8 +506,18 @@ func parseBGPAdvertisements(ads []bgpAdvertisement, cidrsPerAddresses map[string
 		}, nil
 	}
 
+	err := validateDuplicateAdvertisements(ads)
+	if err != nil {
+		return nil, err
+	}
+
 	var ret []*BGPAdvertisement
 	for _, rawAd := range ads {
+		err := validateDuplicateCommunities(rawAd.Communities)
+		if err != nil {
+			return nil, err
+		}
+
 		ad := &BGPAdvertisement{
 			AggregationLength:   32,
 			AggregationLengthV6: 128,
@@ -666,4 +676,26 @@ func bfdIntFromConfig(value *uint32, min, max uint32) (*uint32, error) {
 		return nil, fmt.Errorf("invalid value %d, must be in %d-%d range", *value, min, max)
 	}
 	return value, nil
+}
+
+func validateDuplicateAdvertisements(ads []bgpAdvertisement) error {
+	for i := 0; i < len(ads); i++ {
+		for j := i + 1; j < len(ads); j++ {
+			if reflect.DeepEqual(ads[i], ads[j]) {
+				return fmt.Errorf("duplicate definition of bgpadvertisements. advertisement %d and %d are equal", i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+func validateDuplicateCommunities(communities []string) error {
+	for i := 0; i < len(communities); i++ {
+		for j := i + 1; j < len(communities); j++ {
+			if communities[i] == communities[j] {
+				return fmt.Errorf("duplicate definition of community %q", communities[i])
+			}
+		}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -861,6 +861,33 @@ bfd-profiles:
   receive-interval: 90000
 `,
 		},
+		{
+			desc: "Duplicate bgp advertisment definition",
+			raw: `
+address-pools:
+- name: pool1
+  protocol: bgp
+  addresses:
+  - 10.20.0.0/16
+  bgp-advertisements:
+  - aggregation-length: 26
+  - aggregation-length: 26
+`,
+		},
+		{
+			desc: "Duplicate communities definition",
+			raw: `
+bgp-communities:
+  bar: 64512:1234
+address-pools:
+- name: pool1
+  protocol: bgp
+  addresses:
+  - 10.20.0.0/16
+  bgp-advertisements:
+  - communities: ["bar", "bar"]
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When configuring an addressPool with two same BGPAdvertisements, an error should be produced.