### PR TITLE
Release: replace the speaker / controller version in frr manifests too

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -565,6 +565,8 @@ def release(ctx, version, skip_release_notes=False):
     # Update the manifests with the new version
     run("perl -pi -e 's,image: quay.io/metallb/speaker:.*,image: quay.io/metallb/speaker:v{},g' manifests/metallb.yaml".format(version), echo=True)
     run("perl -pi -e 's,image: quay.io/metallb/controller:.*,image: quay.io/metallb/controller:v{},g' manifests/metallb.yaml".format(version), echo=True)
+    run("perl -pi -e 's,image: quay.io/metallb/speaker:.*,image: quay.io/metallb/speaker:v{},g' manifests/metallb-frr.yaml".format(version), echo=True)
+    run("perl -pi -e 's,image: quay.io/metallb/controller:.*,image: quay.io/metallb/controller:v{},g' manifests/metallb-frr.yaml".format(version), echo=True)
 
     # Update the versions in the helm chart (version and appVersion are always the same)
     # helm chart versions follow Semantic Versioning, and thus exclude the leading 'v'


### PR DESCRIPTION
The release command only replaces the images in the manifest for native mode, omitting the frr manifests.

This will be superseeded by https://github.com/metallb/metallb/pull/1254 , but we need it for fixing the metallb 0.12.x release.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>
