### PR TITLE
Specify the interface list that the speaker uses to announce Service IP

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type configFile struct {
 	BGPCommunities map[string]string `yaml:"bgp-communities"`
 	Pools          []addressPool     `yaml:"address-pools"`
 	BFDProfiles    []bfdProfile      `yaml:"bfd-profiles"`
+	BindInterfaces []string          `yaml:"bind-interfaces"`
 }
 
 type peer struct {
@@ -100,6 +101,8 @@ type Config struct {
 	Pools map[string]*Pool
 	// BFD profiles that can be used by peers.
 	BFDProfiles map[string]*BFDProfile
+	// Interfaces used to announce IP for layer2
+	BindInterfaces []string
 }
 
 // Proto holds the protocol we are speaking.
@@ -257,8 +260,9 @@ func Parse(bs []byte, validate Validate) (*Config, error) {
 	}
 
 	cfg := &Config{
-		Pools:       map[string]*Pool{},
-		BFDProfiles: map[string]*BFDProfile{},
+		Pools:          map[string]*Pool{},
+		BFDProfiles:    map[string]*BFDProfile{},
+		BindInterfaces: []string{},
 	}
 
 	for i, bfd := range raw.BFDProfiles {
@@ -326,6 +330,9 @@ func Parse(bs []byte, validate Validate) (*Config, error) {
 		}
 
 		cfg.Pools[p.Name] = pool
+	}
+	if len(raw.BindInterfaces) > 0 {
+		cfg.BindInterfaces = raw.BindInterfaces
 	}
 
 	return cfg, nil

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -33,7 +33,12 @@ type layer2Controller struct {
 	sList     SpeakerList
 }
 
-func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
+func (c *layer2Controller) SetConfig(l log.Logger, cfg *config.Config) error {
+	if !c.announcer.BindInterfacesNeedUpdate(cfg.BindInterfaces) {
+		return nil
+	}
+	c.announcer.SetBindInterfaces(cfg.BindInterfaces)
+	c.announcer.UpdateInterfaces()
 	return nil
 }
 


### PR DESCRIPTION

 Use ConfigMap to specify the interface list that the speaker uses to announce Service IP for layer2.

ConfigMap data add properties 'bind-interfaces', it specifies the interface list to announce IP. If users don't config 'bind-interface', Speaker announces Service IP from all interfaces.

When ConfigMap change, update properties 'bindInterface' of struct 'Announce'. It will update ARP and NDP responders.

