### PR TITLE
Change logger output

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -67,7 +67,15 @@ func Init(lvl string) (log.Logger, error) {
 		return nil, err
 	}
 
-	return level.NewFilter(log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller), opt), nil
+	timeStampValuer := log.TimestampFormat(time.Now, time.RFC3339)
+	l = log.With(l, "ts", timeStampValuer)
+	l = level.NewFilter(l, opt)
+
+	// Note: caller must be added after everything else that decorates the
+	// logger (otherwise we get incorrect caller reference).
+	l = log.With(l, "caller", log.DefaultCaller)
+
+	return l, nil
 }
 
 func collectGlogs(f *os.File, logger log.Logger) {


### PR DESCRIPTION
Currently, the logger is always referencing "level.go:63" as the caller.
Also, it is printing the nanosecond with each timestamp
making the logs noisy.

This commit fixes those issues.
fix #1324

Before:
```
{"caller":"level.go:63","controller":"ConfigReconciler","level":"info","start reconcile":"/kind-worker2","ts":"2022-05-01T15:19:34.80207407Z"}
{"caller":"level.go:63","controller":"ServiceReconciler - reprocessAll","level":"info","start reconcile":"metallbreload/reload","ts":"2022-05-01T15:19:34.802084883Z"}
{"caller":"level.go:63","controller":"ConfigReconciler","event":"force service reload","level":"info","ts":"2022-05-01T15:19:34.802192555Z"}
{"caller":"level.go:63","controller":"ConfigReconciler","event":"config reloaded","level":"info","ts":"2022-05-01T15:19:34.802207787Z"}
{"caller":"level.go:63","controller":"ConfigReconciler","end reconcile":"/kind-worker2","level":"info","ts":"2022-05-01T15:19:34.802215278Z"}
{"caller":"level.go:63","controller":"ConfigReconciler","level":"info","start reconcile":"/kind-worker","ts":"2022-05-01T15:19:34.8022348Z"}
{"caller":"level.go:63","controller":"ServiceReconciler - reprocessAll","end reconcile":"metallbreload/reload","level":"info","ts":"2022-05-01T15:19:34.802268998Z"}

```
After:
```
{"caller":"node_controller.go:42","controller":"NodeReconciler","level":"info","start reconcile":"/kind-worker2","ts":"2022-05-01T15:39:11Z"}
{"caller":"bgp_controller.go:330","event":"nodeLabelsChanged","level":"info","msg":"Node labels changed, resyncing BGP peers","ts":"2022-05-01T15:39:11Z"}
{"caller":"speakerlist.go:271","level":"info","msg":"triggering discovery","op":"memberDiscovery","ts":"2022-05-01T15:39:11Z"}
{"caller":"config_controller.go:48","controller":"ConfigReconciler","level":"info","start reconcile":"metallb-system/memberlist","ts":"2022-05-01T15:39:11Z"}
{"caller":"node_controller.go:61","controller":"NodeReconciler","end reconcile":"/kind-worker2","level":"info","ts":"2022-05-01T15:39:11Z"}
{"caller":"service_controller_reload.go:98","controller":"ServiceReconciler - reprocessAll","end reconcile":"metallbreload/reload","level":"info","ts":"2022-05-01T15:39:11Z"}
```