### PR TITLE
Fallback to clusterip to determine the service ipfamily

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -720,6 +720,21 @@ func TestControllerMutation(t *testing.T) {
 				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
 			},
 		},
+		{
+			desc: "request dual-stack loadbalancer IPs via custom annotation in a single stack cluster",
+			in: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotationLoadBalancerIPs: "1.2.3.0,1000::",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "1.2.3.4",
+					Type:      "LoadBalancer",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for i := 0; i < 100; i++ {

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -5,6 +5,8 @@ package ipfamily // import "go.universe.tf/metallb/internal/ipfamily"
 import (
 	"fmt"
 	"net"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // IP family helps identifying single stack IPv4/IPv6 vs Dual-stack ["IPv4", "IPv6"] or ["IPv6", "Ipv4"].
@@ -70,4 +72,14 @@ func ForAddress(ip net.IP) Family {
 		return IPv6
 	}
 	return IPv4
+}
+
+// ForService returns the address family of a given service.
+func ForService(svc *v1.Service) (Family, error) {
+	if len(svc.Spec.ClusterIPs) > 0 {
+		return ForAddresses(svc.Spec.ClusterIPs)
+	}
+	// fallback to clusterip if clusterips are not set
+	addresses := []string{svc.Spec.ClusterIP}
+	return ForAddresses(addresses)
 }


### PR DESCRIPTION
K8s versions prior to 1.20 do not have ClusterIPs set, so we fallback to clusterip (singular) to determine the ip family.

Tested locally with 
`inv dev-env --node-img=kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729` as the CI lanes are running against 1.21.

