### PR TITLE
Configmap converter: don't default keepalive time

### DIFF
--- a/configmaptocrs/testdata/config.golden
+++ b/configmaptocrs/testdata/config.golden
@@ -7,7 +7,7 @@ metadata:
   namespace: metallb-system
 spec:
   holdTime: 1m30s
-  keepaliveTime: 30s
+  keepaliveTime: 0s
   myASN: 64512
   passwordSecret: {}
   peerASN: 64512
@@ -22,7 +22,7 @@ metadata:
   namespace: metallb-system
 spec:
   holdTime: 1m30s
-  keepaliveTime: 30s
+  keepaliveTime: 0s
   myASN: 64512
   passwordSecret: {}
   peerASN: 64512


### PR DESCRIPTION
We don't need to default it during the conversion, as if it's nil the config logic will fill it accordingly.
Moreover, deployments with the native bgp mode will fail.

The result is a CR with `keepaliveTime: 0s`, because of the 0 value of the struct. 
Nonethless, the webhook won't refuse the field and the loading logic will default the internal value to the right default if needed. 

This should address the second part of https://github.com/metallb/metallb/issues/1495, described here https://github.com/metallb/metallb/issues/1495#issuecomment-1179804400