### PR TITLE
Helm: setting the command for the controller and the speaker

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -62,6 +62,9 @@ spec:
         {{- if .Values.loadBalancerClass }}
         - --lb-class={{ .Values.loadBalancerClass }}
         {{- end }}
+        {{- if .Values.controller.webhookMode }}
+        - --webhook-mode={{ .Values.controller.webhookMode }}
+        {{- end }}
         env:
         {{- if and .Values.speaker.enabled .Values.speaker.memberlist.enabled }}
         - name: METALLB_ML_SECRET_NAME

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -49,6 +49,10 @@ spec:
         {{- if .Values.controller.image.pullPolicy }}
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- end }}
+        {{- if .Values.controller.command }}
+        command:
+          - {{ .Values.controller.command }}
+        {{- end }}
         args:
         - --port={{ .Values.prometheus.metricsPort }}
         {{- with .Values.controller.logLevel }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -194,6 +194,10 @@ spec:
         {{- if .Values.speaker.image.pullPolicy }}
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         {{- end }}
+        {{- if .Values.speaker.command }}
+        command:
+          - {{ .Values.speaker.command }}
+        {{- end }}
         args:
         - --port={{ .Values.prometheus.metricsPort }}
         {{- with .Values.speaker.logLevel }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -346,6 +346,9 @@
           },
           "command" : {
             "type": "string"
+          },
+          "webhookMode" : {
+            "type": "string"
           }
         }
       }

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -319,6 +319,9 @@
                 "metricsPort": { "type": "integer" }
               },
               "required": [ "enabled" ]
+            },
+            "command" : {
+              "type": "string"
             }
           },
           "required": [ "tolerateMaster" ]
@@ -340,6 +343,9 @@
               }
             },
             "required": [ "type" ]
+          },
+          "command" : {
+            "type": "string"
           }
         }
       }

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -130,6 +130,7 @@ controller:
   enabled: true
   # -- Controller log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none`
   logLevel: info
+  # command: /controller
   image:
     repository: quay.io/metallb/controller
     tag:
@@ -186,6 +187,7 @@ controller:
 # daemonset.
 speaker:
   enabled: true
+  # command: /speaker
   # -- Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none`
   logLevel: info
   tolerateMaster: true

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -131,6 +131,7 @@ controller:
   # -- Controller log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none`
   logLevel: info
   # command: /controller
+  # webhookMode: enabled
   image:
     repository: quay.io/metallb/controller
     tag:


### PR DESCRIPTION
Another change required to align the operator deployment:

- setting the command for the two pods (in case the image used doesn't have a default entry point)
- setting the webhook mode (in the operator the webhook is deployed together with the operator, and in the controller the webhook is disabled)