### PR TITLE
Add BFDProfile validation webhook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,12 @@ jobs:
         run: |
           inv build
           inv dev-env -b frr --enable-webhooks
-
+      
+      # Patch the old e2etest to cleanup the resources in the correct order.
+      - name: Apply patch
+        run: |
+          patch metallb-v0.12.1/e2etest/pkg/config/update.go < e2etest/backwardcompatible/patchfile
+          
       - name: E2E
         run: |
           cat <<EOF | kubectl apply -f -

--- a/api/v1beta1/bfdprofile_webhook.go
+++ b/api/v1beta1/bfdprofile_webhook.go
@@ -1,0 +1,64 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log/level"
+	"go.universe.tf/metallb/api/v1beta2"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (bfdProfile *BFDProfile) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(bfdProfile).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=delete,path=/validate-metallb-io-v1beta1-bfdprofile,mutating=false,failurePolicy=fail,groups=metallb.io,resources=bfdprofiles,versions=v1beta1,name=bfdprofilevalidationwebhook.metallb.io,sideEffects=None,admissionReviewVersions=v1
+
+var _ webhook.Validator = &BFDProfile{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for BFDProfile.
+func (bfdProfile *BFDProfile) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for BFDProfile.
+func (bfdProfile *BFDProfile) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for BFDProfile.
+func (bfdProfile *BFDProfile) ValidateDelete() error {
+	level.Debug(Logger).Log("webhook", "bfdprofile", "action", "delete", "name", bfdProfile.Name, "namespace", bfdProfile.Namespace)
+
+	existingBGPPeers, err := v1beta2.GetExistingBGPPeers()
+	if err != nil {
+		return err
+	}
+
+	for _, peer := range existingBGPPeers.Items {
+		if bfdProfile.Name == peer.Spec.BFDProfile {
+			return fmt.Errorf("Failed to delete BFDProfile %s, used by BGPPeer %s", bfdProfile.Name, peer.Spec.BFDProfile)
+		}
+	}
+	return nil
+}

--- a/api/v1beta1/bfdprofile_webhook_test.go
+++ b/api/v1beta1/bfdprofile_webhook_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package v1beta1
+
+import (
+	"testing"
+
+	"go.universe.tf/metallb/api/v1beta2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateBFDProfile(t *testing.T) {
+	toRestoreBGPPeers := v1beta2.GetExistingBGPPeers
+	v1beta2.GetExistingBGPPeers = func() (*v1beta2.BGPPeerList, error) {
+		return &v1beta2.BGPPeerList{
+			Items: []v1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-bgppeer",
+						Namespace: MetalLBTestNameSpace,
+					},
+					Spec: v1beta2.BGPPeerSpec{
+						BFDProfile: "bfdprofile",
+					},
+				},
+			},
+		}, nil
+	}
+	defer func() {
+		v1beta2.GetExistingBGPPeers = toRestoreBGPPeers
+	}()
+
+	desc := "Delete bfdprofile used by bgppeer"
+	bfdProfile := &BFDProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bfdprofile",
+			Namespace: MetalLBTestNameSpace,
+		},
+	}
+
+	err := bfdProfile.ValidateDelete()
+
+	if err == nil {
+		t.Fatalf("test %s failed, expecting error", desc)
+	}
+}

--- a/api/v1beta1/bgpadvertisement_webhook_test.go
+++ b/api/v1beta1/bgpadvertisement_webhook_test.go
@@ -97,7 +97,7 @@ func TestValidateBGPAdvertisement(t *testing.T) {
 			},
 		},
 		{
-			desc: "Same, update",
+			desc: "Same, new",
 			bgpAdv: &BGPAdvertisement{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-bgpadv",

--- a/api/v1beta2/bgppeer_webhook.go
+++ b/api/v1beta2/bgppeer_webhook.go
@@ -41,7 +41,7 @@ var _ webhook.Validator = &BGPPeer{}
 func (bgpPeer *BGPPeer) ValidateCreate() error {
 	level.Debug(Logger).Log("webhook", "bgppeer", "action", "create", "name", bgpPeer.Name, "namespace", bgpPeer.Namespace)
 
-	existingBGPPeers, err := getExistingBGPPeers()
+	existingBGPPeers, err := GetExistingBGPPeers()
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (bgpPeer *BGPPeer) ValidateCreate() error {
 func (bgpPeer *BGPPeer) ValidateUpdate(old runtime.Object) error {
 	level.Debug(Logger).Log("webhook", "bgppeer", "action", "update", "name", bgpPeer.Name, "namespace", bgpPeer.Namespace)
 
-	existingBGPPeers, err := getExistingBGPPeers()
+	existingBGPPeers, err := GetExistingBGPPeers()
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (bgpPeer *BGPPeer) ValidateDelete() error {
 	return nil
 }
 
-var getExistingBGPPeers = func() (*BGPPeerList, error) {
+var GetExistingBGPPeers = func() (*BGPPeerList, error) {
 	existingBGPPeerslList := &BGPPeerList{}
 	err := WebhookClient.List(context.Background(), existingBGPPeerslList, &client.ListOptions{Namespace: MetalLBNamespace})
 	if err != nil {

--- a/api/v1beta2/bgppeer_webhook_test.go
+++ b/api/v1beta2/bgppeer_webhook_test.go
@@ -22,8 +22,8 @@ func TestValidateBGPPeer(t *testing.T) {
 
 	Logger = log.NewNopLogger()
 
-	toRestore := getExistingBGPPeers
-	getExistingBGPPeers = func() (*BGPPeerList, error) {
+	toRestore := GetExistingBGPPeers
+	GetExistingBGPPeers = func() (*BGPPeerList, error) {
 		return &BGPPeerList{
 			Items: []BGPPeer{
 				bgpPeer,
@@ -32,7 +32,7 @@ func TestValidateBGPPeer(t *testing.T) {
 	}
 
 	defer func() {
-		getExistingBGPPeers = toRestore
+		GetExistingBGPPeers = toRestore
 	}()
 
 	tests := []struct {

--- a/charts/metallb/templates/crds.yaml
+++ b/charts/metallb/templates/crds.yaml
@@ -224,6 +224,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+  {{- if .Values.webhooks.enable }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "metallb.fullname" . }}-serving-cert    
+  {{- end }}
   creationTimestamp: null
   name: bfdprofiles.metallb.io
 spec:

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -116,6 +116,9 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["communities"]
   verbs: ["get", "list"]
+- apiGroups: ["metallb.io"]
+  resources: ["bfdprofiles"]
+  verbs: ["get", "list","watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/metallb/templates/webhooks.yaml
+++ b/charts/metallb/templates/webhooks.yaml
@@ -108,6 +108,25 @@ webhooks:
     resources:
     - communities
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "metallb.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-metallb-io-v1beta1-bfdprofile
+  failurePolicy: Fail
+  name: bfdprofileyvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - bfdprofiles
+  sideEffects: None
 ---
 apiVersion: v1
 kind: Service

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -1239,6 +1239,14 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
   - ipaddresspools
   verbs:
   - get
@@ -1953,6 +1961,25 @@ webhooks:
     - UPDATE
     resources:
     - addresspools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-bfdprofile
+  failurePolicy: Fail
+  name: bfdprofilevalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - bfdprofiles
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1215,6 +1215,14 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
   - ipaddresspools
   verbs:
   - get

--- a/config/manifests/metallb-native-with-webhooks.yaml
+++ b/config/manifests/metallb-native-with-webhooks.yaml
@@ -1239,6 +1239,14 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
   - ipaddresspools
   verbs:
   - get
@@ -1743,6 +1751,25 @@ webhooks:
     - UPDATE
     resources:
     - addresspools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-bfdprofile
+  failurePolicy: Fail
+  name: bfdprofilevalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - bfdprofiles
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1215,6 +1215,14 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
   - ipaddresspools
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -203,6 +203,14 @@ rules:
   - apiGroups:
       - metallb.io
     resources:
+      - bfdprofiles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metallb.io
+    resources:
       - ipaddresspools
     verbs:
       - get

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,6 +52,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-metallb-io-v1beta1-bfdprofile
+  failurePolicy: Fail
+  name: bfdprofilevalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - bfdprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-metallb-io-v1beta1-bgpadvertisement
   failurePolicy: Fail
   name: bgpadvertisementvalidationwebhook.metallb.io

--- a/e2etest/backwardcompatible/patchfile
+++ b/e2etest/backwardcompatible/patchfile
@@ -1,0 +1,16 @@
+Switch the order of the resources deletion to avoid BFDProfile webhook error
+@@ -131,12 +131,12 @@
+ 		return err
+ 	}
+ 
+-	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BFDProfile{}, client.InNamespace(o.namespace))
++	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BGPPeer{}, client.InNamespace(o.namespace))
+ 	if err != nil {
+ 		return err
+ 	}
+ 
+-	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BGPPeer{}, client.InNamespace(o.namespace))
++	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BFDProfile{}, client.InNamespace(o.namespace))
+ 	if err != nil {
+ 		return err
+ 	}

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -310,6 +310,11 @@ func enableWebhook(mgr manager.Manager, validate config.Validate, namespace stri
 		return err
 	}
 
+	if err := (&metallbv1beta1.BFDProfile{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BFDProfile")
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR is adding a validation webhook to the BFDProfile CRD.
This webhook only validates a delete action, asserting that the deleted
profile is not being used by a BGPPeer. 
For "create" and "update" validation, the CRD handles it itself with limits values.