### PR TITLE
annotate a service with the pool used to provide its IP

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -86,16 +86,24 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		return successRes
 	}
 
+	toWrite := svcRo.DeepCopy()
 	if !reflect.DeepEqual(svcRo.Status, svc.Status) {
-		var st v1.ServiceStatus
-		st, svc = svc.Status, svcRo.DeepCopy()
-		svc.Status = st
+		toWrite.Status = svc.Status
+	}
+
+	if !reflect.DeepEqual(svcRo.Annotations, svc.Annotations) {
+		toWrite.Annotations = svc.Annotations
+	}
+
+	if !reflect.DeepEqual(toWrite, svcRo) {
 		if err := c.client.UpdateStatus(svc); err != nil {
-			level.Error(l).Log("op", "updateServiceStatus", "error", err, "msg", "failed to update service status")
+			level.Error(l).Log("op", "updateServiceStatus", "error", err, "msg", "failed to update service")
 			return controllers.SyncStateError
 		}
+		level.Info(l).Log("event", "serviceUpdated", "msg", "updated service object")
 	}
-	level.Info(l).Log("event", "serviceUpdated", "msg", "updated service object")
+
+	level.Info(l).Log("event", "serviceUpdated", "msg", "service is not updated")
 	return successRes
 }
 

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -676,10 +676,14 @@ var _ = ginkgo.Describe("L2", func() {
 			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool}, ingressIP)
 			framework.ExpectNoError(err)
 
+			ginkgo.By("validate annotating a service with the pool used to provide its IP")
+			framework.ExpectEqual(svc.Annotations["metallb.universe.tf/ip-allocated-from-pool"], pool.Name)
+
 			services = append(services, svc)
 			servicesIngressIP = append(servicesIngressIP, ingressIP)
 
 			for j := 0; j <= i; j++ {
+
 				ginkgo.By(fmt.Sprintf("validate service %d IP didn't change", j+1))
 				ip := e2eservice.GetIngressPoint(&services[j].Status.LoadBalancer.Ingress[0])
 				framework.ExpectEqual(ip, servicesIngressIP[j])


### PR DESCRIPTION
annotate a service with the pool used to provide its IP

Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

Fixed https://github.com/metallb/metallb/issues/1448
