### PR TITLE
Doc fixes

### DIFF
--- a/website/content/configuration/_advanced_ipaddresspool_config.md
+++ b/website/content/configuration/_advanced_ipaddresspool_config.md
@@ -14,7 +14,7 @@ with free addresses. This might end up using "expensive" addresses for
 services that don't require it.
 
 To prevent this behaviour you can disable automatic allocation for a pool
-by setting the `auto-assign` flag to `false`:
+by setting the `autoAssign` flag to `false`:
 
 ```yaml
 apiVersion: metallb.io/v1beta1

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -8,7 +8,7 @@ creating and deploying various resources into **the same namespace**
 (metallb-system) MetalLB is deployed into.
 
 There are various examples of the configuration CRs in
-[`configsamples`](https://raw.githubusercontent.com/metallb/metallb/main/configsamples).
+[`configsamples`](https://github.com/metallb/metallb/tree/main/configsamples).
 
 Also, the API is [fully documented here](../apis/_index.md).
 


### PR DESCRIPTION
Error during translating from configmaps, the right name is autoAssign.
Broken link to the configuration examples