### PR TITLE
FRR: restore the image from dockerhub

### DIFF
--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -221,6 +221,6 @@ speaker:
   frr:
     enabled: false
     image:
-      repository: quay.io/frrouting/frr
-      tag: stable_7.5
+      repository: frrouting/frr
+      tag: v7.5.1
       pullPolicy:

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -29,7 +29,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -55,7 +55,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -79,7 +79,7 @@ spec:
               done
               tail -f /etc/frr/frr.log
         - name: reloader
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -89,7 +89,7 @@ spec:
             - name: reloader
               mountPath: /etc/frr_reloader
         - name: frr-metrics
-          image: quay.io/frrouting/frr:stable_7.5
+          image: frrouting/frr:v7.5.1
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473

--- a/config/manifests/metallb-frr-with-webhooks.yaml
+++ b/config/manifests/metallb-frr-with-webhooks.yaml
@@ -1730,7 +1730,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: frr
         securityContext:
           capabilities:
@@ -1746,7 +1746,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: reloader
         volumeMounts:
         - mountPath: /var/run/frr
@@ -1759,7 +1759,7 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -1845,7 +1845,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1681,7 +1681,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: frr
         securityContext:
           capabilities:
@@ -1697,7 +1697,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: reloader
         volumeMounts:
         - mountPath: /var/run/frr
@@ -1710,7 +1710,7 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -1796,7 +1796,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: quay.io/frrouting/frr:stable_7.5
+        image: frrouting/frr:v7.5.1
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -28,7 +28,7 @@ const (
 	// BGP configuration directory.
 	frrConfigDir = "config/frr"
 	// FRR routing image.
-	frrImage = "quay.io/frrouting/frr:stable_7.5"
+	frrImage = "frrouting/frr:v7.5.1"
 	// Host network name.
 	hostNetwork = "host"
 	// FRR container mount destination path.

--- a/tasks.py
+++ b/tasks.py
@@ -477,7 +477,7 @@ def bgp_dev_env(ip_family, frr_volume_dir):
         '    docker rm -f $frr ; '
         'done', echo=True)
     run("docker run -d --privileged --network kind --rm --ulimit core=-1 --name frr --volume %s:/etc/frr "
-            "quay.io/frrouting/frr:stable_7.5" % frr_volume_dir, echo=True)
+            "frrouting/frr:v7.5.1" % frr_volume_dir, echo=True)
 
     if ip_family == "ipv4":
         peer_address = run('docker inspect -f "{{ '


### PR DESCRIPTION
Moving back to dockerhub since it's the official FRR image, plus it supports multi - architecture.