### PR TITLE
Disable metrics endpoint in controller-runtime

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -124,9 +124,10 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:         scheme,
-		Port:           9443, // TODO port only with controller, for webhooks
-		LeaderElection: false,
+		Scheme:             scheme,
+		Port:               9443, // TODO port only with controller, for webhooks
+		LeaderElection:     false,
+		MetricsBindAddress: "0", // Disable metrics endpoint of controller manager
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{
 				&metallbv1beta1.AddressPool{}:      namespaceSelector,


### PR DESCRIPTION
Disable the metrics endpoint in controller-runtime manager,
to allow start up on hosts that already use port 8080.
Fixed #1432