### PR TITLE
E2E: Avoid BGP:FRR spec flakiness

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -77,9 +77,9 @@ var _ = ginkgo.Describe("BGP", func() {
 		}
 	})
 
-	ginkgo.AfterEach(func() {
-		ginkgo.By("Clearing the previous configuration")
-		// Clean previous configuration.
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
 		err := ConfigUpdater.Clean()
 		framework.ExpectNoError(err)
 
@@ -823,7 +823,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		table.DescribeTable("configure peers one by one and validate FRR paired with nodes", func(ipFamily ipfamily.Family) {
 			for i, c := range FRRContainers {
-				ginkgo.By("configure peer")
+				ginkgo.By(fmt.Sprintf("configure FRR peer [%s]", c.Name))
 
 				configData := config.File{
 					Peers: metallb.PeersForContainers([]*frrcontainer.FRR{c}, ipFamily),


### PR DESCRIPTION
As explained [here](https://github.com/metallb/metallb/issues/1196#issuecomment-1026076150), the
`configure peers one by one and validate FRR paired with nodes` relies on BGP FRR peers to be reachable
by speaker nodes but the default configuration does not allow ipv6 traffic to be forwarded to the `multi-hop-net`.

Not sure this fix is clean enough or it's worth to refactor tests.

Fixed #1196 
