### PR TITLE
Pod security admission support

### DIFF
--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: metallb-system
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: metallb-system
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/config/native/ns.yaml
+++ b/config/native/ns.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metallb-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -131,6 +131,21 @@ helm install metallb metallb/metallb -f values.yaml
 ```
 
 {{% notice note %}}
+The speaker pod requires elevated permission in order to perform its network functionalities.
+
+If you are using MetalLB with a kubernetes version that enforces [pod security admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) (which is beta in k8s
+1.23), the namespace MetalLB is deployed to must be labelled with:
+
+```yaml
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+{{% /notice %}}
+
+{{% notice note %}}
 If you want to deploy MetalLB using the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), the following value must be set:
 
 ```yaml


### PR DESCRIPTION
From 1.23, pod security admission can require the namespace to be labelled in order to allow the speaker pod to access to the network stack.
Here we add the labels to kustomize / manifests, and we document what labels need to be added to the ns in case the user is using helm (which requires the ns to be created externally).