### PR TITLE
CI: Bump the operator version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,7 +245,7 @@ jobs:
         with:
           repository: metallb/metallb-operator
           path: metallboperator
-          ref: 705b767ef27731b89c851fdb762d2cc00d5136e2
+          ref: e0f17807883bfb64e0d58429ee3a5e4f200c9a9f
 
       - name: Create multi-node K8s Kind Cluster
         run: |


### PR DESCRIPTION
Aligning the metallb operator used in CI to the latest version so we can consume the latest webhook changes.