### PR TITLE
Helm chart: disable FRR mode by default

### DIFF
--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -230,7 +230,7 @@ speaker:
   # frr contains configuration specific to the MetalLB FRR container,
   # for speaker running alongside FRR.
   frr:
-    enabled: true
+    enabled: false
     # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
     # Possible settings are :-
     #  informational, warning, errors and debugging.

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -3,6 +3,13 @@ title: Release Notes
 weight: 8
 ---
 
+## Version 0.12.1
+
+Bug Fixes:
+
+- (helm chart) FRR mode disabled by default as the FRR mode is still experimental (can be optionally enabled).
+  ([PR #1222](https://github.com/metallb/metallb/pull/1222))
+
 ## Version 0.12.0
 
 New Features:


### PR DESCRIPTION
As the FRR mode is still experimental we set the helm chart default to disable FRR (can be optionally enabled).

Fixing issue https://github.com/metallb/metallb/issues/1221.
