### PR TITLE
E2E: add a test that checks overlapping ip services in bgp

### DIFF
--- a/e2etest/pkg/service/create.go
+++ b/e2etest/pkg/service/create.go
@@ -18,13 +18,17 @@ import (
 var TestServicePort = 80
 
 func CreateWithBackend(cs clientset.Interface, namespace string, jigName string, tweak ...func(svc *corev1.Service)) (*corev1.Service, *e2eservice.TestJig) {
+	return CreateWithBackendPort(cs, namespace, jigName, TestServicePort, tweak...)
+}
+
+func CreateWithBackendPort(cs clientset.Interface, namespace string, jigName string, port int, tweak ...func(svc *corev1.Service)) (*corev1.Service, *e2eservice.TestJig) {
 	var svc *corev1.Service
 	var err error
 
 	jig := e2eservice.NewTestJig(cs, namespace, jigName)
 	timeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
 	svc, err = jig.CreateLoadBalancerService(timeout, func(svc *corev1.Service) {
-		tweakServicePort(svc)
+		tweakServicePort(svc, port)
 		for _, f := range tweak {
 			f(svc)
 		}
@@ -32,7 +36,9 @@ func CreateWithBackend(cs clientset.Interface, namespace string, jigName string,
 
 	framework.ExpectNoError(err)
 	_, err = jig.Run(func(rc *corev1.ReplicationController) {
-		tweakRCPort(rc)
+		if port != 0 {
+			tweakRCPort(rc, port)
+		}
 	})
 	framework.ExpectNoError(err)
 	return svc, jig
@@ -43,17 +49,11 @@ func Delete(cs clientset.Interface, svc *corev1.Service) {
 	framework.ExpectNoError(err)
 }
 
-func tweakServicePort(svc *v1.Service) {
-	if TestServicePort != 80 {
-		// if TestServicePort is non default, then change service spec.
-		svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(TestServicePort))
-	}
+func tweakServicePort(svc *v1.Service, port int) {
+	svc.Spec.Ports[0].TargetPort = intstr.FromInt(port)
 }
 
-func tweakRCPort(rc *v1.ReplicationController) {
-	if TestServicePort != 80 {
-		// if TestServicePort is non default, then change pod's spec
-		rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", TestServicePort), fmt.Sprintf("--udp-port=%d", TestServicePort)}
-		rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(int(TestServicePort))
-	}
+func tweakRCPort(rc *v1.ReplicationController, port int) {
+	rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", port), fmt.Sprintf("--udp-port=%d", port)}
+	rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(port)
 }


### PR DESCRIPTION
We have a test that validate overlapping ips in l2, but we want to ensure it works also with bgp.
