### PR TITLE
e2e: allow using external containers

### DIFF
--- a/e2etest/README.md
+++ b/e2etest/README.md
@@ -63,3 +63,22 @@ The following diagram describes the networks, the pods and the containers involv
 ```
 
 The above diagram is implemented in `infra_setup.go`.
+
+## Use Existing Containers
+
+The E2E tests can run while using existing FRR containers that act as the single/multi-hop BGP routers.
+
+To do so, pass the flag `external-containers` with the value of a comma-separated list of containers names.
+The valid names are: `ibgp-single-hop` / `ibgp-multi-hop` / `ebgp-single-hop` / `ebgp-multi-hop`.
+
+The test setup will use them instead of creating the external frr containers on its own.
+
+The requirements for this are:
+- The external FRR containers must be named as `ibgp-single-hop` / `ibgp-multi-hop` / `ebgp-single-hop` / `ebgp-multi-hop`.
+- When running with an multi-hop container, the `ebgp-single-hop` container must be present.
+Other than that, the multi-hop containers must be connected to a docker network named
+`multi-hop-net`. The test suite will take care of connecting the `ebgp-single-hop` to the multi-hop-net and creating the required static routes between the speakers and the containers, as well as configuring the external FRR containers.
+- When using existing container, i.e. `ibgp_single_hop`, you have to mount a directory named `ibgp-single-hop`
+that has the initial frr configurations files (vtysh.conf, zebra.conf, daemons, bgpd.conf, bfdd.conf).
+See `metallb/e2etest/config/frr` for example.
+Note that the test's teardown will delete the directory, so it's recommended to keep a copy of the directory in a different place.

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -58,6 +58,7 @@ var (
 	prometheusNamespace string
 	nodeNics            string
 	localNics           string
+	external_containers string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -85,6 +86,7 @@ func handleFlags() {
 	flag.BoolVar(&useOperator, "use-operator", false, "set this to true to run the tests using operator custom resources")
 	flag.StringVar(&reportPath, "report-path", "/tmp/report", "the path to be used to dump test failure information")
 	flag.StringVar(&prometheusNamespace, "prometheus-namespace", "monitoring", "the namespace prometheus is running in (if running)")
+	flag.StringVar(&external_containers, "external-containers", "", "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)")
 	flag.Parse()
 }
 
@@ -133,10 +135,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	cs, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
 
-	framework.ExpectNoError(err)
 	v4Addresses := strings.Split(ipv4ForContainers, ",")
 	v6Addresses := strings.Split(ipv6ForContainers, ",")
-	bgptests.FRRContainers, err = bgptests.InfraSetup(v4Addresses, v6Addresses, cs)
+	bgptests.FRRContainers, err = bgptests.InfraSetup(v4Addresses, v6Addresses, external_containers, cs)
 	framework.ExpectNoError(err)
 
 	clientconfig, err := framework.LoadConfig()

--- a/tasks.py
+++ b/tasks.py
@@ -748,8 +748,9 @@ def helmdocs(ctx, env="container"):
     "prometheus_namespace": "the namespace prometheus is deployed to, to validate metrics against prometheus.",
     "node_nics": "a list of node's interfaces separated by comma, default is kind",
     "local_nics": "a list of bridges related node's interfaces separated by comma, default is kind",
+    "external_containers": "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)",
 })
-def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="kube-system,metallb-system", service_pod_port=80, skip_docker=False, focus="", skip="", ipv4_service_range=None, ipv6_service_range=None, prometheus_namespace="", node_nics="kind", local_nics="kind"):
+def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="kube-system,metallb-system", service_pod_port=80, skip_docker=False, focus="", skip="", ipv4_service_range=None, ipv6_service_range=None, prometheus_namespace="", node_nics="kind", local_nics="kind", external_containers=""):
     """Run E2E tests against development cluster."""
     if skip_docker:
         opt_skip_docker = "--skip-docker"
@@ -808,8 +809,11 @@ def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="k
     print("Writing reports to {}".format(report_path))
     os.makedirs(report_path, exist_ok=True)
 
+    if external_containers != "":
+        external_containers = "--external-containers="+(external_containers)
+
     testrun = run("cd `git rev-parse --show-toplevel`/e2etest &&"
-            "KUBECONFIG={} go test -timeout 3h {} {} --provider=local --kubeconfig={} --service-pod-port={} {} {} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {}".format(kubeconfig, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ips_for_containers_v4, ips_for_containers_v6, ipv4_service_range, ipv6_service_range, opt_skip_docker, report_path, prometheus_namespace, node_nics, local_nics), warn="True")
+            "KUBECONFIG={} go test -timeout 3h {} {} --provider=local --kubeconfig={} --service-pod-port={} {} {} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {} {}".format(kubeconfig, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ips_for_containers_v4, ips_for_containers_v6, ipv4_service_range, ipv6_service_range, opt_skip_docker, report_path, prometheus_namespace, node_nics, local_nics, external_containers), warn="True")
 
     if export != None:
         run("kind export logs {}".format(export))


### PR DESCRIPTION
This commit adds the option to run e2etests with existing containers, i.e. the tests don't create the external FRR containers, but use existing ones. see e2etest/README.md for more information.

Extra general code gardening:
* On e2etest_suite_test.go - Deleted redundant assertion.
* On container.go - Renamed function "Stop" to "Delete" to reflect better what it does.
* On container.go - Deleted redundant "todo" comment.