### PR TITLE
FRR route-rules: add on-match next

### DIFF
--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -69,7 +69,7 @@ func Routes(exec executor.Executor) (map[string]bgpfrr.Route, map[string]bgpfrr.
 }
 
 // RoutesForCommunity returns informations about routes in the given executor related to the given community.
-func RoutesForCommunity(exec executor.Executor, community, family ipfamily.Family) (map[string]bgpfrr.Route, error) {
+func RoutesForCommunity(exec executor.Executor, community string, family ipfamily.Family) (map[string]bgpfrr.Route, error) {
 	res, err := exec.Exec("vtysh", "-c", fmt.Sprintf("show bgp %s community %s json", family, community))
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to query routes")

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -64,21 +64,25 @@ receive the same advertisements. Once that changes, we'll need prefix lists per 
 route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
   match ip address prefix-list {{.LocalPreference}}-v4localpref-prefixes
   set local-preference {{.LocalPreference}}
+  on-match next
 {{- end }}
 {{- range $.PrefixesV6ForLocalPref }}
 route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
   match ipv6 address prefix-list {{.LocalPreference}}-v6localpref-prefixes
   set local-preference {{.LocalPreference}}
+  on-match next
 {{- end }}
 {{- range $.PrefixesV4ForCommunity }}
 route-map {{$n.Addr}}-out permit {{ counter $n.Addr }}
   match ip address prefix-list {{.Community}}-v4prefixes
   set community {{.Community}} additive
+  on-match next
 {{- end }}
 {{- range $.PrefixesV6ForCommunity }}
 route-map {{$n.Addr}}-out permit {{ counter $n.Addr }}
   match ipv6 address prefix-list {{.Community}}-v6prefixes
   set community {{.Community}} additive
+  on-match next
 {{- end }}
 route-map {{$n.Addr}}-out permit {{ counter $n.Addr }}
 {{- end }}

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -12,12 +12,15 @@ route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 300-v4localpref-prefixes
   set local-preference 300
+  on-match next
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 1111:2222-v4prefixes
   set community 1111:2222 additive
+  on-match next
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 3333:4444-v4prefixes
   set community 3333:4444 additive
+  on-match next
 route-map 10.2.2.254-out permit 4
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -10,6 +10,7 @@ route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 1111:2222-v4prefixes
   set community 1111:2222 additive
+  on-match next
 route-map 10.2.2.254-out permit 2
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -12,18 +12,22 @@ route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 2-v4localpref-prefixes
   set local-preference 2
+  on-match next
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 1111:2222-v4prefixes
   set community 1111:2222 additive
+  on-match next
 route-map 10.2.2.254-out permit 3
 route-map 10.2.2.255-in deny 20
 
 route-map 10.2.2.255-out permit 1
   match ip address prefix-list 2-v4localpref-prefixes
   set local-preference 2
+  on-match next
 route-map 10.2.2.255-out permit 2
   match ip address prefix-list 1111:2222-v4prefixes
   set community 1111:2222 additive
+  on-match next
 route-map 10.2.2.255-out permit 3
 
 router bgp 100


### PR DESCRIPTION
When we have both communities and localpref advertisement, the community advertisement is skipped because frr stops at the first match.
Here we add on-match next to let it continue.

Also, refactoring advertisement e2e so we can have mixed scenarios.