### PR TITLE
Update reference to API docs

### DIFF
--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -10,7 +10,7 @@ creating and deploying various resources into **the same namespace**
 There are various examples of the configuration CRs in
 [`configsamples`](https://github.com/metallb/metallb/tree/main/configsamples).
 
-Also, the API is [fully documented here](../apis/_index.md).
+Also, the API is [fully documented here](../apis/).
 
 {{% notice note %}}
 If you installed MetalLB with Helm, you will need to change the


### PR DESCRIPTION
This is a small change that fixes the API link shown on the `Configuration` section of the documentation, which currently returns a 404