### PR TITLE
Helm: make frr metrics port configurable

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -93,6 +93,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `"v7.5.1"` |  |
+| speaker.frr.metricsPort | int | `7473` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -333,9 +333,9 @@ spec:
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         command: ["/etc/frr_metrics/frr-metrics"]
         args:
-          - --metrics-port=7473
+          - --metrics-port={{ .Values.speaker.frr.metricsPort }}
         ports:
-          - containerPort: 7473
+          - containerPort: {{ .Values.speaker.frr.metricsPort }}
             name: monitoring
         volumeMounts:
           - name: frr-sockets

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -303,7 +303,8 @@
                 "enabled": {
                   "type": "boolean"
                 },
-                "image": { "$ref": "#/definitions/component/properties/image" }
+                "image": { "$ref": "#/definitions/component/properties/image" },
+                "metricsPort": { "type": "integer" }
               },
               "required": [ "enabled" ]
             }

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -229,6 +229,7 @@ speaker:
       repository: frrouting/frr
       tag: v7.5.1
       pullPolicy:
+    metricsPort: 7473
 
 crds:
   enabled: true


### PR DESCRIPTION
This commit makes frr metrics port to be configurable
from helm chart values.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
