### PR TITLE
Epslices detection: use discoveryv1 instead of v1beta1

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -487,7 +487,7 @@ func UseEndpointSlices(kubeClient kubernetes.Interface) bool {
 		return false
 	}
 	// this is needed to check if ep slices are enabled on the cluster. In 1.17 the resources are there but disabled by default
-	if _, err := kubeClient.DiscoveryV1beta1().EndpointSlices("default").Get(context.Background(), "kubernetes", metav1.GetOptions{}); err != nil {
+	if _, err := kubeClient.DiscoveryV1().EndpointSlices("default").Get(context.Background(), "kubernetes", metav1.GetOptions{}); err != nil {
 		return false
 	}
 	return true


### PR DESCRIPTION
v1beta1 is not being served anymore in 1.25, which will make metallb
unable to detect the availability of epslices.
Fixes https://github.com/metallb/metallb/issues/1578