### PR TITLE
Add a node selector in L2 announcement and BGP announcement

### DIFF
--- a/api/v1beta1/bgpadvertisement_types.go
+++ b/api/v1beta1/bgpadvertisement_types.go
@@ -46,6 +46,9 @@ type BGPAdvertisementSpec struct {
 
 	// IPAddressPools is the list of ipaddresspools to advertise via this advertisement.
 	IPAddressPools []string `json:"ipAddressPools,omitempty"`
+
+	// NodeSelectors is a selector on the node we should perform this advertisement from.
+	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
 }
 
 // BGPAdvertisementStatus defines the observed state of BGPAdvertisement.

--- a/api/v1beta1/l2advertisement_types.go
+++ b/api/v1beta1/l2advertisement_types.go
@@ -27,6 +27,8 @@ import (
 type L2AdvertisementSpec struct {
 	// IPAddressPools is the list of ipaddresspools to advertise via this advertisement.
 	IPAddressPools []string `json:"ipAddressPools,omitempty"`
+	// NodeSelectors is a selector on the node we should perform this advertisement from.
+	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
 }
 
 // L2AdvertisementStatus defines the observed state of L2Advertisement.

--- a/charts/metallb/templates/crds.yaml
+++ b/charts/metallb/templates/crds.yaml
@@ -363,6 +363,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
@@ -775,6 +826,57 @@ spec:
                   via this advertisement.
                 items:
                   type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
                 type: array
             type: object
           status:

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["services, nodes"]
+  resources: ["services"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["services/status"]
@@ -98,20 +98,17 @@ rules:
   resources: ["addresspools"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["metallb.io"]
-  resources: ["bfdprofiles"]
+  resources: ["ipaddresspools"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["metallb.io"]
   resources: ["bgppeers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["metallb.io"]
-  resources: ["l2advertisements"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list"]
 - apiGroups: ["metallb.io"]
   resources: ["bgpadvertisements"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list"]
 - apiGroups: ["metallb.io"]
-  resources: ["ipaddresspools"]
-  verbs: ["get", "list", "watch"]
+  resources: ["l2advertisements"]
+  verbs: ["get", "list"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["services"]
+  resources: ["services, nodes"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["services/status"]

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -75,7 +75,6 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["ipaddresspools"]
   verbs: ["get", "list", "watch"]
-{{- if .Values.speaker.memberlist.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -83,6 +82,7 @@ metadata:
   name: {{ include "metallb.fullname" . }}-controller
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
+{{- if .Values.speaker.memberlist.enabled }}
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "list", "watch"]
@@ -94,6 +94,7 @@ rules:
   resources: ["deployments"]
   resourceNames: ["{{ template "metallb.fullname" . }}-controller"]
   verbs: ["get"]
+{{- end }}
 - apiGroups: ["metallb.io"]
   resources: ["addresspools"]
   verbs: ["get", "list", "watch"]
@@ -109,7 +110,6 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["l2advertisements"]
   verbs: ["get", "list"]
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -153,7 +153,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "metallb.speaker.serviceAccountName" . }}
-{{- if .Values.speaker.memberlist.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -167,5 +166,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "metallb.controller.serviceAccountName" . }}
-{{- end -}}
 {{- end -}}

--- a/config/crd/bases/metallb.io_bgpadvertisements.yaml
+++ b/config/crd/bases/metallb.io_bgpadvertisements.yaml
@@ -66,6 +66,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.

--- a/config/crd/bases/metallb.io_l2advertisements.yaml
+++ b/config/crd/bases/metallb.io_l2advertisements.yaml
@@ -42,6 +42,57 @@ spec:
                 items:
                   type: string
                 type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: L2AdvertisementStatus defines the observed state of L2Advertisement.

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -1019,33 +1019,22 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - addresspools
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
-  - bfdprofiles
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
   - bgppeers
   verbs:
   - get
   - list
+- apiGroups:
+  - metallb.io
+  resources:
+  - addresspools
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - metallb.io
   resources:
-  - l2advertisements
+  - ipaddresspools
   verbs:
   - get
   - list
@@ -1061,7 +1050,7 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - ipaddresspools
+  - l2advertisements
   verbs:
   - get
   - list

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -362,6 +362,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
@@ -769,6 +820,57 @@ spec:
                   via this advertisement.
                 items:
                   type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
                 type: array
             type: object
           status:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1125,6 +1125,7 @@ rules:
   - ""
   resources:
   - services
+  - nodes
   verbs:
   - get
   - list

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -995,33 +995,22 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - addresspools
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
-  - bfdprofiles
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
   - bgppeers
   verbs:
   - get
   - list
+- apiGroups:
+  - metallb.io
+  resources:
+  - addresspools
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - metallb.io
   resources:
-  - l2advertisements
+  - ipaddresspools
   verbs:
   - get
   - list
@@ -1037,7 +1026,7 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - ipaddresspools
+  - l2advertisements
   verbs:
   - get
   - list
@@ -1125,7 +1114,6 @@ rules:
   - ""
   resources:
   - services
-  - nodes
   verbs:
   - get
   - list

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -350,6 +350,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
@@ -745,6 +796,57 @@ spec:
                   via this advertisement.
                 items:
                   type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
                 type: array
             type: object
           status:

--- a/config/manifests/metallb-native-with-webhooks.yaml
+++ b/config/manifests/metallb-native-with-webhooks.yaml
@@ -1019,33 +1019,22 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - addresspools
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
-  - bfdprofiles
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
   - bgppeers
   verbs:
   - get
   - list
+- apiGroups:
+  - metallb.io
+  resources:
+  - addresspools
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - metallb.io
   resources:
-  - l2advertisements
+  - ipaddresspools
   verbs:
   - get
   - list
@@ -1061,7 +1050,7 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - ipaddresspools
+  - l2advertisements
   verbs:
   - get
   - list

--- a/config/manifests/metallb-native-with-webhooks.yaml
+++ b/config/manifests/metallb-native-with-webhooks.yaml
@@ -362,6 +362,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
@@ -769,6 +820,57 @@ spec:
                   via this advertisement.
                 items:
                   type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
                 type: array
             type: object
           status:

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1125,6 +1125,7 @@ rules:
   - ""
   resources:
   - services
+  - nodes
   verbs:
   - get
   - list

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -995,33 +995,22 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - addresspools
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
-  - bfdprofiles
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
   - bgppeers
   verbs:
   - get
   - list
+- apiGroups:
+  - metallb.io
+  resources:
+  - addresspools
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - metallb.io
   resources:
-  - l2advertisements
+  - ipaddresspools
   verbs:
   - get
   - list
@@ -1037,7 +1026,7 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - ipaddresspools
+  - l2advertisements
   verbs:
   - get
   - list
@@ -1125,7 +1114,6 @@ rules:
   - ""
   resources:
   - services
-  - nodes
   verbs:
   - get
   - list

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -350,6 +350,57 @@ spec:
                   lower localpref.
                 format: int32
                 type: integer
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
@@ -745,6 +796,57 @@ spec:
                   via this advertisement.
                 items:
                   type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors is a selector on the node we should perform
+                  this advertisement from.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
                 type: array
             type: object
           status:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
       - ""
     resources:
       - services
+      - nodes
     verbs:
       - get
       - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
       - ""
     resources:
       - services
-      - nodes
     verbs:
       - get
       - list
@@ -182,33 +181,22 @@ rules:
   - apiGroups:
       - metallb.io
     resources:
-      - addresspools
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - metallb.io
-    resources:
-      - bfdprofiles
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - metallb.io
-    resources:
       - bgppeers
     verbs:
       - get
       - list
+  - apiGroups:
+      - metallb.io
+    resources:
+      - addresspools
+    verbs:
+      - get
+      - list
       - watch
   - apiGroups:
       - metallb.io
     resources:
-      - l2advertisements
+      - ipaddresspools
     verbs:
       - get
       - list
@@ -224,7 +212,7 @@ rules:
   - apiGroups:
       - metallb.io
     resources:
-      - ipaddresspools
+      - l2advertisements
     verbs:
       - get
       - list

--- a/controller/service.go
+++ b/controller/service.go
@@ -156,7 +156,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	}
 
 	pool := c.ips.Pool(key)
-	if pool == "" || c.config.Pools[pool] == nil {
+	if pool == "" || c.pools[pool] == nil {
 		level.Error(l).Log("bug", "true", "ip", lbIPs, "msg", "internal error: allocated IP has no matching address pool")
 		c.client.Errorf(svc, "InternalError", "allocated an IP that has no pool")
 		c.clearServiceState(key, svc)

--- a/e2etest/bgptests/dump.go
+++ b/e2etest/bgptests/dump.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package bgptests
+
+import (
+	"fmt"
+
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+	"go.universe.tf/metallb/e2etest/pkg/frr"
+	"go.universe.tf/metallb/e2etest/pkg/k8s"
+	"go.universe.tf/metallb/e2etest/pkg/metallb"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func dumpBGPInfo(cs clientset.Interface, f *framework.Framework) {
+	for _, c := range FRRContainers {
+		address := c.Ipv4
+		if address == "" {
+			address = c.Ipv6
+		}
+		peerAddr := address + fmt.Sprintf(":%d", c.RouterConfig.BGPPort)
+		dump, err := frr.RawDump(c, "/etc/frr/bgpd.conf", "/tmp/frr.log", "/etc/frr/daemons")
+		framework.Logf("External frr dump for %s:%s\n%s\nerrors:%v", c.Name, peerAddr, dump, err)
+	}
+
+	speakerPods, err := metallb.SpeakerPods(cs)
+	framework.ExpectNoError(err)
+	for _, pod := range speakerPods {
+		if len(pod.Spec.Containers) == 1 { // we dump only in case of frr
+			break
+		}
+		podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
+		dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
+		framework.Logf("External frr dump for pod %s\n%s %v", pod.Name, dump, err)
+	}
+	k8s.DescribeSvc(f.Namespace.Name)
+}

--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package bgptests
+
+import (
+	"context"
+
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	"go.universe.tf/metallb/e2etest/pkg/k8s"
+	"go.universe.tf/metallb/e2etest/pkg/metallb"
+	testservice "go.universe.tf/metallb/e2etest/pkg/service"
+	metallbconfig "go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/ipfamily"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+
+	frrconfig "go.universe.tf/metallb/e2etest/pkg/frr/config"
+	frrcontainer "go.universe.tf/metallb/e2etest/pkg/frr/container"
+	corev1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("BGP Node Selector", func() {
+	var cs clientset.Interface
+	var f *framework.Framework
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentGinkgoTestDescription().Failed {
+			dumpBGPInfo(cs, f)
+		}
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
+		err := ConfigUpdater.Clean()
+		framework.ExpectNoError(err)
+
+		for _, c := range FRRContainers {
+			err := c.UpdateBGPConfigFile(frrconfig.Empty)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	f = framework.NewDefaultFramework("bgp")
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	table.DescribeTable("Two services, two distinct advertisements with different node selectors",
+		func(pairingIPFamily ipfamily.Family, addresses []string, nodesForFirstPool, nodesForSecondPool []int) {
+			var allNodes *corev1.NodeList
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+
+			expectedNodesForFirstPool := nodesForSelection(allNodes.Items, nodesForFirstPool)
+			expectedNodesForSecondPool := nodesForSelection(allNodes.Items, nodesForSecondPool)
+
+			resources := metallbconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "first-pool",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{addresses[0]},
+						},
+					}, {
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "second-pool",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{addresses[1]},
+						},
+					},
+				},
+				Peers: metallb.PeersForContainers(FRRContainers, pairingIPFamily),
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "first-adv",
+						},
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							NodeSelectors:  k8s.SelectorsForNodes(expectedNodesForFirstPool),
+							IPAddressPools: []string{"first-pool"},
+						},
+					}, {
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "second-adv",
+						},
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							NodeSelectors:  k8s.SelectorsForNodes(expectedNodesForSecondPool),
+							IPAddressPools: []string{"second-pool"},
+						},
+					},
+				},
+			}
+			for _, c := range FRRContainers {
+				err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily)
+				framework.ExpectNoError(err)
+			}
+
+			err = ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			firstService, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "first-lb", testservice.WithSpecificPool("first-pool"))
+			defer testservice.Delete(cs, firstService)
+			secondService, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "second-lb", testservice.WithSpecificPool("second-pool"))
+			defer testservice.Delete(cs, secondService)
+
+			checkServiceOnlyOnNodes(cs, firstService, expectedNodesForFirstPool, pairingIPFamily)
+			checkServiceOnlyOnNodes(cs, secondService, expectedNodesForSecondPool, pairingIPFamily)
+		},
+		table.Entry("IPV4 - two on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{0, 1}, []int{0, 1}),
+		table.Entry("IPV4 - one on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{0}, []int{0, 1}),
+		table.Entry("IPV4 - zero on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{}, []int{0, 1}),
+		table.Entry("IPV6 - one on first, two on second", ipfamily.IPv6, []string{"fc00:f853:0ccd:e799::/116", "fc00:f853:0ccd:e800::/116"}, []int{0}, []int{1, 2}),
+	)
+
+	// this test is marked FFR only because of https://github.com/metallb/metallb/issues/1315
+	table.DescribeTable("Single service, two advertisement with different node selectors FRR", func(pairingIPFamily ipfamily.Family, address string, nodesForFirstAdv, nodesForSecondAdv []int) {
+		var allNodes *corev1.NodeList
+		allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		framework.ExpectNoError(err)
+
+		expectedNodesForFirstAdv := nodesForSelection(allNodes.Items, nodesForFirstAdv)
+		expectedNodesForSecondAdv := nodesForSelection(allNodes.Items, nodesForSecondAdv)
+
+		resources := metallbconfig.ClusterResources{
+			Pools: []metallbv1beta1.IPAddressPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "first-pool",
+					},
+					Spec: metallbv1beta1.IPAddressPoolSpec{
+						Addresses: []string{address},
+					},
+				},
+			},
+			Peers: metallb.PeersForContainers(FRRContainers, pairingIPFamily),
+			BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "first-adv",
+					},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						NodeSelectors:  k8s.SelectorsForNodes(expectedNodesForFirstAdv),
+						Communities:    []string{CommunityNoAdv},
+						IPAddressPools: []string{"first-pool"},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "second-adv",
+					},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						NodeSelectors:  k8s.SelectorsForNodes(expectedNodesForSecondAdv),
+						Communities:    []string{CommunityGracefulShut},
+						IPAddressPools: []string{"first-pool"},
+					},
+				},
+			},
+		}
+		for _, c := range FRRContainers {
+			err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily)
+			framework.ExpectNoError(err)
+		}
+
+		err = ConfigUpdater.Update(resources)
+		framework.ExpectNoError(err)
+
+		svc, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "first-lb", testservice.TrafficPolicyCluster)
+		defer testservice.Delete(cs, svc)
+
+		checkCommunitiesOnlyOnNodes(cs, svc, CommunityNoAdv, expectedNodesForFirstAdv, pairingIPFamily)
+		checkCommunitiesOnlyOnNodes(cs, svc, CommunityGracefulShut, expectedNodesForSecondAdv, pairingIPFamily)
+	},
+		table.Entry("IPV4 - two on first, two on second", ipfamily.IPv4, "192.168.10.0/24", []int{0, 1}, []int{0, 1}),
+		table.Entry("IPV4 - one on first, two on second", ipfamily.IPv4, "192.168.10.0/24", []int{0}, []int{0, 1}),
+		table.Entry("IPV4 - zero on first, two on second", ipfamily.IPv4, "192.168.10.0/24", []int{}, []int{0, 1}),
+		table.Entry("IPV6 - one on first, two on second", ipfamily.IPv6, "fc00:f853:0ccd:e799::/116", []int{0}, []int{1, 2}),
+	)
+})

--- a/e2etest/l2tests/node_selector.go
+++ b/e2etest/l2tests/node_selector.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package l2tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+	"go.universe.tf/metallb/e2etest/pkg/k8s"
+	"go.universe.tf/metallb/e2etest/pkg/mac"
+	"go.universe.tf/metallb/e2etest/pkg/service"
+	"go.universe.tf/metallb/e2etest/pkg/wget"
+
+	internalconfig "go.universe.tf/metallb/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+)
+
+var _ = ginkgo.Describe("L2", func() {
+	f := framework.NewDefaultFramework("l2")
+	var cs clientset.Interface
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+
+		ginkgo.By("Clearing any previous configuration")
+
+		err := ConfigUpdater.Clean()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.AfterEach(func() {
+		// Clean previous configuration.
+		err := ConfigUpdater.Clean()
+		framework.ExpectNoError(err)
+
+		if ginkgo.CurrentGinkgoTestDescription().Failed {
+			k8s.DescribeSvc(f.Namespace.Name)
+		}
+	})
+
+	ginkgo.Context("Node Selector", func() {
+		ginkgo.BeforeEach(func() {
+			resources := internalconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "l2-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{
+								IPV4ServiceRange,
+								IPV6ServiceRange},
+						},
+					},
+				},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should work selecting one node", func() {
+			svc, _ := service.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", service.TrafficPolicyCluster)
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			ingressIP := e2eservice.GetIngressPoint(
+				&svc.Status.LoadBalancer.Ingress[0])
+
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, node := range allNodes.Items {
+				l2Advertisement := metallbv1beta1.L2Advertisement{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "with-selector",
+					},
+					Spec: metallbv1beta1.L2AdvertisementSpec{
+						NodeSelectors: k8s.SelectorsForNodes([]v1.Node{node}),
+					},
+				}
+
+				ginkgo.By(fmt.Sprintf("Assigning the advertisement to node %s", node.Name))
+				resources := internalconfig.ClusterResources{
+					L2Advs: []metallbv1beta1.L2Advertisement{l2Advertisement},
+				}
+
+				err := ConfigUpdater.Update(resources)
+				framework.ExpectNoError(err)
+				gomega.Eventually(func() error {
+					return mac.RequestAddressResolution(ingressIP, executor.Host)
+				}, 30*time.Second, 1*time.Second).Should(gomega.Not(gomega.HaveOccurred()))
+
+				port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+				hostport := net.JoinHostPort(ingressIP, port)
+				address := fmt.Sprintf("http://%s/", hostport)
+
+				gomega.Eventually(func() string {
+					err = wget.Do(address, executor.Host)
+					framework.ExpectNoError(err)
+					advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
+					if err != nil {
+						return err.Error()
+					}
+					return advNode.Name
+				}, 30*time.Second, 1*time.Second).Should(gomega.Equal(node.Name))
+			}
+		})
+
+		ginkgo.It("should with multiple node selectors", func() {
+			// ETP = local, pin the endpoint to node0, have two l2 advertisements, one for
+			// all and one for node1, check node0 is advertised.
+			jig := e2eservice.NewTestJig(cs, f.Namespace.Name, "svca")
+			loadBalancerCreateTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
+			svc, err := jig.CreateLoadBalancerService(loadBalancerCreateTimeout, func(svc *corev1.Service) {
+				svc.Spec.Ports[0].TargetPort = intstr.FromInt(service.TestServicePort)
+				svc.Spec.Ports[0].Port = int32(service.TestServicePort)
+				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+			})
+			framework.ExpectNoError(err)
+
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			if len(allNodes.Items) < 2 {
+				ginkgo.Skip("Not enough nodes")
+			}
+			_, err = jig.Run(
+				func(rc *corev1.ReplicationController) {
+					rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", service.TestServicePort), fmt.Sprintf("--udp-port=%d", service.TestServicePort)}
+					rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(service.TestServicePort)
+					rc.Spec.Template.Spec.NodeName = allNodes.Items[0].Name
+				})
+			framework.ExpectNoError(err)
+
+			ingressIP := e2eservice.GetIngressPoint(
+				&svc.Status.LoadBalancer.Ingress[0])
+
+			l2Advertisements := []metallbv1beta1.L2Advertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "with-selector",
+					},
+					Spec: metallbv1beta1.L2AdvertisementSpec{
+						NodeSelectors: k8s.SelectorsForNodes([]v1.Node{allNodes.Items[1]}),
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "no-selector",
+					},
+				},
+			}
+
+			ginkgo.By("Creating the l2 advertisements")
+			resources := internalconfig.ClusterResources{
+				L2Advs: l2Advertisements,
+			}
+
+			err = ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+			gomega.Eventually(func() error {
+				return mac.RequestAddressResolution(ingressIP, executor.Host)
+			}, 2*time.Minute, 1*time.Second).Should(gomega.Not(gomega.HaveOccurred()))
+
+			ginkgo.By("checking connectivity to its external VIP")
+			port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+			hostport := net.JoinHostPort(ingressIP, port)
+			address := fmt.Sprintf("http://%s/", hostport)
+
+			gomega.Eventually(func() string {
+				err = wget.Do(address, executor.Host)
+				framework.ExpectNoError(err)
+
+				advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
+				if err != nil {
+					return err.Error()
+				}
+				return advNode.Name
+			}, 2*time.Minute, time.Second).Should(gomega.Equal(allNodes.Items[0].Name))
+		})
+	})
+})

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -68,6 +68,20 @@ func Routes(exec executor.Executor) (map[string]bgpfrr.Route, map[string]bgpfrr.
 	return v4Routes, v6Routes, nil
 }
 
+func RoutesForFamily(exec executor.Executor, family ipfamily.Family) (map[string]bgpfrr.Route, error) {
+	v4, v6, err := Routes(exec)
+	if err != nil {
+		return nil, err
+	}
+	switch family {
+	case ipfamily.IPv4:
+		return v4, nil
+	case ipfamily.IPv6:
+		return v6, nil
+	}
+	return nil, fmt.Errorf("unsupported ipfamily %v", family)
+}
+
 // RoutesForCommunity returns informations about routes in the given executor related to the given community.
 func RoutesForCommunity(exec executor.Executor, community string, family ipfamily.Family) (map[string]bgpfrr.Route, error) {
 	res, err := exec.Exec("vtysh", "-c", fmt.Sprintf("show bgp %s community %s json", family, community))

--- a/e2etest/pkg/k8s/nodes.go
+++ b/e2etest/pkg/k8s/nodes.go
@@ -7,6 +7,7 @@ import (
 
 	"go.universe.tf/metallb/internal/ipfamily"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NodeIPsForFamily(nodes []v1.Node, family ipfamily.Family) []string {
@@ -22,4 +23,25 @@ func NodeIPsForFamily(nodes []v1.Node, family ipfamily.Family) []string {
 		}
 	}
 	return res
+}
+
+func SelectorsForNodes(nodes []v1.Node) []metav1.LabelSelector {
+	selectors := []metav1.LabelSelector{}
+	if len(nodes) == 0 {
+		return []metav1.LabelSelector{
+			{
+				MatchLabels: map[string]string{
+					"non": "existent",
+				},
+			},
+		}
+	}
+	for _, node := range nodes {
+		selectors = append(selectors, metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"kubernetes.io/hostname": node.GetLabels()["kubernetes.io/hostname"],
+			},
+		})
+	}
+	return selectors
 }

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -38,3 +38,11 @@ func WithSpecificIPs(svc *corev1.Service, ips ...string) {
 		"metallb.universe.tf/loadBalancerIPs": strings.Join(ips, ","),
 	}
 }
+
+func WithSpecificPool(poolName string) func(*corev1.Service) {
+	return func(svc *corev1.Service) {
+		svc.Annotations = map[string]string{
+			"metallb.universe.tf/address-pool": poolName,
+		}
+	}
+}

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -50,7 +50,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	var addressPools metallbv1beta1.AddressPoolList
 	if err := r.List(ctx, &addressPools, client.InNamespace(r.Namespace)); err != nil {
-		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to get addresspools", "error", err)
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get addresspools", "error", err)
 		return ctrl.Result{}, err
 	}
 
@@ -62,25 +62,25 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	var bgpPeers metallbv1beta2.BGPPeerList
 	if err := r.List(ctx, &bgpPeers, client.InNamespace(r.Namespace)); err != nil {
-		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to get bgppeers", "error", err)
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get bgppeers", "error", err)
 		return ctrl.Result{}, err
 	}
 
 	var bfdProfiles metallbv1beta1.BFDProfileList
 	if err := r.List(ctx, &bfdProfiles, client.InNamespace(r.Namespace)); err != nil {
-		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to get bfdprofiles", "error", err)
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get bfdprofiles", "error", err)
 		return ctrl.Result{}, err
 	}
 
 	var l2Advertisements metallbv1beta1.L2AdvertisementList
 	if err := r.List(ctx, &l2Advertisements, client.InNamespace(r.Namespace)); err != nil {
-		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to get l2 advertisements", "error", err)
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get l2 advertisements", "error", err)
 		return ctrl.Result{}, err
 	}
 
 	var bgpAdvertisements metallbv1beta1.BGPAdvertisementList
 	if err := r.List(ctx, &bgpAdvertisements, client.InNamespace(r.Namespace)); err != nil {
-		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to get bgp advertisements", "error", err)
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get bgp advertisements", "error", err)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/k8s/controllers/pool_controller.go
+++ b/internal/k8s/controllers/pool_controller.go
@@ -1,0 +1,97 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	"go.universe.tf/metallb/internal/config"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type PoolReconciler struct {
+	client.Client
+	Logger         log.Logger
+	Scheme         *runtime.Scheme
+	Namespace      string
+	Handler        func(log.Logger, map[string]*config.Pool) SyncState
+	ValidateConfig config.Validate
+	ForceReload    func()
+}
+
+func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	level.Info(r.Logger).Log("controller", "PoolReconciler", "start reconcile", req.NamespacedName.String())
+	defer level.Info(r.Logger).Log("controller", "PoolReconciler", "end reconcile", req.NamespacedName.String())
+
+	var addressPools metallbv1beta1.AddressPoolList
+	if err := r.List(ctx, &addressPools, client.InNamespace(r.Namespace)); err != nil {
+		level.Error(r.Logger).Log("controller", "PoolReconciler", "message", "failed to get addresspools", "error", err)
+		return ctrl.Result{}, err
+	}
+
+	var ipAddressPools metallbv1beta1.IPAddressPoolList
+	if err := r.List(ctx, &ipAddressPools, client.InNamespace(r.Namespace)); err != nil {
+		level.Error(r.Logger).Log("controller", "PoolReconciler", "message", "failed to get ipaddresspools", "error", err)
+		return ctrl.Result{}, err
+	}
+
+	resources := config.ClusterResources{
+		Pools:              ipAddressPools.Items,
+		LegacyAddressPools: addressPools.Items,
+	}
+
+	level.Debug(r.Logger).Log("controller", "PoolReconciler", "metallb CRs", spew.Sdump(resources))
+
+	cfg, err := config.For(resources, r.ValidateConfig)
+	if err != nil {
+		level.Error(r.Logger).Log("controller", "PoolReconciler", "error", "failed to parse the configuration", "error", err)
+		return ctrl.Result{}, nil
+	}
+
+	level.Debug(r.Logger).Log("controller", "PoolReconciler", "rendered config", spew.Sdump(cfg))
+
+	res := r.Handler(r.Logger, cfg.Pools)
+	switch res {
+	case SyncStateError:
+		level.Error(r.Logger).Log("controller", "PoolReconciler", "metallb CRs and Secrets", spew.Sdump(resources), "event", "reload failed, retry")
+		return ctrl.Result{}, retryError
+	case SyncStateReprocessAll:
+		level.Info(r.Logger).Log("controller", "PoolReconciler", "event", "force service reload")
+		r.ForceReload()
+	case SyncStateErrorNoRetry:
+		level.Error(r.Logger).Log("controller", "PoolReconciler", "metallb CRs and Secrets", spew.Sdump(resources), "event", "reload failed, no retry")
+		return ctrl.Result{}, nil
+	}
+
+	level.Info(r.Logger).Log("controller", "PoolReconciler", "event", "config reloaded")
+	return ctrl.Result{}, nil
+}
+
+func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&metallbv1beta1.IPAddressPool{}).
+		Watches(&source.Kind{Type: &metallbv1beta1.AddressPool{}}, &handler.EnqueueRequestForObject{}).
+		Complete(r)
+}

--- a/internal/k8s/controllers/service_controller.go
+++ b/internal/k8s/controllers/service_controller.go
@@ -54,13 +54,13 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	service, err := r.serviceFor(ctx, req.NamespacedName)
 	if err != nil {
-		level.Error(r.Logger).Log("controller", "ServiceReconciler", "error", "failed to get service", "service", req.NamespacedName, "error", err)
+		level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "failed to get service", "service", req.NamespacedName, "error", err)
 		return ctrl.Result{}, err
 	}
 
 	epSlices, err := epsOrSlicesForServices(ctx, r, req.NamespacedName, r.Endpoints)
 	if err != nil {
-		level.Error(r.Logger).Log("controller", "ServiceReconciler", "error", "failed to get endpoints", "service", req.NamespacedName, "error", err)
+		level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "failed to get endpoints", "service", req.NamespacedName, "error", err)
 		return ctrl.Result{}, err
 	}
 	if service != nil {
@@ -98,7 +98,7 @@ func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}
 					serviceName, err := epslices.ServiceKeyForSlice(epSlice)
 					if err != nil {
-						level.Error(r.Logger).Log("controller", "ServiceReconciler", "error", "failed to get serviceName for slice", "error", err, "epslice", epSlice.Name)
+						level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "failed to get serviceName for slice", "error", err, "epslice", epSlice.Name)
 						return []reconcile.Request{}
 					}
 					level.Debug(r.Logger).Log("controller", "ServiceReconciler", "enqueueing", serviceName, "epslice", dumpResource(epSlice))

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -169,6 +169,21 @@ func New(cfg *Config) (*Client, error) {
 		}
 	}
 
+	if cfg.PoolChanged != nil {
+		if err = (&controllers.PoolReconciler{
+			Client:         mgr.GetClient(),
+			Logger:         cfg.Logger,
+			Scheme:         mgr.GetScheme(),
+			Namespace:      cfg.Namespace,
+			ValidateConfig: cfg.ValidateConfig,
+			Handler:        cfg.PoolHandler,
+			ForceReload:    reload,
+		}).SetupWithManager(mgr); err != nil {
+			level.Error(c.logger).Log("error", err, "unable to create controller", "config")
+			return nil, errors.Wrap(err, "failed to create config reconciler")
+		}
+	}
+
 	if cfg.NodeChanged != nil {
 		if err = (&controllers.NodeReconciler{
 			Client:   mgr.GetClient(),

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -171,10 +171,11 @@ func New(cfg *Config) (*Client, error) {
 
 	if cfg.NodeChanged != nil {
 		if err = (&controllers.NodeReconciler{
-			Client:  mgr.GetClient(),
-			Logger:  cfg.Logger,
-			Scheme:  mgr.GetScheme(),
-			Handler: cfg.NodeHandler,
+			Client:   mgr.GetClient(),
+			Logger:   cfg.Logger,
+			Scheme:   mgr.GetScheme(),
+			Handler:  cfg.NodeHandler,
+			NodeName: cfg.NodeName,
 		}).SetupWithManager(mgr); err != nil {
 			level.Error(c.logger).Log("error", err, "unable to create controller", "node")
 			return nil, errors.Wrap(err, "failed to create node reconciler")

--- a/internal/k8s/listener.go
+++ b/internal/k8s/listener.go
@@ -24,6 +24,7 @@ func (l *Listener) ServiceHandler(logger log.Logger, serviceName string, svc *v1
 	defer l.Unlock()
 	return l.ServiceChanged(logger, serviceName, svc, endpointsOrSlices)
 }
+
 func (l *Listener) ConfigHandler(logger log.Logger, config *config.Config) controllers.SyncState {
 	l.Lock()
 	defer l.Unlock()

--- a/internal/k8s/listener.go
+++ b/internal/k8s/listener.go
@@ -16,6 +16,7 @@ type Listener struct {
 	sync.Mutex
 	ServiceChanged func(log.Logger, string, *v1.Service, epslices.EpsOrSlices) controllers.SyncState
 	ConfigChanged  func(log.Logger, *config.Config) controllers.SyncState
+	PoolChanged    func(log.Logger, map[string]*config.Pool) controllers.SyncState
 	NodeChanged    func(log.Logger, *v1.Node) controllers.SyncState
 }
 
@@ -35,4 +36,10 @@ func (l *Listener) NodeHandler(logger log.Logger, node *v1.Node) controllers.Syn
 	l.Lock()
 	defer l.Unlock()
 	return l.NodeChanged(logger, node)
+}
+
+func (l *Listener) PoolHandler(logger log.Logger, pools map[string]*config.Pool) controllers.SyncState {
+	l.Lock()
+	defer l.Unlock()
+	return l.PoolChanged(logger, pools)
 }

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -316,14 +316,7 @@ func (c *controller) handleService(l log.Logger,
 		return c.deleteBalancerProtocol(l, protocol, name, "internalError")
 	}
 
-	if !handler.PoolEnabledForProtocol(pool) {
-		if c.announced[protocol][name] {
-			return c.deleteBalancerProtocol(l, protocol, name, "protocol disabled")
-		}
-		return controllers.SyncStateSuccess
-	}
-
-	if deleteReason := handler.ShouldAnnounce(l, name, lbIPs, svc, eps); deleteReason != "" {
+	if deleteReason := handler.ShouldAnnounce(l, name, lbIPs, pool, svc, eps); deleteReason != "" {
 		return c.deleteBalancerProtocol(l, protocol, name, deleteReason)
 	}
 
@@ -475,11 +468,10 @@ func (c *controller) SetNode(l log.Logger, node *v1.Node) controllers.SyncState 
 // A Protocol can advertise an IP address.
 type Protocol interface {
 	SetConfig(log.Logger, *config.Config) error
-	ShouldAnnounce(log.Logger, string, []net.IP, *v1.Service, epslices.EpsOrSlices) string
+	ShouldAnnounce(log.Logger, string, []net.IP, *config.Pool, *v1.Service, epslices.EpsOrSlices) string
 	SetBalancer(log.Logger, string, []net.IP, *config.Pool) error
 	DeleteBalancer(log.Logger, string, string) error
 	SetNode(log.Logger, *v1.Node) error
-	PoolEnabledForProtocol(pool *config.Pool) bool
 }
 
 // Speakerlist represents a list of healthy speakers.

--- a/tasks.py
+++ b/tasks.py
@@ -745,7 +745,7 @@ def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="k
         ips_for_containers_v6 = "--ips-for-containers-v6=" + ips
 
     testrun = run("cd `git rev-parse --show-toplevel`/e2etest &&"
-            "KUBECONFIG={} go test -timeout 1h {} {} --provider=local --kubeconfig={} --service-pod-port={} {} {} -ipv4-service-range={} -ipv6-service-range={} {}".format(kubeconfig, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ips_for_containers_v4, ips_for_containers_v6, ipv4_service_range, ipv6_service_range, opt_skip_docker), warn="True")
+            "KUBECONFIG={} go test -timeout 2h {} {} --provider=local --kubeconfig={} --service-pod-port={} {} {} -ipv4-service-range={} -ipv6-service-range={} {}".format(kubeconfig, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ips_for_containers_v4, ips_for_containers_v6, ipv4_service_range, ipv6_service_range, opt_skip_docker), warn="True")
 
     if export != None:
         run("kind export logs {}".format(export))


### PR DESCRIPTION
As described in https://github.com/metallb/metallb/blob/main/design/pool-configuration.md , we add a node selector to both the L2 advertisement and the BGP advertisement.

The semantic is, if the selector is present we should advertise only from the nodes selected by the selector. An empty selector is interpreted as willing to select all the nodes.