### PR TITLE
Restore back the FRR images to dockerhub

### DIFF
--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -222,6 +222,6 @@ speaker:
     #  informational, warning, errors and debugging.
     logLevel: informational
     image:
-      repository: quay.io/frrouting/frr
-      tag: stable_7.5
+      repository: frrouting/frr
+      tag: v7.5.1
       pullPolicy:

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -28,7 +28,7 @@ const (
 	// BGP configuration directory.
 	frrConfigDir = "config/frr"
 	// FRR routing image.
-	frrImage = "quay.io/frrouting/frr:stable_7.5"
+	frrImage = "frrouting/frr:v7.5.1"
 	// Host network name.
 	hostNetwork = "host"
 	// FRR container mount destination path.

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -870,7 +870,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -896,7 +896,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -920,7 +920,7 @@ spec:
               done
               tail -f /etc/frr/frr.log
         - name: reloader
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -930,7 +930,7 @@ spec:
             - name: reloader
               mountPath: /etc/frr_reloader
         - name: frr-metrics
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473


### PR DESCRIPTION
The images pulled from quay lack of multi arch support, making the frr mode unusable on ARM (for RPis, for example). Here we revert back to dockerhub.
