### PR TITLE
Fix SetPools function

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -854,7 +854,7 @@ func TestControllerConfig(t *testing.T) {
 	}
 
 	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetPools(l, map[string]*config.Pool{}) == controllers.SyncStateError {
+	if c.SetPools(l, map[string]*config.Pool{}) != controllers.SyncStateError {
 		t.Fatalf("SetPools that deletes allocated IPs was accepted")
 	}
 
@@ -1007,7 +1007,7 @@ func TestControllerDualStackConfig(t *testing.T) {
 	}
 
 	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetPools(l, map[string]*config.Pool{}) != controllers.SyncStateErrorNoRetry {
+	if c.SetPools(l, map[string]*config.Pool{}) != controllers.SyncStateError {
 		t.Fatalf("SetPools that deletes allocated IPs was accepted")
 	}
 

--- a/controller/main.go
+++ b/controller/main.go
@@ -102,7 +102,7 @@ func (c *controller) SetPools(l log.Logger, pools map[string]*config.Pool) contr
 	level.Debug(l).Log("event", "startUpdate", "msg", "start of config update")
 	defer level.Debug(l).Log("event", "endUpdate", "msg", "end of config update")
 
-	if len(pools) == 0 {
+	if pools == nil {
 		level.Error(l).Log("op", "setConfig", "error", "no MetalLB configuration in cluster", "msg", "configuration is missing, MetalLB will not function")
 		return controllers.SyncStateErrorNoRetry
 	}


### PR DESCRIPTION
SetPools might be called with no pools,
e.g. when a user deletes the last ipaddresspool,

This commit fixes the if statement, as it's supposed  to
check if the pools parameter is nil, not if it's empty.

Added the check if pools is not empty before
calling c.ips.SetPools(pools)

And removed a test assertion that expects calling SetPools
with empty Pools to return SyncStateErrorNoRetry.

fix #1330 