### PR TITLE
Update metrics when service is deleted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - 'main'
+      - "main"
+      - "v**"
   pull_request:
     branches:
-      - 'main'
+      - "main"
+      - "v**"
   workflow_dispatch:
 
 jobs:
@@ -146,7 +148,8 @@ jobs:
         with:
           repository: metallb/metallb-operator
           path: metallboperator
-          ref: e84470bf3644e6444169abb65483bb1a60c957af
+          ref: v0.12
+          fetch-depth: 0
 
       - uses: actions/setup-go@v2
         with:

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -343,7 +343,7 @@ func (c *controller) deleteBalancer(l log.Logger, name, reason string) k8s.SyncS
 			"protocol": string(proto),
 			"service":  name,
 			"node":     c.myNode,
-			"ips":      ip.String(),
+			"ip":       ip.String(),
 		})
 	}
 	delete(c.announced, name)


### PR DESCRIPTION
This commit fixes service announced metric to be deleted from
prometheus when corresponding load balancer type service
is removed.

Fixes #1342 

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>