### PR TITLE
BFDProfile Webhook: Fix delete message

### DIFF
--- a/api/v1beta1/bfdprofile_webhook.go
+++ b/api/v1beta1/bfdprofile_webhook.go
@@ -57,7 +57,7 @@ func (bfdProfile *BFDProfile) ValidateDelete() error {
 
 	for _, peer := range existingBGPPeers.Items {
 		if bfdProfile.Name == peer.Spec.BFDProfile {
-			return fmt.Errorf("Failed to delete BFDProfile %s, used by BGPPeer %s", bfdProfile.Name, peer.Spec.BFDProfile)
+			return fmt.Errorf("Failed to delete BFDProfile %s, used by BGPPeer %s", bfdProfile.Name, peer.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION
The name of the BGP peer that's using the BFDProfile should be specified.
