### PR TITLE
Cancel previous jobs when overriding a PR

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,13 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,11 @@ jobs:
   unit-tests:
     runs-on: ubuntu-20.04
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -83,6 +88,11 @@ jobs:
         bgp-type: [native, frr]
         deployment: [manifests, helm]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -141,6 +151,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout Metal LB Operator
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
When overriding a PR, previous jobs still run, and eventually filling the jobs available. Since the PR was overridden, there is no point in waiting them.

Here we use https://github.com/marketplace/actions/cancel-workflow-action to cancel them.
