### PR TITLE
Remove the cidr check with ip ranges

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -753,8 +753,12 @@ func bgpAdvertisementsFromLegacyCR(ads []metallbv1beta1.LegacyBgpAdvertisement, 
 				maxLength = ad.AggregationLengthV6
 			}
 
-			// in case of range format, we may have a set of cidrs associated to a given address.
-			// We reject if none of the cidrs are compatible with the aggregation length.
+			// we don't check in case of range formats, because we don't know if the originating range
+			// is a full range minus buggy ips.
+			if strings.Contains(addr, "-") {
+				continue
+			}
+
 			lowest := lowestMask(cidrs)
 			if maxLength < lowest {
 				return nil, fmt.Errorf("invalid aggregation length %d: prefix %d in "+
@@ -814,8 +818,12 @@ func validateBGPAdvPerPool(adv *BGPAdvertisement, pool *Pool) error {
 			maxLength = adv.AggregationLengthV6
 		}
 
-		// in case of range format, we may have a set of cidrs associated to a given address.
-		// We reject if none of the cidrs are compatible with the aggregation length.
+		// we don't check in case of range formats, because we don't know if the originating range
+		// is a full range minus buggy ips.
+		if strings.Contains(addr, "-") {
+			continue
+		}
+
 		lowest := lowestMask(cidrs)
 		if maxLength < lowest {
 			return fmt.Errorf("invalid aggregation length %d: prefix %d in "+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -842,28 +842,6 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			desc: "aggregation length by range, too wide",
-			crs: ClusterResources{
-				Pools: []v1beta1.IPAddressPool{
-					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
-						Spec: v1beta1.IPAddressPoolSpec{
-							Addresses: []string{
-								"3.3.3.2-3.3.3.254",
-							},
-						},
-					},
-				},
-				BGPAdvs: []v1beta1.BGPAdvertisement{
-					{
-						Spec: v1beta1.BGPAdvertisementSpec{
-							AggregationLength: pointer.Int32Ptr(24),
-						},
-					},
-				},
-			},
-		},
-		{
 			desc: "duplicate ip address pools - in L2 adv",
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{testPool},


### PR DESCRIPTION
Implementing a reliable cidr check without offering the remove buggy ips
flag is not possible.

A user that wants a full cidr without buggy ips will have to specify the
range without the extremes, and trying to reverse the logic of removing
the buggy ips is not reliable.

For this reason, we remove the consistency check between the cidr and
the aggregation length in case the cidr comes from a manual range.

Potential fix for the first issue described in https://github.com/metallb/metallb/issues/1495 (but also affecting regular users who want to avoid the buggyips).

Potential alternatives to this implementation:
- we competely remove the check, making the behaviour simmetric
- we restore the avoidbuggyips flag

