### PR TITLE
Delete L2 metrics when service is removed

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -272,8 +272,9 @@ func (a *Announce) DeleteBalancer(name string) {
 				level.Error(a.logger).Log("op", "unwatchMulticastGroup", "error", err, "ip", ip, "msg", "failed to unwatch NDP multicast group for IP")
 			}
 		}
+		// It's safe to unregister l2 metrics now as announced IP is already removed from a.ips.
+		stats.DeleteLayer2Metrics(ip.String())
 	}
-
 }
 
 // AnnounceName returns true when we have an announcement under name.

--- a/internal/layer2/stats.go
+++ b/internal/layer2/stats.go
@@ -56,3 +56,9 @@ func (m *metrics) SentResponse(addr string) {
 func (m *metrics) SentGratuitous(addr string) {
 	m.gratuitous.WithLabelValues(addr).Add(1)
 }
+
+func (m *metrics) DeleteLayer2Metrics(addr string) {
+	m.in.DeleteLabelValues(addr)
+	m.out.DeleteLabelValues(addr)
+	m.gratuitous.DeleteLabelValues(addr)
+}


### PR DESCRIPTION
This commit fixes layer2 metrics to be deleted from prometheus
when corresponding load balancer type service is removed.

Fixes #1342 

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>