### PR TITLE
Publish: checkout before publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      - name: Code checkout
+        uses: actions/checkout@v3
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v2
 
@@ -91,6 +94,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          push: true
           build-args: |
             GIT_BRANCH: ${{ github.ref_name }}
             GIT_COMMIT: ${{ github.sha }}


### PR DESCRIPTION
We need to checkout otherwise the dockerfiles won't be available.
Moreover, we set push to true to push the images.