### PR TITLE
CI: use composite action to collect the setup step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ on:
       - "v**"
   workflow_dispatch:
 
-env:
-  METALLB_OPERATOR_SHA: e444bb9c23df5bdb944bf138e67964fc8141aa31
-  OLDEST_SUPPORTED_K8s: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -249,7 +245,7 @@ jobs:
         with:
           repository: metallb/metallb-operator
           path: metallboperator
-          ref: $METALLB_OPERATOR_SHA
+          ref: e444bb9c23df5bdb944bf138e67964fc8141aa31
 
       - name: Create multi-node K8s Kind Cluster
         run: |
@@ -303,7 +299,7 @@ jobs:
 
       - name: Deploy MetalLB
         run: |
-          inv dev-env -b frr --no-build-images --node-img $OLDEST_SUPPORTED_K8s
+          inv dev-env -b frr --no-build-images --node-img kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
              
       - name: E2E
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
       - "v**"
   workflow_dispatch:
 
+env:
+  METALLB_OPERATOR_SHA: e444bb9c23df5bdb944bf138e67964fc8141aa31
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -130,40 +133,13 @@ jobs:
         bgp-type: [native, frr]
         deployment: [manifests, helm]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17.1"
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python3-pip arping ndisc6
-          sudo pip3 install invoke semver pyyaml
-          GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
-
-      - name: Download MetalLB images
-        uses: actions/download-artifact@v3
-        with:
-          name: metallb-images
-          path: metallb-images
-
-      - name: Load MetalLB images
-        working-directory: metallb-images
-        run: |
-          docker load -i speaker.tar
-          docker load -i controller.tar
-          docker load -i mirror-server.tar
+      - name: Setup
+        uses: ./.github/workflows/composite/setup
 
       - name: Deploy MetalLB
         run: |
@@ -185,17 +161,12 @@ jobs:
           echo "Skipping $SKIP"
           sudo -E env "PATH=$PATH" inv e2etest --skip $SKIP -e /tmp/kind_logs $HELM_FLAGS
 
-      - name: Log permissions
-        if: ${{ always() }}
-        run: |
-          sudo chmod -R o+r /tmp/kind_logs
-
-      - name: Upload logs
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+      - name: Collect Logs
+        if: ${{ failure() }}
+        uses: ./.github/workflows/composite/collectlogs
         with:
-          name: kind-logs-${{ matrix.ip-family }}-${{ matrix.bgp-type }}-${{ matrix.deployment}}
-          path: /tmp/kind_logs/
+          artifact-name: kind-logs-${{ matrix.ip-family }}-${{ matrix.bgp-type }}-${{ matrix.deployment}}
+
   # This lane checks if conversion webhooks work and if metallb is compatible with the CRDs
   # in the operator. We deploy a v4-frr lane, clone the v0.12.1 version of metallb and run CI
   # in operator mode. We run few significative tests that cover all the crds.
@@ -206,51 +177,24 @@ jobs:
       - helm
       - commitlint
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Checkout
+      - name: Setup
+        uses: ./.github/workflows/composite/setup
+
+      - name: Deploy MetalLB
+        run: |
+          inv dev-env -b frr --no-build-images
+      
+      - name: Checkout previous
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
           path: metallb-v0.12.1
           ref: v0.12.1
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17.1"
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python3-pip arping ndisc6
-          sudo pip3 install invoke semver pyyaml
-          GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
-
-      - name: Download MetalLB images
-        uses: actions/download-artifact@v3
-        with:
-          name: metallb-images
-          path: metallb-images
-
-      - name: Load MetalLB images
-        working-directory: metallb-images
-        run: |
-          docker load -i speaker.tar
-          docker load -i controller.tar
-          docker load -i mirror-server.tar
-
-      - name: Deploy MetalLB
-        run: |
-          inv dev-env -b frr --no-build-images
       
       # Patch the old e2etest to cleanup the resources in the correct order.
       - name: Apply patch
@@ -271,17 +215,12 @@ jobs:
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
           sudo -E env "PATH=$PATH" inv e2etest --use-operator --focus "$FOCUS" -e /tmp/kind_logs
 
-      - name: Log permissions
-        if: ${{ always() }}
-        run: |
-          sudo chmod -R o+r /tmp/kind_logs
-
-      - name: Upload logs
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+      - name: Collect Logs
+        if: ${{ failure() }}
+        uses: ./.github/workflows/composite/collectlogs
         with:
-          name: kind-logs-backward-compatible
-          path: /tmp/kind_logs/
+          artifact-name: kind-logs-backward-compatible
+
 
   e2e-use-operator:
     runs-on: ubuntu-20.04
@@ -296,47 +235,20 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          access_token: ${{ github.token }}
+          fetch-depth: 0
 
+      - name: Setup
+        uses: ./.github/workflows/composite/setup
+      
       - name: Checkout Metal LB Operator
         uses: actions/checkout@v2
         with:
           repository: metallb/metallb-operator
           path: metallboperator
-          ref: e444bb9c23df5bdb944bf138e67964fc8141aa31
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.1'
-
-      - name: Checkout MetalLB
-        uses: actions/checkout@v2
-        with:
-          path: metallb
-          fetch-depth: 0
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python3-pip arping ndisc6
-          sudo pip3 install -r ./dev-env/requirements.txt
-          GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
-
-      - name: Download MetalLB images
-        uses: actions/download-artifact@v3
-        with:
-          name: metallb-images
-          path: metallb-images
-
-      - name: Load MetalLB images
-        working-directory: metallb-images
-        run: |
-          docker load -i speaker.tar
-          docker load -i controller.tar
-          docker load -i mirror-server.tar
+          ref: $METALLB_OPERATOR_SHA
 
       - name: Create multi-node K8s Kind Cluster
         run: |
@@ -367,14 +279,8 @@ jobs:
           EOF
           sudo -E env "PATH=$PATH" inv e2etest --skip "IPV6|DUALSTACK" -e /tmp/kind_logs
 
-      - name: Change permissions for kind logs
+      - name: Collect Logs
         if: ${{ failure() }}
-        run: |
-          sudo chmod -R o+r /tmp/kind_logs
-
-      - name: Archive kind logs
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: ./.github/workflows/composite/collectlogs
         with:
-          name: kind_logs_use_operator
-          path: /tmp/kind_logs
+          artifact-name: kind_logs_use_operator

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   METALLB_OPERATOR_SHA: e444bb9c23df5bdb944bf138e67964fc8141aa31
+  OLDEST_SUPPORTED_K8s: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
 
 jobs:
   commitlint:
@@ -284,3 +285,33 @@ jobs:
         uses: ./.github/workflows/composite/collectlogs
         with:
           artifact-name: kind_logs_use_operator
+
+  oldest_k8s:
+    runs-on: ubuntu-20.04
+    needs:
+      - unit-tests-and-build
+      - helm
+      - commitlint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/workflows/composite/setup
+
+      - name: Deploy MetalLB
+        run: |
+          inv dev-env -b frr --no-build-images --node-img $OLDEST_SUPPORTED_K8s
+             
+      - name: E2E
+        run: |
+          FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
+          sudo -E env "PATH=$PATH" inv e2etest --focus "$FOCUS" -e /tmp/kind_logs
+
+      - name: Collect Logs
+        if: ${{ failure() }}
+        uses: ./.github/workflows/composite/collectlogs
+        with:
+          artifact-name: kind-logs-oldest-k8s

--- a/.github/workflows/composite/collectlogs/action.yaml
+++ b/.github/workflows/composite/collectlogs/action.yaml
@@ -1,0 +1,21 @@
+name: "collectlogs"
+description: "Collect and upload the logs"
+
+inputs:
+  artifact-name:
+    description: "the name of artifacts to store"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Log permissions
+      shell: bash
+      run: |
+        sudo chmod -R o+r /tmp/kind_logs
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/kind_logs/

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
         sudo apt-get update
         sudo apt-get install python3-pip arping ndisc6
         sudo pip3 install invoke semver pyyaml
-        GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
+        GO111MODULE="on" go get sigs.k8s.io/kind@v0.14.0
         go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
 
     - name: Download MetalLB images

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -1,0 +1,37 @@
+name: "install-deps"
+description: "Install deps required for metallb CI"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.17.1"
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install python3-pip arping ndisc6
+        sudo pip3 install invoke semver pyyaml
+        GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
+        go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
+
+    - name: Download MetalLB images
+      uses: actions/download-artifact@v3
+      with:
+        name: metallb-images
+        path: metallb-images
+
+    - name: Load MetalLB images
+      shell: bash
+      working-directory: metallb-images
+      run: |
+        docker load -i speaker.tar
+        docker load -i controller.tar
+        docker load -i mirror-server.tar

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -357,6 +357,9 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
         operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+        operator: Exists        
       {{- end }}
       {{- with .Values.speaker.tolerations }}
         {{- toYaml . | nindent 6 }}

--- a/config/controllers/speaker.yaml
+++ b/config/controllers/speaker.yaml
@@ -93,3 +93,6 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists 

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1911,6 +1911,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: frr-sockets

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1713,6 +1713,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -53,6 +53,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 const (
@@ -109,6 +110,7 @@ var _ = ginkgo.Describe("BGP", func() {
 	})
 
 	f = framework.NewDefaultFramework("bgp")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet

--- a/e2etest/bgptests/bgppeer_selector.go
+++ b/e2etest/bgptests/bgppeer_selector.go
@@ -24,6 +24,7 @@ import (
 	frrcontainer "go.universe.tf/metallb/e2etest/pkg/frr/container"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = ginkgo.Describe("BGP Peer Selector", func() {
@@ -52,6 +53,7 @@ var _ = ginkgo.Describe("BGP Peer Selector", func() {
 	})
 
 	f = framework.NewDefaultFramework("bgp")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet

--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = ginkgo.Describe("BGP Node Selector", func() {
@@ -57,6 +58,7 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 	})
 
 	f = framework.NewDefaultFramework("bgp")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -48,6 +48,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var (
@@ -79,6 +80,7 @@ var _ = ginkgo.Describe("L2", func() {
 	})
 
 	f = framework.NewDefaultFramework("l2")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet

--- a/e2etest/l2tests/node_selector.go
+++ b/e2etest/l2tests/node_selector.go
@@ -26,6 +26,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = ginkgo.Describe("L2", func() {
@@ -48,6 +49,7 @@ var _ = ginkgo.Describe("L2", func() {
 	})
 
 	f = framework.NewDefaultFramework("l2")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	k8s.io/client-go v0.24.0
 	k8s.io/klog v1.0.0
 	k8s.io/kubernetes v1.21.23
+	k8s.io/pod-security-admission v0.0.0
 	sigs.k8s.io/controller-runtime v0.11.2
 )
 
@@ -160,7 +161,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/kubectl v0.0.0 // indirect
 	k8s.io/kubelet v0.0.0 // indirect
-	k8s.io/pod-security-admission v0.0.0 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect


### PR DESCRIPTION
- Refactor the shared steps in a composite action we can reuse
- Bump the kind version used by CI (and the version of the cluster we test against)
- Add a lane to test against the oldest supported k8s version (1.22)

