### PR TITLE
Docs: remove the experimental wording around FRR

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -57,7 +57,6 @@ Previous versions of MetalLB are configurable via a `configmap`. However, starti
 `v0.13.0`, it will be possible to configure it only via CRs. [A tool to convert]({{% relref "configuration/migration_to_crds.md" %}}) old configmaps to CRs
 is provided as a container image under `quay.io/metallb/configmaptocrs`.
 
-
 ## Usage
 
 The [concepts]({{% relref "concepts/_index.md" %}}) section will give
@@ -68,9 +67,11 @@ to deploy to a Kubernetes cluster, head to the
 
 ## FRR Mode
 
-MetalLB implements an experimental FRR Mode that uses an [FRR](https://frrouting.org/) container as the backend for handling BGP sessions. It provides features that are not available with the native BGP implementation, such as pairing BGP sessions with BFD sessions, and advertising IPV6 addresses.
+MetalLB implements a FRR Mode that uses an [FRR](https://frrouting.org/) container as the backend for handling BGP sessions. It provides features that are not available with the native BGP implementation, such as pairing BGP sessions with BFD sessions, and advertising IPV6 addresses.
 
-The FRR mode is considered to be experimental, please see the [installation](https://metallb.universe.tf/installation/) section for instructions on how to enable it.
+Despite being less battle tested than the native BGP implementation, the FRR mode is currently used by those users that require either BFD or IPV6, and it is the only supported method in the MetalLB version distributed with OpenShift. The long term plan is to make it the only BGP implementation available in MetalLB.
+
+Please see the [installation](https://metallb.universe.tf/installation/) section for instructions on how to enable it.
 
 ## Contributing
 

--- a/website/content/concepts/bgp.md
+++ b/website/content/concepts/bgp.md
@@ -122,7 +122,7 @@ strategies you can employ:
 
 ## FRR Mode
 
-MetalLB provides an experimental mode using FRR as a backend for the BGP
+MetalLB provides a deployment mode that uses FRR as a backend for the BGP
 layer.
 
 When the FRR mode is enabled, the following additional features are available:

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -189,7 +189,7 @@ spec:
 
 ### Enabling BFD support for BGP sessions
 
-With the experimental FRR mode, BGP sessions can be backed up by BFD sessions in order to provide a quicker path failure detection than BGP alone provides.
+With the FRR mode, BGP sessions can be backed up by BFD sessions in order to provide a quicker path failure detection than BGP alone provides.
 
 In order to enable BFD, a BFD profile must be added and referenced by a given peer:
 

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -63,7 +63,7 @@ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/config/m
 ```
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), apply the manifests:
+If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), apply the manifests:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/config/manifests/metallb-frr.yaml
@@ -109,7 +109,7 @@ resources:
   - github.com/metallb/metallb/config/native?ref=main
 ```
 
-In order to deploy the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions):
+In order to deploy the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions):
 
 ```yaml
 # kustomization.yml
@@ -151,7 +151,7 @@ If you are using MetalLB with a kubernetes version that enforces [pod security a
 {{% /notice %}}
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), the following value must be set:
+If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), the following value must be set:
 
 ```yaml
 speaker:
@@ -166,7 +166,7 @@ speaker:
 The MetalLB Operator is available on OperatorHub at [operatorhub.io/operator/metallb-operator](https://operatorhub.io/operator/metallb-operator). It eases the deployment and life-cycle of MetalLB in a cluster and allows configuring MetalLB via CRDs.
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [experimental FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), you must edit the ClusterServiceVersion resource
+If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), you must edit the ClusterServiceVersion resource
 named `metallb-operator`:
 
 ```bash

--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -158,7 +158,7 @@ information.
 ## IPv6 and dual stack services
 
 IPv6 and dual stack services are supported in L2 mode, and in BGP mode only
-via the experimental FRR mode.
+via the FRR mode.
 
 In order for MetalLB to allocate IPs to a dual stack service, there must be
 at least one address pool having both addresses of version v4 and v6.


### PR DESCRIPTION
FRR is now be used by multiple users (and in OpenShift). Given that in long term we want it to be the BGP backend, it makes sense to remove the "experimental" wording that might intimidate some users.

