### PR TITLE
Change e2etests cleanup order v0.12

### DIFF
--- a/e2etest/pkg/config/update.go
+++ b/e2etest/pkg/config/update.go
@@ -131,12 +131,12 @@ func (o operatorUpdater) Clean() error {
 		return err
 	}
 
-	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BFDProfile{}, client.InNamespace(o.namespace))
+	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BGPPeer{}, client.InNamespace(o.namespace))
 	if err != nil {
 		return err
 	}
 
-	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BGPPeer{}, client.InNamespace(o.namespace))
+	err = o.DeleteAllOf(context.Background(), &operatorv1beta1.BFDProfile{}, client.InNamespace(o.namespace))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For backward_compatible CI lane in MetalLB's main branch, adding
BFDProfile requires us to change the cleanup order so the Peers
will be deleted before the BFDProfiles, so the webhook won't deny
the cleanup and fail the tests.
