### PR TITLE
Support optional creation of rbac resources for prometheus

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -85,6 +85,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | prometheus.prometheusRule.extraAlerts | list | `[]` |  |
 | prometheus.prometheusRule.staleConfig.enabled | bool | `true` |  |
 | prometheus.prometheusRule.staleConfig.labels.severity | string | `"warning"` |  |
+| prometheus.rbacPrometheus | bool | `true` |  |
 | prometheus.rbacProxy.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
 | prometheus.rbacProxy.tag | string | `"v0.12.0"` |  |
 | prometheus.scrapeAnnotations | bool | `false` |  |

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -75,6 +75,7 @@ spec:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
 ---
+{{- if .Values.prometheus.rbacPrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -101,4 +102,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.serviceAccount }}
     namespace: {{ required ".Values.prometheus.namespace must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.namespace }}
+{{- end }}
 {{- end }}

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -155,6 +155,7 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
+{{- if .Values.prometheus.rbacPrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -183,4 +184,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.serviceMonitor.enabled == true" .Values.prometheus.serviceAccount }}
     namespace: {{ required ".Values.prometheus.namespace must be defined when .Values.prometheus.serviceMonitor.enabled == true" .Values.prometheus.namespace }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -179,6 +179,7 @@
         "scrapeAnnotations": { "type": "boolean" },
         "metricsPort": { "type": "integer" },
         "secureMetricsPort": { "type": "integer" },
+        "rbacPrometheus": { "type": "boolean" },
         "serviceAccount": { "type": "string" },
         "namespace": { "type": "string" },
         "rbacProxy": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -42,12 +42,15 @@ prometheus:
   # certificate to be used.
   controllerMetricsTLSSecret: ""
 
+  # prometheus doens't have the permission to scrape all namespaces so we give it permission to scrape metallb's one
+  rbacPrometheus: true
+
   # the service account used by prometheus
-  # required when .Values.prometheus.podMonitor.enabled == true
+  # required when " .Values.prometheus.rbacPrometheus == true " and " .Values.prometheus.podMonitor.enabled=true or prometheus.serviceMonitor.enabled=true "
   serviceAccount: ""
 
   # the namespace where prometheus is deployed
-  # required when .Values.prometheus.podMonitor.enabled == true
+  # required when " .Values.prometheus.rbacPrometheus == true " and " .Values.prometheus.podMonitor.enabled=true or prometheus.serviceMonitor.enabled=true "
   namespace: ""
 
   # the image to be used for the kuberbacproxy container

--- a/tasks.py
+++ b/tasks.py
@@ -386,7 +386,7 @@ def dev_env(ctx, architecture="amd64", name="kind", protocol=None, frr_volume_di
                 "--set controller.logLevel=debug {} --namespace metallb-system".format(architecture, architecture, 
                 "true" if bgp_type == "frr" else "false", prometheus_values), echo=True)
     else:
-        run("kubectl delete po -nmetallb-system --all", echo=True)
+        run("kubectl delete po -n metallb-system --all", echo=True)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_file = tmpdir + "/metallb.yaml"


### PR DESCRIPTION
In general, Prometheus is able to watch the various resources needed such as serviceMonitor, So we don't need to explicitly create prometheus rbac resources in the matallb. Optional, You can also pass "--set prometheus.rbacPrometheus.enabled=true --set prometheus.rbacPrometheus.serviceAccount= --set prometheus.rbacPrometheus.namespace=<prometheus-operator-namespace" to create rbac resources for prometheus.


Signed-off-by:  cyclinder <qifeng.guo@daocloud.io>