### PR TITLE
configurable failurePolicy for validating webhooks

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -52,6 +52,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | controller.strategy.type | string | `"RollingUpdate"` |  |
 | controller.tolerations | list | `[]` |  |
 | crds.enabled | bool | `true` |  |
+| crds.validationFailurePolicy | string | `"Fail"` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | loadBalancerClass | string | `""` |  |

--- a/charts/metallb/templates/webhooks.yaml
+++ b/charts/metallb/templates/webhooks.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-addresspool
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: addresspoolvalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -32,7 +32,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta2-bgppeer
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: bgppeervalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -52,7 +52,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-ipaddresspool
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: ipaddresspoolvalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -72,7 +72,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-bgpadvertisement
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: bgpadvertisementvalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -92,7 +92,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-community
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: communityvalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -112,7 +112,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-bfdprofile
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: bfdprofilevalidationwebhook.metallb.io
   rules:
   - apiGroups:
@@ -132,7 +132,7 @@ webhooks:
       name: metallb-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-metallb-io-v1beta1-l2advertisement
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.crds.validationFailurePolicy }}
   name: l2advertisementvalidationwebhook.metallb.io
   rules:
   - apiGroups:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -354,6 +354,21 @@
           "required": [ "tolerateMaster" ]
         }
       ]
+    },
+    "crds": {
+      "description": "CRD configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable CRDs",
+          "type": "boolean"
+        },
+        "validationFailurePolicy": {
+          "description": "Failure policy to use with validating webhooks",
+          "type": "string",
+          "enum": [ "Ignore", "Fail" ]
+        }
+      }
     }
   },
   "controller": { 

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -322,3 +322,4 @@ speaker:
 
 crds:
   enabled: true
+  validationFailurePolicy: Fail


### PR DESCRIPTION
This PR adds a new configuration option to the helm chart: `crds.validationFailurePolicy`. The value is injected into the validating webhook's `failurePolicy` field. Defaults to `Fail` (current behavior).

---

Closes https://github.com/metallb/metallb/issues/1598