### PR TITLE
chart: add option to set speaker sidecar resources

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -110,6 +110,8 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.frr.image.repository | string | `"frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `"v7.5.1"` |  |
 | speaker.frr.metricsPort | int | `7473` |  |
+| speaker.frr.resources | object | `{}` |  |
+| speaker.frrMetrics.resources | object | `{}` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
@@ -131,6 +133,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.readinessProbe.periodSeconds | int | `10` |  |
 | speaker.readinessProbe.successThreshold | int | `1` |  |
 | speaker.readinessProbe.timeoutSeconds | int | `1` |  |
+| speaker.reloader.resources | object | `{}` |  |
 | speaker.resources | object | `{}` |  |
 | speaker.runtimeClassName | string | `""` |  |
 | speaker.serviceAccount.annotations | object | `{}` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -328,6 +328,10 @@ spec:
               attempts=$(( $attempts + 1 ))
             done
             tail -f /etc/frr/frr.log
+        {{- with .Values.speaker.frr.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       - name: reloader
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}
@@ -341,6 +345,10 @@ spec:
             mountPath: /etc/frr
           - name: reloader
             mountPath: /etc/frr_reloader
+        {{- with .Values.speaker.reloader.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       - name: frr-metrics
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         command: ["/etc/frr_metrics/frr-metrics"]
@@ -356,6 +364,10 @@ spec:
             mountPath: /etc/frr
           - name: metrics
             mountPath: /etc/frr_metrics
+        {{- with .Values.speaker.frrMetrics.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.prometheus.secureMetricsPort }}
       - name: kube-rbac-proxy

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -343,12 +343,25 @@
                 },
                 "image": { "$ref": "#/definitions/component/properties/image" },
                 "metricsPort": { "type": "integer" },
-                "secureMetricsPort": { "type": "integer" }
+                "secureMetricsPort": { "type": "integer" },
+                "resources:": { "type": "object" }
               },
               "required": [ "enabled" ]
             },
             "command" : {
               "type": "string"
+            },
+            "reloader": {
+              "type": "object",
+              "properties": {
+                "resources": { "type": "object" }
+              }
+            },
+            "frrMetrics": {
+              "type": "object",
+              "properties": {
+                "resources": { "type": "object" }
+              }
             }
           },
           "required": [ "tolerateMaster" ]

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -315,10 +315,17 @@ speaker:
       tag: v7.5.1
       pullPolicy:
     metricsPort: 7473
+    resources: {}
 
     # if set, enables a rbac proxy sidecar container on the speaker to
     # expose the frr metrics via tls.
     # secureMetricsPort: 9121
+
+  reloader:
+    resources: {}
+
+  frrMetrics:
+    resources: {}
 
 crds:
   enabled: true


### PR DESCRIPTION
Add option to set speaker sidecar resources in helm chart (for these containers, frr, reloader, and frr-metrics)