### PR TITLE
L2: add ndp responders when the address is v6 only

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -95,7 +95,7 @@ func (a *Announce) updateInterfaces() {
 			if ipaddr.IP.To4() != nil && (ifi.Flags&net.FlagBroadcast) != 0 {
 				keepARP[ifi.Index] = true
 			}
-			if ipaddr.IP.IsLinkLocalUnicast() {
+			if ipaddr.IP.To4() == nil && ipaddr.IP.IsLinkLocalUnicast() {
 				keepNDP[ifi.Index] = true
 			}
 		}

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -8,6 +8,7 @@ weight: 8
 Bug Fixes:
 
 - Change the validating webhook configuration name to metallb-webhook-configuration instead of validating-webhook-configuration ([PR 1497](https://github.com/metallb/metallb/pull/1497))
+- L2 mode not working with ipv4 only nodes ([Issue 1507](https://github.com/metallb/metallb/issues/1507) , [PR 1506](https://github.com/metallb/metallb/pull/1506))
 
 ## Version 0.13.3
 


### PR DESCRIPTION
A regression introduced by
https://github.com/metallb/metallb/pull/1347, we were adding records to
the keepNDP map regardless of the fact that a v6 address was present on
the interface.
Here we enforce the if checking that the ip is not v4.

Fixes https://github.com/metallb/metallb/issues/1507

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>