### PR TITLE
Update NOTES.txt

### DIFF
--- a/charts/metallb/templates/NOTES.txt
+++ b/charts/metallb/templates/NOTES.txt
@@ -6,7 +6,7 @@ defined in MetalLB's configuration:
 config:
 {{ toYaml .Values.configInline | indent 2 }}
 
-To see IP assignments, try `kubectl get services`.
+To see IP assignments, try `kubectl get services --all-namespaces`.
 {{- else }}
 WARNING: you specified a ConfigMap that isn't managed by
 Helm. LoadBalancer services will not function until you add that


### PR DESCRIPTION
I know this is a small change  but this may help people that are new to Kubernetes.

If I type `kubectl get services` I don't get the IP assigned to my Ingress

```bash
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.43.0.1    <none>        443/TCP   116m
```

But if I type `kubectl get services --all-namespaces` I can for sure see all the services:

```bash
NAMESPACE     NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
default       kubernetes       ClusterIP      10.43.0.1       <none>          443/TCP                      124m
kube-system   kube-dns         ClusterIP      10.43.0.10      <none>          53/UDP,53/TCP,9153/TCP       124m
kube-system   metrics-server   ClusterIP      10.43.31.125    <none>          443/TCP                      124m
kube-system   traefik          LoadBalancer   10.43.147.160   192.168.8.150   80:30636/TCP,443:32388/TCP   122m
```

Thanks for sending a pull request! A few things before we get started:

1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
