### PR TITLE
Build in container and update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
 
-  unit-tests-and-build:
+  unit-tests:
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
@@ -25,13 +25,12 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17.1"
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Install Dependencies
         run: |
@@ -56,31 +55,42 @@ jobs:
           inv generateapidocs
           inv checkchanges --action="run inv generateapidocs"
 
-      - name: Build and save MetalLB images
-        run: |
-          inv build --binaries all
-          docker save quay.io/metallb/speaker:dev-amd64 > speaker.tar
-          docker save quay.io/metallb/controller:dev-amd64 > controller.tar
-          docker save quay.io/metallb/mirror-server:dev-amd64 > mirror-server.tar
+  build-test-images:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        image: [speaker, controller, mirror-server, configmaptocrs]
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v3
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Upload images
+      - name: Build and export ${{ matrix.image }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: quay.io/metallb/${{ matrix.image }}:dev-amd64
+          file: ${{matrix.image}}/Dockerfile
+          outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Upload ${{ matrix.image }} artifact
         uses: actions/upload-artifact@v3
         with:
-          name: metallb-images
           retention-days: 1
-          path: |
-            speaker.tar
-            controller.tar
-            mirror-server.tar
+          name: image-tar-${{ matrix.image }}
+          path: /tmp/${{ matrix.image }}.tar
 
   helm:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: "0"
-
+          # Required for chart-testing
+          fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
@@ -120,7 +130,8 @@ jobs:
   e2e:
     runs-on: ubuntu-20.04
     needs:
-      - unit-tests-and-build
+      - unit-tests
+      - build-test-images
       - helm
       - commitlint
     strategy:
@@ -131,9 +142,7 @@ jobs:
         deployment: [manifests, helm]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
 
       - name: Setup
         uses: ./.github/workflows/composite/setup
@@ -170,34 +179,34 @@ jobs:
   backward_compatible:
     runs-on: ubuntu-20.04
     needs:
-      - unit-tests-and-build
+      - unit-tests
+      - build-test-images
       - helm
       - commitlint
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/workflows/composite/setup
 
-      - name: Deploy MetalLB
-        run: |
-          inv dev-env -b frr --no-build-images
-      
-      - name: Checkout previous
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: "0"
           path: metallb-v0.12.1
           ref: v0.12.1
-      
+
+      - name: Deploy MetalLB
+        run: |
+          inv dev-env -b frr --no-build-images
       # Patch the old e2etest to cleanup the resources in the correct order.
       - name: Apply patch
         run: |
           patch metallb-v0.12.1/e2etest/pkg/config/update.go < e2etest/backwardcompatible/patchfile
-          
+
       - name: E2E
         run: |
           cat <<EOF | kubectl apply -f -
@@ -210,7 +219,7 @@ jobs:
           rm -rf e2etest # we want to make sure we are not running current e2e by mistake
           cd metallb-v0.12.1
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
-          sudo -E env "PATH=$PATH" inv e2etest --use-operator --focus "$FOCUS" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest --skip-docker --use-operator --focus "$FOCUS" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}
@@ -218,19 +227,17 @@ jobs:
         with:
           artifact-name: kind-logs-backward-compatible
 
-
   e2e-use-operator:
     runs-on: ubuntu-20.04
     needs:
-      - unit-tests-and-build
+      - unit-tests
+      - build-test-images
       - helm
       - commitlint
     defaults:
       run:
         shell: bash
 
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -239,13 +246,19 @@ jobs:
 
       - name: Setup
         uses: ./.github/workflows/composite/setup
-      
+
       - name: Checkout Metal LB Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: metallb/metallb-operator
           path: metallboperator
           ref: e0f17807883bfb64e0d58429ee3a5e4f200c9a9f
+
+      - name: Checkout MetalLB
+        uses: actions/checkout@v3
+        with:
+          path: metallb
+          fetch-depth: 0
 
       - name: Create multi-node K8s Kind Cluster
         run: |
@@ -285,7 +298,8 @@ jobs:
   oldest_k8s:
     runs-on: ubuntu-20.04
     needs:
-      - unit-tests-and-build
+      - unit-tests
+      - build-test-images
       - helm
       - commitlint
     steps:
@@ -300,7 +314,7 @@ jobs:
       - name: Deploy MetalLB
         run: |
           inv dev-env -b frr --no-build-images --node-img kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-             
+
       - name: E2E
         run: |
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -9,9 +9,10 @@ runs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: "1.17.1"
+        go-version-file: "go.mod"
+        cache: true
 
     - name: Install Dependencies
       shell: bash
@@ -25,13 +26,13 @@ runs:
     - name: Download MetalLB images
       uses: actions/download-artifact@v3
       with:
-        name: metallb-images
         path: metallb-images
 
     - name: Load MetalLB images
       shell: bash
       working-directory: metallb-images
       run: |
-        docker load -i speaker.tar
-        docker load -i controller.tar
-        docker load -i mirror-server.tar
+        docker load -i image-tar-speaker/speaker.tar
+        docker load -i image-tar-controller/controller.tar
+        docker load -i image-tar-mirror-server/mirror-server.tar
+        docker load -i image-tar-configmaptocrs/configmaptocrs.tar

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,10 +2,10 @@ name: Publish
 on:
   push:
     branches:
-      - 'main'
-      - 'v.*'
+      - "main"
+      - "v.*"
     tags:
-      - '.*'
+      - ".*"
 
 jobs:
   unit-tests:
@@ -17,13 +17,12 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17.1"
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Install Dependencies
         run: |
@@ -48,39 +47,50 @@ jobs:
           inv generateapidocs
           inv checkchanges --action="run inv generateapidocs"
 
-  build-and-push:
-    needs: unit-tests
+  publish-images:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        image: [speaker, controller, configmaptocrs]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17.1"
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python3-pip arping ndisc6
-          sudo pip3 install invoke semver pyyaml
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
-
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Quay.io container registry
-        uses: docker/login-action@v1
+      - name: Log into Quay
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build and push MetalLB images
-        run: |
-          mkdir -p ./bin
-          wget -qO- https://github.com/estesp/manifest-tool/releases/download/v2.0.3/binaries-manifest-tool-2.0.3.tar.gz | tar xvz -C ./bin
-          mv ./bin/manifest-tool-linux-amd64 ./bin/manifest-tool && chmod +x ./bin/manifest-tool
-          sudo -E env "PATH=./bin:$PATH" inv push-multiarch --binaries=controller --binaries=speaker --binaries=configmaptocrs --registry=quay.io --repo=metallb --tag=${{ github.ref_name }}
+      - name: Docker meta ${{ matrix.image }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            quay.io/metallb/${{ matrix.image }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=push
+            type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.description=${{ matrix.image }} for metallb, a network load-balancer implementation for Kubernetes using standard routing protocols
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{matrix.image}}/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_BRANCH: ${{ github.ref_name }}
+            GIT_COMMIT: ${{ github.sha }}

--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,9 +1,32 @@
-FROM alpine:latest
+# syntax=docker/dockerfile:1.2
 
-# When running as non root and building in an environment that `umask` masks out
-# '+x' for others, it won't be possible to execute. Make sure all can execute,
-# just in case
-COPY --chmod=a+x configmaptocrs /configmaptocrs
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.17 AS builder
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
+WORKDIR $GOPATH/go.universe.tf/metallb
+
+# Cache the downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+# COPY internals
+COPY internal internal
+COPY api api
+
+# COPY configmaptocrs
+COPY configmaptocrs/*.go configmaptocrs/
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  CGO_ENABLED=0 GOARM=6 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+  go build -v -o /build/configmaptocrs \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  go.universe.tf/metallb/configmaptocrs
+
+FROM docker.io/alpine:latest
+
+COPY --from=builder /build/configmaptocrs /configmaptocrs
+COPY LICENSE /
 
 LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.url="https://github.com/metallb/metallb" \
@@ -16,4 +39,3 @@ LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.base.name="docker.io/alpine:latest"
 
 ENTRYPOINT ["/configmaptocrs"]
-

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,9 +1,29 @@
-FROM alpine:latest
+# syntax=docker/dockerfile:1.2
 
-# When running as non root and building in an environment that `umask` masks out
-# '+x' for others, it won't be possible to execute. Make sure all can execute,
-# just in case
-COPY --chmod=a+x controller /controller
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.17 AS builder
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
+
+WORKDIR $GOPATH/go.universe.tf/metallb
+# Caching dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY controller/*.go .
+COPY internal internal
+COPY api api
+
+# Cache builds directory for faster rebuild
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=6 \
+  go build -v -o /build/controller \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'"
+
+FROM docker.io/alpine:latest
+
+COPY --from=builder /build/controller /controller
+COPY LICENSE /
 
 LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.url="https://github.com/metallb/metallb" \
@@ -14,6 +34,5 @@ LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.description="Metallb Controller" \
   org.opencontainers.image.title="controller" \
   org.opencontainers.image.base.name="docker.io/alpine:latest"
-
 
 ENTRYPOINT ["/controller"]

--- a/mirror-server/Dockerfile
+++ b/mirror-server/Dockerfile
@@ -1,4 +1,19 @@
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.17 AS builder
+WORKDIR $GOPATH/go.universe.tf/metallb
+# Caching dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY mirror-server/*.go .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
+  go build -v -o /build/mirror
+
 FROM alpine:latest
 
-ADD mirror-server /mirror
+COPY --from=builder /build/mirror /mirror
+COPY LICENSE /
 ENTRYPOINT ["/mirror"]

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,15 +1,44 @@
-FROM alpine:latest
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.17 AS builder
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
+WORKDIR $GOPATH/go.universe.tf/metallb
+
+# Cache the downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy speaker
+COPY speaker/*.go speaker/
+# Copy frr-metrics
+COPY frr-metrics ./frr-metrics/
+# COPY internals
+COPY internal internal
+COPY api api
 
 
-# When running as non root and building in an environment that `umask` masks out
-# '+x' for others, it won't be possible to execute. Make sure all can execute,
-# just in case
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  # build frr metrics
+  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=6 \
+  go build -v -o /build/frr-metrics \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  frr-metrics/exporter.go \
+  && \
+  # build speaker
+  CGO_ENABLED=0 GOARM=6 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+  go build -v -o /build/speaker \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  go.universe.tf/metallb/speaker
 
-COPY --chmod=a+x frr-reloader.sh /frr-reloader.sh
-COPY frr-metrics /frr-metrics
-COPY --chmod=a+x speaker /speaker
+FROM docker.io/alpine:latest
 
 
+COPY --from=builder /build/speaker /speaker
+COPY --from=builder /build/frr-metrics /frr-metrics
+COPY frr-reloader/frr-reloader.sh /frr-reloader.sh
+COPY LICENSE /
 
 LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.url="https://github.com/metallb/metallb" \


### PR DESCRIPTION
This MR changes the build process for metallb to build inside a docker container instead of building outside and copying in. It further refactors much of the CI to better build images inside containers and leverage github actions instead of custom scripting.

Fixes #1392 #1408 #1413 