### PR TITLE
Disable directly connected check for IPv6 eBGP sessions by default

### DIFF
--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -128,6 +128,21 @@ func TestSingleEBGPSessionOneHop(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+func TestSingleIPv6EBGPSessionOneHop(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l, "[127:0:0::2]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
 func TestSingleIBGPSession(t *testing.T) {
 	testSetup(t)
 
@@ -135,6 +150,21 @@ func TestSingleIBGPSession(t *testing.T) {
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 100, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleIPv6IBGPSession(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l, "[10:2:2::254]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 100, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -170,6 +200,26 @@ func TestTwoSessions(t *testing.T) {
 	}
 	defer session1.Close()
 	session2, err := sessionManager.NewSession(l, "10.4.4.255:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "", true, "test-peer2")
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session2.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoIPv6Sessions(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session1, err := sessionManager.NewSession(l, "[10:2:2::254]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", false, "test-peer1")
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+	session2, err := sessionManager.NewSession(l, "[10:4:4::255]:179", net.ParseIP("10:3:3::254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "", false, "test-peer2")
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}

--- a/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
@@ -1,0 +1,36 @@
+
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 127:0:0::2-in deny 20
+route-map 127:0:0::2-out permit 1
+  match ipv6 address prefix-list 127:0:0::2-pl-ipv6
+  on-match next
+ipv6 prefix-list 127:0:0::2-pl-ipv6 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+
+  neighbor 127:0:0::2 remote-as 200
+  neighbor 127:0:0::2 port 179
+  neighbor 127:0:0::2 timers 1 1
+  neighbor 127:0:0::2 password password
+  neighbor 127:0:0::2 update-source 10:1:1::254
+  neighbor 127:0:0::2 disable-connected-check
+
+  address-family ipv4 unicast
+    neighbor 127:0:0::2 activate
+    neighbor 127:0:0::2 route-map 127:0:0::2-in in
+	neighbor 127:0:0::2 route-map 127:0:0::2-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 127:0:0::2 activate
+    neighbor 127:0:0::2 route-map 127:0:0::2-in in
+	neighbor 127:0:0::2 route-map 127:0:0::2-out out
+  exit-address-family

--- a/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
@@ -1,0 +1,35 @@
+
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10:2:2::254-in deny 20
+route-map 10:2:2::254-out permit 1
+  match ipv6 address prefix-list 10:2:2::254-pl-ipv6
+  on-match next
+ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+
+  neighbor 10:2:2::254 remote-as 100
+  neighbor 10:2:2::254 port 179
+  neighbor 10:2:2::254 timers 1 1
+  neighbor 10:2:2::254 password password
+  neighbor 10:2:2::254 update-source 10:1:1::254
+
+  address-family ipv4 unicast
+    neighbor 10:2:2::254 activate
+    neighbor 10:2:2::254 route-map 10:2:2::254-in in
+	neighbor 10:2:2::254 route-map 10:2:2::254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10:2:2::254 activate
+    neighbor 10:2:2::254 route-map 10:2:2::254-in in
+	neighbor 10:2:2::254 route-map 10:2:2::254-out out
+  exit-address-family

--- a/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
@@ -1,0 +1,65 @@
+
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10:2:2::254-in deny 20
+route-map 10:2:2::254-out permit 1
+  match ipv6 address prefix-list 10:2:2::254-pl-ipv6
+  on-match next
+ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
+route-map 10:4:4::255-in deny 20
+route-map 10:4:4::255-out permit 1
+  match ipv6 address prefix-list 10:4:4::255-pl-ipv6
+  on-match next
+ipv6 prefix-list 10:4:4::255-pl-ipv6 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+
+  neighbor 10:2:2::254 remote-as 200
+  neighbor 10:2:2::254 port 179
+  neighbor 10:2:2::254 timers 1 1
+  neighbor 10:2:2::254 password password
+  neighbor 10:2:2::254 update-source 10:1:1::254
+  neighbor 10:2:2::254 disable-connected-check
+
+  address-family ipv4 unicast
+    neighbor 10:2:2::254 activate
+    neighbor 10:2:2::254 route-map 10:2:2::254-in in
+	neighbor 10:2:2::254 route-map 10:2:2::254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10:2:2::254 activate
+    neighbor 10:2:2::254 route-map 10:2:2::254-in in
+	neighbor 10:2:2::254 route-map 10:2:2::254-out out
+  exit-address-family
+router bgp 300
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.3.3.254
+
+  neighbor 10:4:4::255 remote-as 400
+  neighbor 10:4:4::255 port 179
+  neighbor 10:4:4::255 timers 1 1
+  neighbor 10:4:4::255 password password
+  neighbor 10:4:4::255 update-source 10:3:3::254
+  neighbor 10:4:4::255 disable-connected-check
+
+  address-family ipv4 unicast
+    neighbor 10:4:4::255 activate
+    neighbor 10:4:4::255 route-map 10:4:4::255-in in
+	neighbor 10:4:4::255 route-map 10:4:4::255-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10:4:4::255 activate
+    neighbor 10:4:4::255 route-map 10:4:4::255-in in
+	neighbor 10:4:4::255 route-map 10:4:4::255-out out
+  exit-address-family


### PR DESCRIPTION
There is an issue with how MHT works for IPv6 neighbors
specifically if DHCPv6 was used to assign interfaces IP
because of this issue eBGP directly connected sessions
won't get to establish state.

using disable directly connected check mitigate this
issue for the time being till frr has fix.

for more details about this issue pls refer to
https://github.com/FRRouting/frr/issues/11185

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>