### PR TITLE
Repeat check for frr config file

### DIFF
--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -4,6 +4,7 @@ package frr
 
 import (
 	"flag"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/pkg/errors"
 	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -30,15 +30,38 @@ func testOsHostname() (string, error) {
 }
 
 func testCompareFiles(t *testing.T, configFile, goldenFile string) {
-	cmd := exec.Command("diff", configFile, goldenFile)
-	output, err := cmd.Output()
+
+	var lastError error
+
+	// Try comparing files multiple times because tests can generate more than one configuration
+	err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
+		lastError = nil
+		cmd := exec.Command("diff", configFile, goldenFile)
+		output, err := cmd.Output()
+
+		if err != nil {
+			lastError = fmt.Errorf("command %s returned error: %s\n%s", cmd.String(), err, output)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	// err can only be a ErrWaitTimeout, as the check function always return nil errors.
+	// So lastError is always set
 	if err != nil {
-		t.Fatalf("command %s returned error: %s\n%s", cmd.String(), err, output)
+		t.Fatalf("failed to compare configfiles %s, %s using poll interval\nlast error: %v", configFile, goldenFile, lastError)
 	}
 }
 
 func testUpdateGoldenFile(t *testing.T, configFile, goldenFile string) {
 	t.Log("update golden file")
+
+	// Sleep to be sure the sessionManager has produced all configuration the test
+	// has triggered and no config is still waiting in the debouncer() local variables.
+	// No other conditions can be checked, so sleeping is our best option.
+	time.Sleep(100 * time.Millisecond)
+
 	cmd := exec.Command("cp", "-a", configFile, goldenFile)
 	output, err := cmd.Output()
 	if err != nil {
@@ -59,24 +82,13 @@ func testSetup(t *testing.T) {
 
 func testCheckConfigFile(t *testing.T) {
 	configFile, goldenFile := testGenerateFileNames(t)
-	err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
-		_, err := os.Stat(configFile)
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
 
-	if err != nil {
-		t.Fatalf("Failed to wait for configfile %s, err %v", configFile, err)
-	}
 	if *update {
 		testUpdateGoldenFile(t, configFile, goldenFile)
 	}
+
 	testCompareFiles(t, configFile, goldenFile)
+
 	if !strings.Contains(configFile, "Invalid") {
 		err := testFileIsValid(configFile)
 		if err != nil {


### PR DESCRIPTION
Hi,

I discovered a flaky unit test caused by the [asynchronous nature of the debouncer](https://github.com/metallb/metallb/blob/46675f03d788549897ff59c6b3b268c162a394d0/internal/bgp/frr/config.go#L328).
Here the symptom:
https://github.com/metallb/metallb/runs/4920413290?check_suite_focus=true

The check is done against an intermediate configuration file generated during the test, as `TestTwoAdvertisementsTwoSessions` triggers the configuration render twice.

This PR make the assertion to be repeated using a poll interval, so if spurious config file should be discarder.

Please, let me know if there is a better way to work around this edge case.
