### PR TITLE
Add OCI image annotations

### DIFF
--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -5,5 +5,15 @@ FROM alpine:latest
 # just in case
 COPY --chmod=a+x configmaptocrs /configmaptocrs
 
+LABEL org.opencontainers.image.authors="metallb" \
+  org.opencontainers.image.url="https://github.com/metallb/metallb" \
+  org.opencontainers.image.documentation="https://metallb.universe.tf" \
+  org.opencontainers.image.source="https://github.com/metallb/metallb" \
+  org.opencontainers.image.vendor="metallb" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.description="Metallb Configmap to CRs converter" \
+  org.opencontainers.image.title="configmap to crs" \
+  org.opencontainers.image.base.name="docker.io/alpine:latest"
+
 ENTRYPOINT ["/configmaptocrs"]
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -5,4 +5,15 @@ FROM alpine:latest
 # just in case
 COPY --chmod=a+x controller /controller
 
+LABEL org.opencontainers.image.authors="metallb" \
+  org.opencontainers.image.url="https://github.com/metallb/metallb" \
+  org.opencontainers.image.documentation="https://metallb.universe.tf" \
+  org.opencontainers.image.source="https://github.com/metallb/metallb" \
+  org.opencontainers.image.vendor="metallb" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.description="Metallb Controller" \
+  org.opencontainers.image.title="controller" \
+  org.opencontainers.image.base.name="docker.io/alpine:latest"
+
+
 ENTRYPOINT ["/controller"]

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -11,4 +11,14 @@ COPY --chmod=a+x speaker /speaker
 
 
 
+LABEL org.opencontainers.image.authors="metallb" \
+  org.opencontainers.image.url="https://github.com/metallb/metallb" \
+  org.opencontainers.image.documentation="https://metallb.universe.tf" \
+  org.opencontainers.image.source="https://github.com/metallb/metallb" \
+  org.opencontainers.image.vendor="metallb" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.description="Metallb speaker" \
+  org.opencontainers.image.title="speaker" \
+  org.opencontainers.image.base.name="docker.io/alpine:latest"
+
 ENTRYPOINT ["/speaker"]


### PR DESCRIPTION
Small MR to add OCI image annotations to speaker and controller images.

Fixes #1392 

Signed-off-by: Joshua Carnes <56089764+jtcarnes@users.noreply.github.com>
