### PR TITLE
Fix my email in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ prefer private disclosure, please email to all of the maintainers:
 
 - fpaoline@redhat.com
 - rbryant@redhat.com
-- rodrigo@kinvolk.com
+- rodrigoca@microsoft.com
 - jliebermann@microsoft.com
 
 We aim for initial response to vulnerability reports within 48

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ which will give us warm fuzzy feelings :).
 # Reporting security issues
 
 You can report security issues in the github issue tracker. If you
-prefer private disclosure, please email to one of the maintainers:
+prefer private disclosure, please email to all of the maintainers:
 
 - fpaoline@redhat.com
 - rbryant@redhat.com


### PR DESCRIPTION
This PR is quite simple:
 * It fixes my email (kinvolk.com is not a valid domain, it is kinvolk.io!)
 * It changes the advice to mail all of the maintainers instead (more reasons in the commit, but it seems just simpler and in case someone is AFK).