### PR TITLE
Updated _index.md to resolve issue 1247

### DIFF
--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -164,10 +164,8 @@ In order for MetalLB to allocate IPs to a dual stack service, there must be
 at least one address pool having both addresses of version v4 and v6.
 
 Note that in case of dual stack services, it is not possible to use
-`spec.loadBalancerIP` as it does not allow to request for multiple IPs.
-
-This problem will be solved by using a custom service annotation in one
-of the next releases.
+`spec.loadBalancerIP` as it does not allow to request for multiple IPs,
+so the annotation `metallb.universe.tf/loadBalancerIPs` must be used.
 
 ## IP address sharing
 


### PR DESCRIPTION
@fedepaol I removed the below lines from _index.md, to resolve issue 1247. Please review.
"Note that in case of dual stack services, it is not possible to use spec.loadBalancerIP as it does not allow to request for multiple IPs.

This problem will be solved by using a custom service annotation in one of the next releases."

Thanks for sending a pull request! A few things before we get started:

1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
