### PR TITLE
API: remove yaml marshalling names

### DIFF
--- a/api/v1alpha1/addresspool_types.go
+++ b/api/v1alpha1/addresspool_types.go
@@ -25,20 +25,20 @@ type BgpAdvertisement struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=32
 	// +optional
-	AggregationLength *int32 `json:"aggregationLength,omitempty" yaml:"aggregation-length,omitempty"`
+	AggregationLength *int32 `json:"aggregationLength,omitempty"`
 
 	// Optional, defaults to 128 (i.e. no aggregation) if not
 	// specified.
 	// +kubebuilder:default:=128
 	// +optional
-	AggregationLengthV6 *int32 `json:"aggregationLengthV6,omitempty" yaml:"aggregation-length-v6,omitempty"`
+	AggregationLengthV6 *int32 `json:"aggregationLengthV6,omitempty"`
 
 	// BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
 	// Path with higher localpref is preferred over one with lower localpref.
-	LocalPref uint32 `json:"localPref,omitempty" yaml:"localpref,omitempty"`
+	LocalPref uint32 `json:"localPref,omitempty"`
 
 	// BGP communities
-	Communities []string `json:"communities,omitempty" yaml:"communities,omitempty"`
+	Communities []string `json:"communities,omitempty"`
 }
 
 // AddressPoolSpec defines the desired state of AddressPool.
@@ -57,12 +57,12 @@ type AddressPoolSpec struct {
 	// for a pool.
 	// +optional
 	// +kubebuilder:default:=true
-	AutoAssign *bool `json:"autoAssign,omitempty" yaml:"auto-assign,omitempty"`
+	AutoAssign *bool `json:"autoAssign,omitempty"`
 
 	// When an IP is allocated from this pool, how should it be
 	// translated into BGP announcements?
 	// +optional
-	BGPAdvertisements []BgpAdvertisement `json:"bgpAdvertisements,omitempty" yaml:"bgp-advertisements,omitempty"`
+	BGPAdvertisements []BgpAdvertisement `json:"bgpAdvertisements,omitempty"`
 }
 
 // AddressPoolStatus defines the observed state of AddressPool.

--- a/api/v1beta1/addresspool_types.go
+++ b/api/v1beta1/addresspool_types.go
@@ -25,20 +25,20 @@ type LegacyBgpAdvertisement struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=32
 	// +optional
-	AggregationLength *int32 `json:"aggregationLength,omitempty" yaml:"aggregation-length,omitempty"`
+	AggregationLength *int32 `json:"aggregationLength,omitempty"`
 
 	// Optional, defaults to 128 (i.e. no aggregation) if not
 	// specified.
 	// +kubebuilder:default:=128
 	// +optional
-	AggregationLengthV6 *int32 `json:"aggregationLengthV6,omitempty" yaml:"aggregation-length-v6,omitempty"`
+	AggregationLengthV6 *int32 `json:"aggregationLengthV6,omitempty"`
 
 	// BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
 	// Path with higher localpref is preferred over one with lower localpref.
-	LocalPref uint32 `json:"localPref,omitempty" yaml:"localpref,omitempty"`
+	LocalPref uint32 `json:"localPref,omitempty"`
 
 	// BGP communities to be associated with the given advertisement.
-	Communities []string `json:"communities,omitempty" yaml:"communities,omitempty"`
+	Communities []string `json:"communities,omitempty"`
 }
 
 // AddressPoolSpec defines the desired state of AddressPool.
@@ -68,7 +68,7 @@ type AddressPoolSpec struct {
 	// Drives how an IP allocated from this pool should
 	// translated into BGP announcements.
 	// +optional
-	BGPAdvertisements []LegacyBgpAdvertisement `json:"bgpAdvertisements,omitempty" yaml:"bgp-advertisements,omitempty"`
+	BGPAdvertisements []LegacyBgpAdvertisement `json:"bgpAdvertisements,omitempty"`
 }
 
 // AddressPoolStatus defines the observed state of AddressPool.

--- a/api/v1beta1/bgpadvertisement_types.go
+++ b/api/v1beta1/bgpadvertisement_types.go
@@ -53,11 +53,11 @@ type BGPAdvertisementSpec struct {
 	// A selector for the IPAddressPools which would get advertised via this advertisement.
 	// If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
 	// +optional
-	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty" yaml:"ipaddress-pool-selectors,omitempty"`
+	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty"`
 
 	// NodeSelectors allows to limit the nodes to announce as next hops for the LoadBalancer IP. When empty, all the nodes having  are announced as next hops.
 	// +optional
-	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
+	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
 
 	// Peers limits the bgppeer to advertise the ips of the selected pools to.
 	// When empty, the loadbalancer IP is announced to all the BGPPeers configured.

--- a/api/v1beta1/bgppeer_types.go
+++ b/api/v1beta1/bgppeer_types.go
@@ -21,18 +21,18 @@ import (
 )
 
 type MatchExpression struct {
-	Key      string `json:"key" yaml:"key"`
-	Operator string `json:"operator" yaml:"operator"`
+	Key      string `json:"key"`
+	Operator string `json:"operator"`
 	// +kubebuilder:validation:MinItems:=1
-	Values []string `json:"values" yaml:"values"`
+	Values []string `json:"values"`
 }
 
 type NodeSelector struct {
 	// +optional
-	MatchLabels map[string]string `json:"matchLabels,omitempty" yaml:"match-labels,omitempty"`
+	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 
 	// +optional
-	MatchExpressions []MatchExpression `json:"matchExpressions,omitempty" yaml:"match-expressions,omitempty"`
+	MatchExpressions []MatchExpression `json:"matchExpressions,omitempty"`
 }
 
 // BGPPeerSpec defines the desired state of Peer.
@@ -40,51 +40,51 @@ type BGPPeerSpec struct {
 	// AS number to use for the local end of the session.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
-	MyASN uint32 `json:"myASN" yaml:"my-asn"`
+	MyASN uint32 `json:"myASN"`
 
 	// AS number to expect from the remote end of the session.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
-	ASN uint32 `json:"peerASN" yaml:"peer-asn"`
+	ASN uint32 `json:"peerASN"`
 
 	// Address to dial when establishing the session.
-	Address string `json:"peerAddress" yaml:"peer-address"`
+	Address string `json:"peerAddress"`
 
 	// Source address to use when establishing the session.
 	// +optional
-	SrcAddress string `json:"sourceAddress,omitempty" yaml:"source-address,omitempty"`
+	SrcAddress string `json:"sourceAddress,omitempty"`
 
 	// Port to dial when establishing the session.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=16384
-	Port uint16 `json:"peerPort,omitempty" yaml:"peer-port,omitempty"`
+	Port uint16 `json:"peerPort,omitempty"`
 
 	// Requested BGP hold time, per RFC4271.
 	// +optional
-	HoldTime metav1.Duration `json:"holdTime,omitempty" yaml:"hold-time,omitempty"`
+	HoldTime metav1.Duration `json:"holdTime,omitempty"`
 
 	// Requested BGP keepalive time, per RFC4271.
 	// +optional
-	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty" yaml:"keepalive-time,omitempty"`
+	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty"`
 
 	// BGP router ID to advertise to the peer
 	// +optional
-	RouterID string `json:"routerID,omitempty" yaml:"router-id,omitempty"`
+	RouterID string `json:"routerID,omitempty"`
 
 	// Only connect to this peer on nodes that match one of these
 	// selectors.
 	// +optional
-	NodeSelectors []NodeSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
+	NodeSelectors []NodeSelector `json:"nodeSelectors,omitempty"`
 
 	// Authentication password for routers enforcing TCP MD5 authenticated sessions
 	// +optional
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	Password string `json:"password,omitempty"`
 
-	BFDProfile string `json:"bfdProfile,omitempty" yaml:"bfdprofile,omitempty"`
+	BFDProfile string `json:"bfdProfile,omitempty"`
 
 	// EBGP peer is multi-hops away
-	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty" yaml:"ebgp-multihop,omitempty"`
+	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty"`
 	// Add future BGP configuration here
 }
 

--- a/api/v1beta1/l2advertisement_types.go
+++ b/api/v1beta1/l2advertisement_types.go
@@ -31,10 +31,10 @@ type L2AdvertisementSpec struct {
 	// A selector for the IPAddressPools which would get advertised via this advertisement.
 	// If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
 	// +optional
-	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty" yaml:"ipaddress-pool-selectors,omitempty"`
+	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty"`
 	// NodeSelectors allows to limit the nodes to announce as next hops for the LoadBalancer IP. When empty, all the nodes having  are announced as next hops.
 	// +optional
-	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
+	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
 }
 
 // L2AdvertisementStatus defines the observed state of L2Advertisement.

--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -26,59 +26,59 @@ type BGPPeerSpec struct {
 	// AS number to use for the local end of the session.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
-	MyASN uint32 `json:"myASN" yaml:"my-asn"`
+	MyASN uint32 `json:"myASN"`
 
 	// AS number to expect from the remote end of the session.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
-	ASN uint32 `json:"peerASN" yaml:"peer-asn"`
+	ASN uint32 `json:"peerASN"`
 
 	// Address to dial when establishing the session.
-	Address string `json:"peerAddress" yaml:"peer-address"`
+	Address string `json:"peerAddress"`
 
 	// Source address to use when establishing the session.
 	// +optional
-	SrcAddress string `json:"sourceAddress,omitempty" yaml:"source-address,omitempty"`
+	SrcAddress string `json:"sourceAddress,omitempty"`
 
 	// Port to dial when establishing the session.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=16384
 	// +kubebuilder:default:=179
-	Port uint16 `json:"peerPort,omitempty" yaml:"peer-port,omitempty"`
+	Port uint16 `json:"peerPort,omitempty"`
 
 	// Requested BGP hold time, per RFC4271.
 	// +optional
-	HoldTime metav1.Duration `json:"holdTime,omitempty" yaml:"hold-time,omitempty"`
+	HoldTime metav1.Duration `json:"holdTime,omitempty"`
 
 	// Requested BGP keepalive time, per RFC4271.
 	// +optional
-	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty" yaml:"keepalive-time,omitempty"`
+	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty"`
 
 	// BGP router ID to advertise to the peer
 	// +optional
-	RouterID string `json:"routerID,omitempty" yaml:"router-id,omitempty"`
+	RouterID string `json:"routerID,omitempty"`
 
 	// Only connect to this peer on nodes that match one of these
 	// selectors.
 	// +optional
-	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty" yaml:"node-selectors,omitempty"`
+	NodeSelectors []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
 
 	// Authentication password for routers enforcing TCP MD5 authenticated sessions
 	// +optional
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	Password string `json:"password,omitempty"`
 
 	// passwordSecret is name of the authentication secret for BGP Peer
 	// +optional
-	PasswordSecret v1.SecretReference `json:"passwordSecret,omitempty" yaml:"passwordSecret,omitempty"`
+	PasswordSecret v1.SecretReference `json:"passwordSecret,omitempty"`
 
 	// The name of the BFD Profile to be used for the BFD session associated to the BGP session. If not set, the BFD session won't be set up.
 	// +optional
-	BFDProfile string `json:"bfdProfile,omitempty" yaml:"bfdprofile,omitempty"`
+	BFDProfile string `json:"bfdProfile,omitempty"`
 
 	// To set if the BGPPeer is multi-hops away. Needed for FRR mode only.
 	// +optional
-	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty" yaml:"ebgp-multihop,omitempty"`
+	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty"`
 	// Add future BGP configuration here
 }
 


### PR DESCRIPTION
The yaml names are a legacy of the initial implementation of the
operator, which was leveraging them to render the configmap. They are
not needed anymore.