### PR TITLE
Helm: Add optional annotations for podMonitors and prometheusRules

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -49,6 +49,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | prometheus.metricsPort | int | `7472` |  |
 | prometheus.namespace | string | `""` |  |
 | prometheus.podMonitor.additionalLabels | object | `{}` |  |
+| prometheus.podMonitor.annotations | object | `{}` |  |
 | prometheus.podMonitor.enabled | bool | `false` |  |
 | prometheus.podMonitor.interval | string | `nil` |  |
 | prometheus.podMonitor.jobLabel | string | `"app.kubernetes.io/name"` |  |
@@ -64,6 +65,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | prometheus.prometheusRule.addressPoolUsage.thresholds[1].percent | int | `85` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[2].labels.severity | string | `"alert"` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[2].percent | int | `95` |  |
+| prometheus.prometheusRule.annotations | object | `{}` |  |
 | prometheus.prometheusRule.bgpSessionDown.enabled | bool | `true` |  |
 | prometheus.prometheusRule.bgpSessionDown.labels.severity | string | `"alert"` |  |
 | prometheus.prometheusRule.configNotLoaded.enabled | bool | `true` |  |

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- if .Values.prometheus.podMonitor.additionalLabels }}
 {{ toYaml .Values.prometheus.podMonitor.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.prometheus.podMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.podMonitor.annotations | indent 4 }}
+  {{- end }}
 spec:
   jobLabel: {{ .Values.prometheus.podMonitor.jobLabel | quote }}
   selector:
@@ -43,6 +47,10 @@ metadata:
     {{- if .Values.prometheus.podMonitor.additionalLabels }}
 {{ toYaml .Values.prometheus.podMonitor.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.prometheus.podMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.podMonitor.annotations | indent 4 }}
+  {{- end }}
 spec:
   jobLabel: {{ .Values.prometheus.podMonitor.jobLabel | quote }}
   selector:

--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- if .Values.prometheus.prometheusRule.additionalLabels }}
 {{ toYaml .Values.prometheus.prometheusRule.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.prometheus.prometheusRule.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.prometheusRule.annotations | indent 4 }}
+  {{- end }}
 spec:
   groups:
   - name: {{ template "metallb.fullname" . }}.rules
@@ -74,4 +78,4 @@ spec:
     {{- with .Values.prometheus.prometheusRule.extraAlerts }}
     {{- toYaml . | nindent 4 }}
     {{- end}}
-{{- end }} 
+{{- end }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -48,6 +48,9 @@ prometheus:
     # optional additionnal labels for podMonitors
     additionalLabels: {}
 
+    # optional annotations for podMonitors
+    annotations: {}
+
     # Job label for scrape target
     jobLabel: "app.kubernetes.io/name"
 
@@ -77,6 +80,9 @@ prometheus:
 
     # optional additionnal labels for prometheusRules
     additionalLabels: {}
+
+    # optional annotations for prometheusRules
+    annotations: {}
 
     # MetalLBStaleConfig
     staleConfig:

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -26,6 +26,8 @@ New Features:
 
 - LoadBalancerClass support: it's possible to have MetalLB listen only to services with the provided load balancer class to comply with [kubernetes loadbalancer class](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class). ([PR 1417](https://github.com/metallb/metallb/pull/1417)).
 
+- Helm Charts: optional annotations for PodMonitors and PrometheusRules ([PR 1407](https://github.com/metallb/metallb/pull/1407))
+
 Changes in behavior:
 
 - the biggest change is the introduction of CRDs and removing support for the configuration via ConfigMap. In order to ease the transition


### PR DESCRIPTION
My particular use case is adding the following annotation:

```
argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
```

Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types