### PR TITLE
L2 SetBalancer: return instead of continue if we find the ip

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -227,14 +227,13 @@ func (a *Announce) SetBalancer(name string, ip net.IP) {
 
 	// Kubernetes may inform us that we should advertise this address multiple
 	// times, so just no-op any subsequent requests.
-	if ips, ok := a.ips[name]; ok {
-		for i, ip := range ips {
-			if ip.Equal(a.ips[name][i]) {
-				continue
+	if serviceIPs, ok := a.ips[name]; ok {
+		for _, serviceIP := range serviceIPs {
+			if serviceIP.Equal(ip) {
+				return
 			}
 		}
 	}
-
 	a.ips[name] = append(a.ips[name], ip)
 
 	a.ipRefcnt[ip.String()]++

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -38,7 +38,13 @@ func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 		<-announce.spamCh
 
 		if !announce.AnnounceName(service.name) {
-			t.Fatalf("service %v is not anounced", service.name)
+			t.Fatalf("service %v is not announced", service.name)
 		}
+	}
+	if len(announce.ips["foo"]) != 2 {
+		t.Fatalf("service foo has more than 2 ips: %d", len(announce.ips["foo"]))
+	}
+	if announce.ipRefcnt["192.168.1.20"] != 2 {
+		t.Fatalf("ip 192.168.1.20 has not 2 refcnt: %d", announce.ipRefcnt["192.168.1.20"])
 	}
 }


### PR DESCRIPTION
In transitioning to dual stack we introduced an issue: if the ip was found, instead of returning the new code continued, grewing the a.ips[name] list on every service update.