### PR TITLE
Remove the avoidBuggyIps field from the api

### DIFF
--- a/api/v1beta1/addresspool_types.go
+++ b/api/v1beta1/addresspool_types.go
@@ -59,12 +59,6 @@ type AddressPoolSpec struct {
 	// +kubebuilder:default:=true
 	AutoAssign *bool `json:"autoAssign,omitempty"`
 
-	// AvoidBuggyIPs prevents addresses ending with .0 and .255
-	// to be used by a pool.
-	// +optional
-	// +kubebuilder:default:=false
-	AvoidBuggyIPs bool `json:"avoidBuggyIPs,omitempty"`
-
 	// Drives how an IP allocated from this pool should
 	// translated into BGP announcements.
 	// +optional

--- a/api/v1beta1/ipaddresspool_types.go
+++ b/api/v1beta1/ipaddresspool_types.go
@@ -33,12 +33,6 @@ type IPAddressPoolSpec struct {
 	// +optional
 	// +kubebuilder:default:=true
 	AutoAssign *bool `json:"autoAssign,omitempty"`
-
-	// AvoidBuggyIPs prevents addresses ending with .0 and .255
-	// to be used by a pool.
-	// +optional
-	// +kubebuilder:default:=false
-	AvoidBuggyIPs bool `json:"avoidBuggyIPs,omitempty"`
 }
 
 // IPAddressPoolStatus defines the observed state of IPAddressPool.

--- a/charts/metallb/templates/crds.yaml
+++ b/charts/metallb/templates/crds.yaml
@@ -159,11 +159,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.
@@ -859,11 +854,6 @@ spec:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
                 type: boolean
             required:
             - addresses

--- a/config/crd/bases/metallb.io_addresspools.yaml
+++ b/config/crd/bases/metallb.io_addresspools.yaml
@@ -141,11 +141,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.

--- a/config/crd/bases/metallb.io_ipaddresspools.yaml
+++ b/config/crd/bases/metallb.io_ipaddresspools.yaml
@@ -50,11 +50,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
             required:
             - addresses
             type: object

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -156,11 +156,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.
@@ -914,11 +909,6 @@ spec:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
                 type: boolean
             required:
             - addresses

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -144,11 +144,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.
@@ -890,11 +885,6 @@ spec:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
                 type: boolean
             required:
             - addresses

--- a/config/manifests/metallb-native-with-webhooks.yaml
+++ b/config/manifests/metallb-native-with-webhooks.yaml
@@ -156,11 +156,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.
@@ -914,11 +909,6 @@ spec:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
                 type: boolean
             required:
             - addresses

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -144,11 +144,6 @@ spec:
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
                 type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
               bgpAdvertisements:
                 description: Drives how an IP allocated from this pool should translated
                   into BGP announcements.
@@ -890,11 +885,6 @@ spec:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
                 type: boolean
             required:
             - addresses

--- a/e2etest/pkg/config/parse.go
+++ b/e2etest/pkg/config/parse.go
@@ -38,7 +38,6 @@ func IPAddressPoolToLegacy(ipAddressPool metallbv1beta1.IPAddressPool, protocol 
 			Protocol:          string(protocol),
 			Addresses:         make([]string, 0),
 			AutoAssign:        ipAddressPool.Spec.AutoAssign,
-			AvoidBuggyIPs:     ipAddressPool.Spec.AvoidBuggyIPs,
 			BGPAdvertisements: make([]metallbv1beta1.LegacyBgpAdvertisement, 0),
 		},
 	}

--- a/e2etest/pkg/config/validate.go
+++ b/e2etest/pkg/config/validate.go
@@ -68,39 +68,8 @@ func PoolCount(p metallbv1beta1.IPAddressPool) (int64, error) {
 				return math.MaxInt64, nil
 			}
 			sz := int64(math.Pow(2, float64(b-o)))
-
-			cur := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})
-			firstIP := cur.First().IP
-			lastIP := cur.Last().IP
-
-			if p.Spec.AvoidBuggyIPs {
-				if o <= 24 {
-					// A pair of buggy IPs occur for each /24 present in the range.
-					buggies := int64(math.Pow(2, float64(24-o))) * 2
-					sz -= buggies
-				} else {
-					// Ranges smaller than /24 contain 1 buggy IP if they
-					// start/end on a /24 boundary, otherwise they contain
-					// none.
-					if ipConfusesBuggyFirmwares(firstIP) {
-						sz--
-					}
-					if ipConfusesBuggyFirmwares(lastIP) {
-						sz--
-					}
-				}
-			}
-
 			total += sz
 		}
 	}
 	return total, nil
-}
-
-func ipConfusesBuggyFirmwares(ip net.IP) bool {
-	ip = ip.To4()
-	if ip == nil {
-		return false
-	}
-	return ip[3] == 0 || ip[3] == 255
 }

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -27,8 +27,7 @@ func TestAssignment(t *testing.T) {
 			},
 		},
 		"test2": {
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
+			AutoAssign: true,
 			CIDR: []*net.IPNet{
 				ipnet("1.2.4.0/24"),
 				ipnet("1000::4:0/120"),
@@ -88,18 +87,6 @@ func TestAssignment(t *testing.T) {
 			desc: "s1 can now grab s2's former IP",
 			svc:  "s1",
 			ips:  []string{"1.2.3.5"},
-		},
-		{
-			desc:    "s3 cannot grab a 0 buggy IP",
-			svc:     "s3",
-			ips:     []string{"1.2.4.0"},
-			wantErr: true,
-		},
-		{
-			desc:    "s3 cannot grab a 255 buggy IP",
-			svc:     "s3",
-			ips:     []string{"1.2.4.255"},
-			wantErr: true,
 		},
 		{
 			desc: "s3 can grab another IP in that pool",
@@ -1113,14 +1100,12 @@ func TestBuggyIPs(t *testing.T) {
 			CIDR:       []*net.IPNet{ipnet("1.2.3.254/31")},
 		},
 		"test3": {
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
-			CIDR:          []*net.IPNet{ipnet("1.2.4.0/31")},
+			AutoAssign: true,
+			CIDR:       []*net.IPNet{ipnet("1.2.4.0/31")},
 		},
 		"test4": {
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
-			CIDR:          []*net.IPNet{ipnet("1.2.4.254/31")},
+			AutoAssign: true,
+			CIDR:       []*net.IPNet{ipnet("1.2.4.254/31")},
 		},
 	}); err != nil {
 		t.Fatalf("SetPools: %s", err)
@@ -1133,6 +1118,8 @@ func TestBuggyIPs(t *testing.T) {
 		"1.2.3.255": true,
 		"1.2.4.1":   true,
 		"1.2.4.254": true,
+		"1.2.4.255": true,
+		"1.2.4.0":   true,
 	}
 
 	tests := []struct {
@@ -1145,10 +1132,7 @@ func TestBuggyIPs(t *testing.T) {
 		{svc: "s4"},
 		{svc: "s5"},
 		{svc: "s6"},
-		{
-			svc:     "s7",
-			wantErr: true,
-		},
+		{svc: "s7"},
 	}
 
 	for i, test := range tests {
@@ -1315,18 +1299,6 @@ func TestConfigReload(t *testing.T) {
 				},
 			},
 			pool: "test2",
-		},
-		{
-			desc: "enable buggy IPs not allowed",
-			pools: map[string]*config.Pool{
-				"test2": {
-					AutoAssign:    true,
-					AvoidBuggyIPs: true,
-					CIDR:          []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
-				},
-			},
-			pool:    "test2",
-			wantErr: true,
 		},
 	}
 
@@ -1545,18 +1517,9 @@ func TestPoolCount(t *testing.T) {
 			want: 384,
 		},
 		{
-			desc: "BGP /24 and /25, no buggy IPs",
-			pool: &config.Pool{
-				CIDR:          []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("2.3.4.128/25")},
-				AvoidBuggyIPs: true,
-			},
-			want: 381,
-		},
-		{
 			desc: "BGP a BIG ipv6 range",
 			pool: &config.Pool{
-				CIDR:          []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("2.3.4.128/25"), ipnet("1000::/64")},
-				AvoidBuggyIPs: true,
+				CIDR: []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("2.3.4.128/25"), ipnet("1000::/64")},
 			},
 			want: math.MaxInt64,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,12 +106,7 @@ type Pool struct {
 	// prefixes. config.Parse guarantees that these are
 	// non-overlapping, both within and between pools.
 	CIDR []*net.IPNet
-	// Some buggy consumer devices mistakenly drop IPv4 traffic for IP
-	// addresses ending in .0 or .255, due to poor implementations of
-	// smurf protection. This setting marks such addresses as
-	// unusable, for maximum compatibility with ancient parts of the
-	// internet.
-	AvoidBuggyIPs bool
+
 	// If false, prevents IP addresses to be automatically assigned
 	// from this pool.
 	AutoAssign bool
@@ -438,8 +433,7 @@ func addressPoolFromCR(p metallbv1beta1.IPAddressPool) (*Pool, error) {
 	}
 
 	ret := &Pool{
-		AvoidBuggyIPs: p.Spec.AvoidBuggyIPs,
-		AutoAssign:    true,
+		AutoAssign: true,
 	}
 
 	if p.Spec.AutoAssign != nil {
@@ -469,8 +463,7 @@ func addressPoolFromLegacyCR(p metallbv1beta1.AddressPool, bgpCommunities map[st
 	}
 
 	ret := &Pool{
-		AvoidBuggyIPs: p.Spec.AvoidBuggyIPs,
-		AutoAssign:    true,
+		AutoAssign: true,
 	}
 
 	if p.Spec.AutoAssign != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,8 +113,7 @@ func TestParse(t *testing.T) {
 								"10.20.0.0/16",
 								"10.50.0.0/24",
 							},
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 					{
@@ -242,9 +241,8 @@ func TestParse(t *testing.T) {
 				},
 				Pools: map[string]*Pool{
 					"pool1": {
-						CIDR:          []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
-						AvoidBuggyIPs: true,
-						AutoAssign:    false,
+						CIDR:       []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
+						AutoAssign: false,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
 								AggregationLength:   32,
@@ -1467,8 +1465,7 @@ func TestParse(t *testing.T) {
 								"10.20.0.0/16",
 								"10.50.0.0/24",
 							},
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 				},
@@ -1482,9 +1479,8 @@ func TestParse(t *testing.T) {
 								"10.21.0.0/16",
 								"10.51.0.0/24",
 							},
-							Protocol:      string(Layer2),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(Layer2),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 					{
@@ -1496,9 +1492,8 @@ func TestParse(t *testing.T) {
 								"10.40.0.0/16",
 								"10.60.0.0/24",
 							},
-							Protocol:      string(BGP),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(BGP),
+							AutoAssign: pointer.BoolPtr(false),
 							BGPAdvertisements: []v1beta1.LegacyBgpAdvertisement{
 								{
 									AggregationLength: pointer.Int32Ptr(32),
@@ -1540,9 +1535,8 @@ func TestParse(t *testing.T) {
 				},
 				Pools: map[string]*Pool{
 					"pool1": {
-						CIDR:          []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
-						AvoidBuggyIPs: true,
-						AutoAssign:    false,
+						CIDR:       []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
+						AutoAssign: false,
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
 								AggregationLength:   32,
@@ -1556,8 +1550,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					"legacybgppool1": {
-						CIDR:          []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
-						AvoidBuggyIPs: true,
+						CIDR: []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
 								AggregationLength:   32,
@@ -1571,8 +1564,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					"legacyl2pool1": {
-						CIDR:          []*net.IPNet{ipnet("10.21.0.0/16"), ipnet("10.51.0.0/24")},
-						AvoidBuggyIPs: true,
+						CIDR: []*net.IPNet{ipnet("10.21.0.0/16"), ipnet("10.51.0.0/24")},
 						L2Advertisements: []*L2Advertisement{{
 							Nodes: map[string]bool{},
 						}},
@@ -1595,9 +1587,8 @@ func TestParse(t *testing.T) {
 								"10.40.0.0/16",
 								"10.60.0.0/24",
 							},
-							Protocol:      string(BGP),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(BGP),
+							AutoAssign: pointer.BoolPtr(false),
 							BGPAdvertisements: []v1beta1.LegacyBgpAdvertisement{
 								{
 									AggregationLength: pointer.Int32Ptr(32),
@@ -1627,8 +1618,7 @@ func TestParse(t *testing.T) {
 			want: &Config{
 				Pools: map[string]*Pool{
 					"legacybgppool1": {
-						CIDR:          []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
-						AvoidBuggyIPs: true,
+						CIDR: []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
 								AggregationLength:   32,
@@ -1658,8 +1648,7 @@ func TestParse(t *testing.T) {
 								"10.20.0.0/16",
 								"10.50.0.0/24",
 							},
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 				},
@@ -1673,9 +1662,8 @@ func TestParse(t *testing.T) {
 								"10.20.0.0/16",
 								"10.51.0.0/24",
 							},
-							Protocol:      string(Layer2),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(Layer2),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 					{
@@ -1987,9 +1975,8 @@ func TestParse(t *testing.T) {
 								"10.21.0.0/16",
 								"10.51.0.0/24",
 							},
-							Protocol:      string(Layer2),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(Layer2),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 					{
@@ -2001,9 +1988,8 @@ func TestParse(t *testing.T) {
 								"10.40.0.0/16",
 								"10.60.0.0/24",
 							},
-							Protocol:      string(BGP),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(BGP),
+							AutoAssign: pointer.BoolPtr(false),
 						},
 					},
 				},
@@ -2028,8 +2014,7 @@ func TestParse(t *testing.T) {
 			want: &Config{
 				Pools: map[string]*Pool{
 					"legacybgppool1": {
-						CIDR:          []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
-						AvoidBuggyIPs: true,
+						CIDR: []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
 						BGPAdvertisements: []*BGPAdvertisement{
 							{
 								AggregationLength:   32,
@@ -2044,8 +2029,7 @@ func TestParse(t *testing.T) {
 					},
 
 					"legacyl2pool1": {
-						CIDR:          []*net.IPNet{ipnet("10.21.0.0/16"), ipnet("10.51.0.0/24")},
-						AvoidBuggyIPs: true,
+						CIDR: []*net.IPNet{ipnet("10.21.0.0/16"), ipnet("10.51.0.0/24")},
 						L2Advertisements: []*L2Advertisement{{
 							Nodes: map[string]bool{
 								"first":  true,
@@ -2248,9 +2232,8 @@ func TestParse(t *testing.T) {
 								"10.40.0.0/16",
 								"10.60.0.0/24",
 							},
-							Protocol:      string(BGP),
-							AvoidBuggyIPs: true,
-							AutoAssign:    pointer.BoolPtr(false),
+							Protocol:   string(BGP),
+							AutoAssign: pointer.BoolPtr(false),
 							BGPAdvertisements: []v1beta1.LegacyBgpAdvertisement{
 								{
 									AggregationLength: pointer.Int32Ptr(32),

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -509,19 +509,6 @@ bool
 for a pool.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>avoidBuggyIPs</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AvoidBuggyIPs prevents addresses ending with .0 and .255
-to be used by a pool.</p>
-</td>
-</tr>
 </table>
 </td>
 </tr>


### PR DESCRIPTION
When defining the first version of the CRDs, it was decided not to
expose this flag.
If .0 / .255 ips are problematic, users can define custom ranges to skip
them. Given this is the first version of the api, we are removing the
field in order to propose a slimmer api surface, with the possibility of
readding it later on.

Link to the discussion: https://github.com/metallb/metallb-operator/pull/17#discussion_r652824338