### PR TITLE
feat: fail helm templating if configInline is defined

### DIFF
--- a/charts/metallb/templates/deprecated_configInline.yaml
+++ b/charts/metallb/templates/deprecated_configInline.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.configInline }}
+{{- fail "Starting from v0.13.0 configInline is no longer supported. Please see https://metallb.universe.tf/#backward-compatibility" }}
+{{- end }}


### PR DESCRIPTION
This PR will prevent existing setups from destroying themselves, by raising an exception if `configInline` is defined.
```
philipp@ ~/metallb/charts/metallb (patch-2) $ helm template --namespace metallb-system metallb . --set configInline.bla.foo=hi
zsh: correct 'template' to 'templates' [nyae]? n
Error: execution error at (metallb/templates/deprecated_configInline.yaml:2:4): Starting from v0.13.0 configInline is no longer supported. Please see https://metallb.universe.tf/#backward-compatibility

Use --debug flag to render out invalid YAML
philipp@ ~/metallb/charts/metallb (patch-2) $
```