### PR TITLE
CI: Re-enable E2E operator lane

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,78 +212,87 @@ jobs:
         with:
           name: kind-logs-backward-compatible
           path: /tmp/kind_logs/
-#  e2e-use-operator:
-#    runs-on: ubuntu-20.04
-#    defaults:
-#      run:
-#        shell: bash
-#        working-directory: metallb
-#    strategy:
-#      fail-fast: false
-#    steps:
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.9.1
-#        with:
-#          access_token: ${{ github.token }}
-#
-#      - name: Checkout Metal LB Operator
-#        uses: actions/checkout@v2
-#        with:
-#          repository: metallb/metallb-operator
-#          path: metallboperator
-#          ref: e84470bf3644e6444169abb65483bb1a60c957af
-#
-#      - uses: actions/setup-go@v2
-#        with:
-#          go-version: '1.17.1'
-#
-#      - name: Checkout MetalLB
-#        uses: actions/checkout@v2
-#        with:
-#          path: metallb
-#          fetch-depth: 0
-#
-#      - name: Install Dependencies
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install python3-pip arping ndisc6
-#          sudo pip3 install -r ./dev-env/requirements.txt
-#          GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
-#
-#      - name: Build MetalLB Images
-#        run: |
-#          inv build
-#
-#      - name: Create multi-node K8s Kind Cluster
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/metallboperator
-#          ./hack/kind-multi-node-cluster-without-registry.sh
-#          kind load docker-image quay.io/metallb/speaker:dev-amd64
-#          kind load docker-image quay.io/metallb/controller:dev-amd64
-#          export KUBECONFIG=${HOME}/.kube/config
-#
-#      - name: Deploy Metal LB Operator
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/metallboperator
-#          sed -i 's/quay.io\/metallb\/speaker:main/quay.io\/metallb\/speaker:dev-amd64/g' bin/metallb-operator-with-webhooks.yaml
-#          sed -i 's/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:dev-amd64/g' bin/metallb-operator-with-webhooks.yaml
-#          sed -i 's/native/frr/g' bin/metallb-operator-with-webhooks.yaml
-#          make deploy-cert-manager
-#          kubectl apply -f bin/metallb-operator-with-webhooks.yaml
-#
-#      - name: MetalLB E2E Tests with Operator Deployment
-#        run: |
-#          kubectl apply -f ${GITHUB_WORKSPACE}/metallboperator/config/samples/metallb.yaml
-#          sudo -E env "PATH=$PATH" inv e2etest --skip "IPV6|DUALSTACK" -e /tmp/kind_logs --use-operator
-#
-#      - name: Change permissions for kind logs
-#        if: ${{ failure() }}
-#        run: |
-#          sudo chmod -R o+r /tmp/kind_logs
-#
-#      - name: Archive kind logs
-#        if: ${{ failure() }}
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: kind_logs_use_operator
-#          path: /tmp/kind_logs
+
+  e2e-use-operator:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: metallb
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout Metal LB Operator
+        uses: actions/checkout@v2
+        with:
+          repository: metallb/metallb-operator
+          path: metallboperator
+          ref: f0a89e03bc4963ef021b02e858fe3ce78dcf6b41
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.1'
+
+      - name: Checkout MetalLB
+        uses: actions/checkout@v2
+        with:
+          path: metallb
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-pip arping ndisc6
+          sudo pip3 install -r ./dev-env/requirements.txt
+          GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
+
+      - name: Build MetalLB Images
+        run: |
+          inv build
+
+      - name: Create multi-node K8s Kind Cluster
+        run: |
+          cd ${GITHUB_WORKSPACE}/metallboperator
+          ./hack/kind-multi-node-cluster-without-registry.sh
+          kind load docker-image quay.io/metallb/speaker:dev-amd64
+          kind load docker-image quay.io/metallb/controller:dev-amd64
+          export KUBECONFIG=${HOME}/.kube/config
+
+      - name: Deploy Metal LB Operator
+        run: |
+          cd ${GITHUB_WORKSPACE}/metallboperator
+          sed -i 's/quay.io\/metallb\/speaker:main/quay.io\/metallb\/speaker:dev-amd64/g' bin/metallb-operator-with-webhooks.yaml
+          sed -i 's/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:dev-amd64/g' bin/metallb-operator-with-webhooks.yaml
+          sed -i 's/native/frr/g' bin/metallb-operator-with-webhooks.yaml
+          make deploy-cert-manager
+          kubectl apply -f bin/metallb-operator-with-webhooks.yaml
+
+      - name: MetalLB E2E Tests with Operator Deployment
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: metallb.io/v1beta1
+          kind: MetalLB
+          metadata:
+            name: metallb
+            namespace: metallb-system
+          spec:
+            logLevel: debug
+          EOF
+          sudo -E env "PATH=$PATH" inv e2etest --skip "IPV6|DUALSTACK" -e /tmp/kind_logs
+
+      - name: Change permissions for kind logs
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R o+r /tmp/kind_logs
+
+      - name: Archive kind logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind_logs_use_operator
+          path: /tmp/kind_logs

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -104,7 +104,6 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.tolerateMaster | bool | `true` |  |
 | speaker.tolerations | list | `[]` |  |
 | speaker.frr.enabled | bool | `true` |  |
-| speaker.frr.logLevel | string | `"informational"` | FRR process log level. Must be one of: `informational`, `warning`, `errors` or `debugging` |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `v7.5.1` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -227,8 +227,6 @@ spec:
           value: /etc/frr_reloader/reloader.pid
         - name: METALLB_BGP_TYPE
           value: frr
-        - name: FRR_LOGGING_LEVEL
-          value: {{ .Values.speaker.frr.logLevel }}
         {{- end }}
         ports:
         - name: monitoring

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -310,10 +310,6 @@
                 "enabled": {
                   "type": "boolean"
                 },
-                "logLevel": {
-                  "type": "string",
-                  "enum": [ "informational", "warning", "errors", "debugging" ]
-                },
                 "image": { "$ref": "#/definitions/component/properties/image" }
               },
               "required": [ "enabled" ]

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -220,10 +220,6 @@ speaker:
   # for speaker running alongside FRR.
   frr:
     enabled: false
-    # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
-    # Possible settings are :-
-    #  informational, warning, errors and debugging.
-    logLevel: informational
     image:
       repository: quay.io/frrouting/frr
       tag: stable_7.5

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -111,11 +111,6 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
-            # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
-            # Possible settings are :-
-            #  informational, warning, errors and debugging.
-            - name: FRR_LOGGING_LEVEL
-              value: informational
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -1737,8 +1737,6 @@ spec:
           value: /etc/frr_reloader/reloader.pid
         - name: METALLB_BGP_TYPE
           value: frr
-        - name: FRR_LOGGING_LEVEL
-          value: informational
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1688,8 +1688,6 @@ spec:
           value: /etc/frr_reloader/reloader.pid
         - name: METALLB_BGP_TYPE
           value: frr
-        - name: FRR_LOGGING_LEVEL
-          value: informational
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1546,7 +1546,7 @@ var _ = ginkgo.Describe("BGP", func() {
 					return cfgStr
 				}, 1*time.Minute).Should(
 					And(
-						ContainSubstring("log file /etc/frr/frr.log informational"),
+						ContainSubstring("log file /etc/frr/frr.log"),
 						WithTransform(substringCount("\n profile fullbfdprofile1"), Equal(1)),
 						ContainSubstring("receive-interval 93"),
 						ContainSubstring("transmit-interval 95"),


### PR DESCRIPTION
re-enabling the E2E lane that ensures MetalLB is working fine when its deployed via operator.
