### PR TITLE
Fix docker metadata action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,7 +75,7 @@ jobs:
             quay.io/metallb/${{ matrix.image }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=ref,event=push
+            type=ref,event=branch
             type=semver,pattern={{version}}
           labels: |
             org.opencontainers.image.title=${{ matrix.image }}


### PR DESCRIPTION
Fixes release CI's docker metadata action to properly generate tags
instead of failing.
