### PR TITLE
WIP: Migrate frr components to their own images

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -83,6 +83,13 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `"v7.5.1"` |  |
+| speaker.frr.metrics.enabled | bool | `true` |  |
+| speaker.frr.metrics.image.pullPolicy | string | `nil` |  |
+| speaker.frr.metrics.image.repository | string | `"quay.io/metallb/frr-metrics"` |  |
+| speaker.frr.metrics.image.tag | string | `nil` |  |
+| speaker.frr.reloader.image.pullPolicy | string | `nil` |  |
+| speaker.frr.reloader.image.repository | string | `"quay.io/metallb/frr-reloader"` |  |
+| speaker.frr.reloader.image.tag | string | `nil` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -176,13 +176,6 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
-        # Copies the metrics exporter
-        - name: cp-metrics
-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /frr-metrics /etc/frr_metrics/"]
-          volumeMounts:
-            - name: metrics
-              mountPath: /etc/frr_metrics
       shareProcessNamespace: true
       {{- end }}
       containers:
@@ -329,21 +322,17 @@ spec:
             mountPath: /etc/frr
           - name: reloader
             mountPath: /etc/frr_reloader
+      {{- if .Values.speaker.frr.metrics.enabled }}
+      {{- with .Values.speaker.frr.metrics }}
       - name: frr-metrics
-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
-        command: ["/etc/frr_metrics/frr-metrics"]
+        image: {{ .image.repository }}:{{ .image.tag | default .Chart.AppVersion }}
         args:
           - --metrics-port=7473
         ports:
           - containerPort: 7473
             name: monitoring
-        volumeMounts:
-          - name: frr-sockets
-            mountPath: /var/run/frr
-          - name: frr-conf
-            mountPath: /etc/frr
-          - name: metrics
-            mountPath: /etc/frr_metrics
+      {{- end }}
+      {{- end }}
       {{- end }}
       nodeSelector:
         "kubernetes.io/os": linux

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -169,13 +169,6 @@ spec:
               mountPath: /tmp/frr
             - name: frr-conf
               mountPath: /etc/frr
-        # Copies the reloader to the shared volume between the speaker and reloader.
-        - name: cp-reloader
-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /frr-reloader.sh /etc/frr_reloader/"]
-          volumeMounts:
-            - name: reloader
-              mountPath: /etc/frr_reloader
       shareProcessNamespace: true
       {{- end }}
       containers:
@@ -277,6 +270,9 @@ spec:
       {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             add:
             - NET_ADMIN
@@ -309,12 +305,19 @@ spec:
               attempts=$(( $attempts + 1 ))
             done
             tail -f /etc/frr/frr.log
+      {{- with .Values.speaker.frr.reloader }}
       - name: reloader
-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
-        {{- if .Values.speaker.frr.image.pullPolicy }}
-        imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
+        image: {{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}
+        {{- if .image.pullPolicy }}
+        imagePullPolicy: {{ .image.pullPolicy }}
         {{- end }}
-        command: ["/etc/frr_reloader/frr-reloader.sh"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - name: frr-sockets
             mountPath: /var/run/frr
@@ -322,10 +325,18 @@ spec:
             mountPath: /etc/frr
           - name: reloader
             mountPath: /etc/frr_reloader
+      {{- end }}
       {{- if .Values.speaker.frr.metrics.enabled }}
       {{- with .Values.speaker.frr.metrics }}
       - name: frr-metrics
-        image: {{ .image.repository }}:{{ .image.tag | default .Chart.AppVersion }}
+        image: {{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         args:
           - --metrics-port=7473
         ports:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -312,6 +312,13 @@
                       "type": "boolean"
                     },
                     "image": { "$ref": "#/definitions/component/properties/image" }
+                  },
+                  "reloader": {
+                    "type": "object",
+                    "description": "FRR reloading image",
+                    "properties": {
+                      "image": {"$ref": "#/definitions/component/properties/image" }
+                    }
                   }
                 }
               },

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -303,7 +303,17 @@
                 "enabled": {
                   "type": "boolean"
                 },
-                "image": { "$ref": "#/definitions/component/properties/image" }
+                "image": { "$ref": "#/definitions/component/properties/image" },
+                "metrics" : {
+                  "type" : "object",
+                  "description": "Install FRR metrics sidecar",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "image": { "$ref": "#/definitions/component/properties/image" }
+                  }
+                }
               },
               "required": [ "enabled" ]
             }

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -42,7 +42,6 @@ prometheus:
 
   # Prometheus Operator PodMonitors
   podMonitor:
-
     # enable support for Prometheus Operator
     enabled: false
 
@@ -72,7 +71,6 @@ prometheus:
 
   # Prometheus Operator alertmanager alerts
   prometheusRule:
-
     # enable alertmanager alerts
     enabled: false
 
@@ -140,10 +138,11 @@ controller:
     # nobody
     runAsUser: 65534
     fsGroup: 65534
-  resources: {}
+  resources:
+    {}
     # limits:
-      # cpu: 100m
-      # memory: 100Mi
+    # cpu: 100m
+    # memory: 100Mi
   nodeSelector: {}
   tolerations: []
   priorityClassName: ""
@@ -189,10 +188,11 @@ speaker:
   ## By default secretName: {{ "metallb.fullname" }}-memberlist
   ##
   # secretName:
-  resources: {}
+  resources:
+    {}
     # limits:
-      # cpu: 100m
-      # memory: 100Mi
+    # cpu: 100m
+    # memory: 100Mi
   nodeSelector: {}
   tolerations: []
   priorityClassName: ""
@@ -224,6 +224,12 @@ speaker:
       pullPolicy:
     metrics:
       enabled: true
-      repository: quay.io/metallb/frr-metrics
-      tag:
-      pullPolicy:
+      image:
+        repository: quay.io/metallb/frr-metrics
+        tag:
+        pullPolicy:
+    reloader:
+      image:
+        repository: quay.io/metallb/frr-reloader
+        tag:
+        pullPolicy:

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -222,3 +222,8 @@ speaker:
       repository: frrouting/frr
       tag: v7.5.1
       pullPolicy:
+    metrics:
+      enabled: true
+      repository: quay.io/metallb/frr-metrics
+      tag:
+      pullPolicy:

--- a/frr-metrics/Dockerfile
+++ b/frr-metrics/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.17 AS builder
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
+WORKDIR $GOPATH/go.universe.tf/metallb
+
+# Cache the downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy frr-metrics
+COPY frr-metrics ./frr-metrics/
+# COPY internals
+COPY internal internal
+COPY api api
+
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  # build frr metrics
+  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=6 \
+  go build -v -o /build/frr-metrics \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  frr-metrics/exporter.go
+
+FROM alpine:latest
+
+COPY --from=builder /build/frr-metrics /frr-metrics
+COPY LICENSE /
+ENTRYPOINT ["/frr-metrics"]

--- a/frr-reloader/Dockerfile
+++ b/frr-reloader/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/frrouting/frr:v7.5.1
+
+COPY frr-reloader/frr-reloader.sh /frr-reloader.sh
+COPY LICENSE /
+ENTRYPOINT [ "/frr-reloader.sh" ]


### PR DESCRIPTION
Currently, FRR components for metrics and reloaded are packaged into speaker and are then copied out into
other containers via initContainers. This requires speaker to have a shell and to copy these components to
other containers. Instead, containers which have the requisite components can be created instead so that
they are properly packaged and secured.

Fixes #1428 