### PR TITLE
Remove FRR_LOGGING_LEVEL from manifests

### DIFF
--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -231,10 +231,6 @@ speaker:
   # for speaker running alongside FRR.
   frr:
     enabled: false
-    # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
-    # Possible settings are :-
-    #  informational, warning, errors and debugging.
-    logLevel: informational
     image:
       repository: quay.io/frrouting/frr
       tag: stable_7.5

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -535,11 +535,6 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
-            # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
-            # Possible settings are :-
-            #  informational, warning, errors and debugging.
-            - name: FRR_LOGGING_LEVEL
-              value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The environment variable is still read for backward
compatibility but if it is set, the --log-level parameter
value is not forwarded to the FRR configuration.

The presence of the variable in the manifest makes the MetalLB operator not working properly, as it uses the manifests to
deploy speaker's pod