### PR TITLE
Slower debounce time in FRR reloading

### DIFF
--- a/frr-reloader/frr-reloader.sh
+++ b/frr-reloader/frr-reloader.sh
@@ -9,23 +9,25 @@ cleanup() {
 reload_frr() {
   flock 200
   echo "Caught SIGHUP and acquired lock! Reloading FRR.."
+  SECONDS=0
+
   kill_sleep
 
   echo "Checking the configuration file syntax"
   if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" ; then
-    echo "Syntax error spotted: aborting.."
+    echo "Syntax error spotted: aborting.. $SECONDS seconds"
     echo -n "$(date +%s) failure"  > "$STATUSFILE"
     return
   fi
 
   echo "Applying the configuration file"
   if ! python3 /usr/lib/frr/frr-reload.py --reload --overwrite --stdout "$FILE_TO_RELOAD" ; then
-    echo "Failed to fully apply configuration file"
+    echo "Failed to fully apply configuration file $SECONDS seconds"
     echo -n "$(date +%s) failure"  > "$STATUSFILE"
     return
   fi
   
-  echo "FRR reloaded successfully!"
+  echo "FRR reloaded successfully! $SECONDS seconds"
   echo -n "$(date +%s) success"  > "$STATUSFILE"
 } 200<"$LOCKFILE"
 

--- a/internal/bgp/frr/debounce_test.go
+++ b/internal/bgp/frr/debounce_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/go-kit/log"
 )
 
 const timer = 10 * time.Millisecond
@@ -20,7 +22,7 @@ func TestDebounce(t *testing.T) {
 
 	reload := make(chan reloadEvent)
 	defer close(reload)
-	debouncer(dummyUpdate, reload, timer, failureTimer)
+	debouncer(dummyUpdate, reload, timer, failureTimer, log.NewNopLogger())
 	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
 	reload <- reloadEvent{config: &frrConfig{Hostname: "2"}}
 	reload <- reloadEvent{config: &frrConfig{Hostname: "3"}}
@@ -63,7 +65,7 @@ func TestDebounceRetry(t *testing.T) {
 
 	reload := make(chan reloadEvent)
 	defer close(reload)
-	debouncer(dummyUpdate, reload, timer, failureTimer)
+	debouncer(dummyUpdate, reload, timer, failureTimer, log.NewNopLogger())
 
 	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
 	reload <- reloadEvent{config: &frrConfig{Hostname: "2"}}
@@ -89,7 +91,7 @@ func TestDebounceReuseOld(t *testing.T) {
 
 	reload := make(chan reloadEvent)
 	defer close(reload)
-	debouncer(dummyUpdate, reload, timer, failureTimer)
+	debouncer(dummyUpdate, reload, timer, failureTimer, log.NewNopLogger())
 
 	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
 	if len(result) != 0 {
@@ -112,5 +114,40 @@ func TestDebounceReuseOld(t *testing.T) {
 	updated = <-result
 	if updated.Hostname != "1" {
 		t.Fatal("Config was not updated")
+	}
+}
+
+func TestDebounceSameConfig(t *testing.T) {
+	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	dummyUpdate := func(config *frrConfig) error {
+		result <- config
+		return nil
+	}
+
+	reload := make(chan reloadEvent)
+	defer close(reload)
+	debouncer(dummyUpdate, reload, timer, failureTimer, log.NewNopLogger())
+	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "2"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "3", Routers: map[string]*routerConfig{"foo": {MyASN: 23}}}}
+	if len(result) != 0 {
+		t.Fatal("received update before time")
+	}
+	time.Sleep(3 * timer)
+	if len(result) != 1 {
+		t.Fatal("received extra updates", len(result))
+	}
+	updated := <-result
+	if updated.Hostname != "3" {
+		t.Fatal("Config was not updated")
+	}
+
+	reload <- reloadEvent{config: &frrConfig{Hostname: "3", Routers: map[string]*routerConfig{"foo": {MyASN: 23}}}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "3", Routers: map[string]*routerConfig{"foo": {MyASN: 23}}}}
+
+	time.Sleep(3 * timer)
+	if len(result) != 0 {
+		updated := <-result
+		t.Fatalf("received extra updates: %d %s", len(result), updated.Hostname)
 	}
 }

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -305,7 +305,7 @@ func NewSessionManager(l log.Logger, logLevel logging.Level) *sessionManager {
 		return generateAndReloadConfigFile(config, l)
 	}
 
-	debouncer(reload, res.reloadConfig, debounceTimeout, failureTimeout)
+	debouncer(reload, res.reloadConfig, debounceTimeout, failureTimeout, l)
 
 	reloadValidator(l, res.reloadConfig)
 

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -291,7 +291,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 	return config, nil
 }
 
-var debounceTimeout = 500 * time.Millisecond
+var debounceTimeout = 3 * time.Second
 var failureTimeout = time.Second * 5
 
 func NewSessionManager(l log.Logger, logLevel logging.Level) *sessionManager {


### PR DESCRIPTION
In corner cases where we have a bouncing service, the number of updates requested to the reloader is higher than how fast the reloader is able to consume those requests. The requests are mutexed, so what happens is that we have a long (and growing) list of reloader child processes spun up by the sighup that we are not able to estinguish.
This consumes memory and may end up in having the speaker killed.

To fix this, we make the debounce timeout longer

Fixes https://github.com/metallb/metallb/issues/1581
