### PR TITLE
Fixing broken link in configuration docs

### DIFF
--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -10,7 +10,7 @@ creating and deploying various resources into **the same namespace**
 There are various examples of the configuration CRs in
 [`configsamples`](https://github.com/metallb/metallb/tree/main/configsamples).
 
-Also, the API is [fully documented here](../apis/_index.md).
+Also, the API is [fully documented here](../apis/).
 
 {{% notice note %}}
 If you installed MetalLB with Helm, you will need to change the


### PR DESCRIPTION
The link references the markdown file that Hugo uses, which isn't the actual path to the API documentation.