### PR TITLE
Charts: add the selectorlabels to the webhook service and give controller permission to watch communities

### DIFF
--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -124,7 +124,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["metallb.io"]
   resources: ["communities"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list","watch"]
 - apiGroups: ["metallb.io"]
   resources: ["bfdprofiles"]
   verbs: ["get", "list","watch"]

--- a/charts/metallb/templates/webhooks.yaml
+++ b/charts/metallb/templates/webhooks.yaml
@@ -156,6 +156,7 @@ spec:
   - port: 443
     targetPort: 9443
   selector:
+    {{- include "metallb.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 ---
 apiVersion: v1


### PR DESCRIPTION
The selector is only aiming at app.kubernetes.io/component, so if
there's another pod in the same namespace labeled controller, the
webhook service won't work (or it will work only if the service balances
the request to the real controller).

Also, give the controller the required permissions to watch communities.
