### PR TITLE
Revert "Filter out no IP interfaces for L2 advertisement"

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -86,18 +86,20 @@ func (a *Announce) updateInterfaces() {
 				continue
 			}
 		}
+		if ifi.Flags&net.FlagBroadcast != 0 {
+			keepARP[ifi.Index] = true
+		}
 
 		for _, a := range addrs {
 			ipaddr, ok := a.(*net.IPNet)
 			if !ok {
 				continue
 			}
-			if ipaddr.IP.To4() != nil && (ifi.Flags&net.FlagBroadcast) != 0 {
-				keepARP[ifi.Index] = true
+			if ipaddr.IP.To4() != nil || !ipaddr.IP.IsLinkLocalUnicast() {
+				continue
 			}
-			if ipaddr.IP.To4() == nil && ipaddr.IP.IsLinkLocalUnicast() {
-				keepNDP[ifi.Index] = true
-			}
+			keepNDP[ifi.Index] = true
+			break
 		}
 
 		if keepARP[ifi.Index] && a.arps[ifi.Index] == nil {


### PR DESCRIPTION
This reverts commit 9936f3b89a96e6e05bbddae815b6351d4ee243c1.

There's a use case where metallb is used together with vlan interfaces
with no ips which wouldn't work with this change.

For this reason, it makes sense to listen and announce on interfaces
with no ip.
