### PR TITLE
Publish job: change the branch / tag selector

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - "main"
-      - "v.*"
+      - v*
     tags:
-      - ".*"
+      - v*
 
 jobs:
   unit-tests:


### PR DESCRIPTION
During the latest release, the job did not trigger. Using the same as
the helm chart which was triggered.