### PR TITLE
Always use the main branch of the operator for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,7 +252,7 @@ jobs:
         with:
           repository: metallb/metallb-operator
           path: metallboperator
-          ref: e0f17807883bfb64e0d58429ee3a5e4f200c9a9f
+          ref: main
 
       - name: Checkout MetalLB
         uses: actions/checkout@v3


### PR DESCRIPTION
We normally align the operator to metallb changes, and this will avoid
the extra jump of bumping back the operator on metallb ci due to a
change in metallb itself.