### PR TITLE
Remove myself as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # The MetalLB maintainers team
-*   @fedepaol @johananl @rata @russellb
+*   @fedepaol @johananl @russellb
 
 # Emeritus Maintainers
 #
@@ -11,3 +11,4 @@
 #
 # - danderson  # Creator of MetalLB
 # - daxmc99
+# - rata

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ prefer private disclosure, please email to all of the maintainers:
 
 - fpaoline@redhat.com
 - rbryant@redhat.com
-- rodrigoca@microsoft.com
 - jliebermann@microsoft.com
 
 We aim for initial response to vulnerability reports within 48

--- a/website/content/community/code-of-conduct.md
+++ b/website/content/community/code-of-conduct.md
@@ -58,12 +58,12 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Rodrigo Campos at rodrigocc@gmail.com and Dax McDonald
-at daxmc99@gmail.com (please mail both addresses). All complaints will be
-reviewed and investigated and will result in a response that is deemed
-necessary and appropriate to the circumstances. The project team is obligated
-to maintain confidentiality with regard to the reporter of an incident. Further
-details of specific enforcement policies may be posted separately.
+reported by contacting fpaoline@redhat.com and rbryant@redhat.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other


### PR DESCRIPTION
Here I remove myself from the CODEOWNERS.

The COC was still listing only myself and Dax as contacts in case of issues. I added all current maintainers as contacts now (except for @johananl, as he will be stepping down soon too). Let me know if you prefer to keep some external person but familiar with the project or something, I have no problem. I don't know how that will age with time, though.

I'll be following the other steps in https://metallb.universe.tf/community/maintainers/#removing-maintainers and opening PRs for anything missing there. The last step will be to remove myself from the metallb org in a few weeks, just in case there is something else missing that I need the permissions to deactivate.