### PR TITLE
Revert the speaker and controller selector to the old version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         run: |
           HELM_FLAGS=""
           echo '/etc/frr/core-%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern
-          if [ ${{ matrix.deployment }} = "helm" ]; then HELM_FLAGS="--system-namespaces=default" && export OO_INSTALL_NAMESPACE=default && export CONFIGMAP_NAME=metallb; fi
+          if [ ${{ matrix.deployment }} = "helm" ]; then HELM_FLAGS="--system-namespaces=default" && export OO_INSTALL_NAMESPACE=default && export CONFIGMAP_NAME=metallb && export SPEAKER_SELECTOR="app.kubernetes.io/component=speaker" && export CONTROLLER_SELECTOR="app.kubernetes.io/component=controller"; fi
           SKIP="none"
           if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|BFD|DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|DUALSTACK"; fi

--- a/e2etest/pkg/metallb/metallb.go
+++ b/e2etest/pkg/metallb/metallb.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	controllerLabelSelector = "app.kubernetes.io/component=controller"
-	speakerLabelgSelector   = "app.kubernetes.io/component=speaker"
+	controllerLabelSelector = "component=controller"
+	speakerLabelgSelector   = "component=speaker"
 )
 
 func init() {

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -416,21 +416,21 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    component: speaker
   name: speaker
   namespace: metallb-system
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      component: speaker
   template:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        component: speaker
     spec:
       volumes:
         - name: frr-sockets
@@ -558,7 +558,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,app.kubernetes.io/component=speaker"
+              value: "app=metallb,component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -619,7 +619,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    component: controller
   name: controller
   namespace: metallb-system
 spec:
@@ -627,7 +627,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      component: controller
   template:
     metadata:
       annotations:
@@ -635,7 +635,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        component: controller
     spec:
       containers:
       - args:

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -315,14 +315,14 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    component: speaker
   name: speaker
   namespace: metallb-system
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      component: speaker
   template:
     metadata:
       annotations:
@@ -330,7 +330,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        component: speaker
     spec:
       containers:
       - args:
@@ -356,7 +356,7 @@ spec:
         #- name: METALLB_ML_BIND_PORT
         #  value: "7946"
         - name: METALLB_ML_LABELS
-          value: "app=metallb,app.kubernetes.io/component=speaker"
+          value: "app=metallb,component=speaker"
         - name: METALLB_ML_SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -413,7 +413,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    component: controller
   name: controller
   namespace: metallb-system
 spec:
@@ -421,7 +421,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      component: controller
   template:
     metadata:
       annotations:
@@ -429,7 +429,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        component: controller
     spec:
       containers:
       - args:

--- a/manifests/prometheus-operator.yaml
+++ b/manifests/prometheus-operator.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: controller
+      component: controller
   namespaceSelector:
     matchNames:
       - metallb-system
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: speaker
+      component: speaker
   namespaceSelector:
     matchNames:
       - metallb-system


### PR DESCRIPTION
If users are using the manifests, upgrading will not work because of the
change of the label selector of the daemonset / deployment.

Here we revert and adjust the value used by the tests, and override the
selector in tests because helm uses the app.kubernetes.io/component
version.
