### PR TITLE
Adjust kustomize release / docs

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -579,12 +579,16 @@ def release(ctx, version, skip_release_notes=False):
     run("perl -pi -e 's,^appVersion: .*,appVersion: v{},g' charts/metallb/Chart.yaml".format(version), echo=True)
     run("perl -pi -e 's,^Current chart version is: .*,Current chart version is: `{}`,g' charts/metallb/README.md".format(version), echo=True)
 
+    # Generate the manifests with the new version of the images
+    generate_manifests(ctx)
+
     # Update the version in kustomize instructions
     #
     # TODO: Check if kustomize instructions really need the version in the
     # website or if there is a simpler way. For now, though, we just replace the
     # only page that mentions the version on release.
-    run("perl -pi -e 's,github.com/metallb/metallb//manifests\?ref=.*,github.com/metallb/metallb//manifests\?ref=v{},g' website/content/installation/_index.md".format(version), echo=True)
+    run("sed -i 's/github.com\/metallb\/metallb\/config\/native?ref=main/github.com\/metallb\/metallb\/config\/native?ref={}/g' website/content/installation/_index.md".format(version))
+    run("sed -i 's/github.com\/metallb\/metallb\/config\/native?ref=main/github.com\/metallb\/metallb\/config\/frr?ref={}/g' website/content/installation/_index.md".format(version))
 
     # Update the version embedded in the binary
     run("perl -pi -e 's/version\s+=.*/version = \"{}\"/g' internal/version/version.go".format(version), echo=True)

--- a/tasks.py
+++ b/tasks.py
@@ -557,6 +557,19 @@ def release(ctx, version, skip_release_notes=False):
         previous_version = "v{}.{}.{}".format(version.major, version.minor, version.patch-1)
     else:
         previous_version = "main"
+    bumprelease(ctx, version, previous_version)
+    
+    run("git commit -a -m 'Automated update for release v{}'".format(version), echo=True)
+    run("git tag v{} -m 'See the release notes for details:\n\nhttps://metallb.universe.tf/release-notes/#version-{}-{}-{}'".format(version, version.major, version.minor, version.patch), echo=True)
+    run("git checkout main", echo=True)
+
+@task(help={
+    "version": "version of MetalLB to release.",
+    "previous_version": "version of the previous release.",
+})
+def bumprelease(ctx, version, previous_version):
+    version = semver.parse_version_info(version)
+
     def _replace(pattern):
         oldpat = pattern.format(previous_version)
         newpat = pattern.format("v{}").format(version)
@@ -580,7 +593,7 @@ def release(ctx, version, skip_release_notes=False):
     run("perl -pi -e 's,^Current chart version is: .*,Current chart version is: `{}`,g' charts/metallb/README.md".format(version), echo=True)
 
     # Generate the manifests with the new version of the images
-    generate_manifests(ctx)
+    generatemanifests(ctx)
 
     # Update the version in kustomize instructions
     #
@@ -593,11 +606,6 @@ def release(ctx, version, skip_release_notes=False):
     # Update the version embedded in the binary
     run("perl -pi -e 's/version\s+=.*/version = \"{}\"/g' internal/version/version.go".format(version), echo=True)
     run("gofmt -w internal/version/version.go", echo=True)
-
-    run("git commit -a -m 'Automated update for release v{}'".format(version), echo=True)
-    run("git tag v{} -m 'See the release notes for details:\n\nhttps://metallb.universe.tf/release-notes/#version-{}-{}-{}'".format(version, version.major, version.minor, version.patch), echo=True)
-    run("git checkout main", echo=True)
-
 
 @task
 def test(ctx):

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -96,56 +96,25 @@ You can install MetalLB with
 [Kustomize](https://github.com/kubernetes-sigs/kustomize) by pointing
 at the remote kustomization file.
 
-In the following example, we are deploying the v0.11.0 version of MetalLB :
+In the following example, we are deploying MetalLB with the native bgp implementation :
 
 ```yaml
 # kustomization.yml
 namespace: metallb-system
 
 resources:
-  - github.com/metallb/metallb/config/manifests?ref=v0.11.0
-  - configmap.yml 
+  - github.com/metallb/metallb/config/native?ref=main
 ```
 
-If you want to use a
-[configMapGenerator](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/configGeneration.md)
-for config file, you want to tell Kustomize not to append a hash to
-the config map, as MetalLB is waiting for a config map named `config`
-(see
-<https://github.com/kubernetes-sigs/kustomize/blob/master/examples/generatorOptions.md>):
+
+In order to deploy the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions):
 
 ```yaml
 # kustomization.yml
 namespace: metallb-system
 
 resources:
-  - github.com/metallb/metallb/config/manifests?ref=v0.11.0
-
-configMapGenerator:
-- name: config
-  files:
-    - configs/config
-
-generatorOptions:
- disableNameSuffixHash: true
-```
-
-If you want to build the manifests:
-
-```bash
-kustomize build config/native
-```
-
-If you want to set the namespace:
-
-```bash
-cd config/native && kustomize edit set namespace metallb-system
-```
-
-If you want to build the manifests with the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions):
-
-```bash
-kustomize build config/frr
+  - github.com/metallb/metallb/config/frr?ref=main
 ```
 
 ## Installation with Helm


### PR DESCRIPTION
Follow up of https://github.com/metallb/metallb/pull/1282

- The kustomize instructions are fixed and pinned to a specific release.
- The release task also bumps the all in one manifests
- We split the bump action in a separate function, so it's easier to check if changes in the bumping logic works