### PR TITLE
BFDProfile: Fix: Deleted profile not being updated in speakers

### DIFF
--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -92,7 +92,11 @@ func (sm *sessionManager) NewSession(l log.Logger, addr string, srcAddr net.IP, 
 }
 
 func (sm *sessionManager) SyncBFDProfiles(profiles map[string]*config.BFDProfile) error {
-	return errors.New("bfd profiles not supported in native mode")
+	if len(profiles) > 0 {
+		return errors.New("bfd profiles not supported in native mode")
+	}
+
+	return nil
 }
 
 // run tries to stay connected to the peer, and pumps route updates to it.

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -231,10 +231,6 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 }
 
 func (c *bgpController) syncBFDProfiles(profiles map[string]*config.BFDProfile) error {
-	if len(profiles) == 0 {
-		return nil
-	}
-
 	return c.sessionManager.SyncBFDProfiles(profiles)
 }
 


### PR DESCRIPTION
If a BFD profile was deleted and there are no more configured BFD profiles (the length of profiles is 0) the sync function should be called to update the config and not skipped.

