### PR TITLE
Start the metrics after the webhook is ready

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -100,9 +100,8 @@ spec:
         {{- if .Values.controller.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -100,7 +100,7 @@ spec:
         {{- if .Values.controller.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}

--- a/config/controllers/controller.yaml
+++ b/config/controllers/controller.yaml
@@ -48,9 +48,8 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 1

--- a/config/controllers/controller.yaml
+++ b/config/controllers/controller.yaml
@@ -48,7 +48,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -1752,9 +1752,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -1752,7 +1752,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1631,7 +1631,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1631,9 +1631,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -1649,9 +1649,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -1649,7 +1649,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1531,7 +1531,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /validate-metallb-io-v1beta1-addresspool
+            path: /
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1531,9 +1531,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: webhook-server
-            scheme: HTTPS
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -28,14 +28,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -262,125 +260,48 @@ func New(cfg *Config) (*Client, error) {
 		}
 	}
 
-	if cfg.EnableWebhook {
-		setupFinished := make(chan struct{})
-		if !cfg.DisableCertRotation {
-			webhooks := []rotator.WebhookInfo{
-				{
-					Name: validatingWebhookName,
-					Type: rotator.Validating,
-				},
-				{
-					Name: addresspoolConvertingWebhookCRD,
-					Type: rotator.CRDConversion,
-				},
-				{
-					Name: bgppeerConvertingWebhookCRD,
-					Type: rotator.CRDConversion,
-				},
-			}
-
-			level.Info(c.logger).Log("op", "startup", "action", "setting up cert rotation")
-			err := rotator.AddRotator(mgr, &rotator.CertRotator{
-				SecretKey: types.NamespacedName{
-					Namespace: cfg.Namespace,
-					Name:      webhookSecretName,
-				},
-				CertDir:        cfg.CertDir,
-				CAName:         caName,
-				CAOrganization: caOrganization,
-				DNSName:        fmt.Sprintf("%s.%s.svc", cfg.CertServiceName, cfg.Namespace),
-				IsReady:        setupFinished,
-				Webhooks:       webhooks,
-			})
-			if err != nil {
-				level.Error(c.logger).Log("error", err, "unable to set up", "cert rotation")
-				return nil, err
-			}
-		} else {
-			close(setupFinished)
-		}
-
-		go func() {
-			// Block until the setup (certificate generation) finishes.
-			<-setupFinished
+	startListeners := make(chan struct{})
+	go func(l log.Logger) {
+		// We start the webhooks and the metric at the same time so the readiness probe will
+		// return success only when we are able to serve webhook requests.
+		<-startListeners
+		if cfg.EnableWebhook {
 			err := enableWebhook(c.mgr, cfg.ValidateConfig, cfg.Namespace, cfg.Logger)
 			if err != nil {
-				level.Error(c.logger).Log("error", err, "unable to create", "webhooks")
+				level.Error(l).Log("error", err, "unable to create", "webhooks")
 			}
-		}()
-	}
+		}
 
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
 
-	if cfg.EnablePprof {
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	}
+		if cfg.EnablePprof {
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		}
 
-	go func(l log.Logger) {
 		err := http.ListenAndServe(net.JoinHostPort(cfg.MetricsHost, fmt.Sprint(cfg.MetricsPort)), mux)
 		if err != nil {
 			level.Error(l).Log("op", "listenAndServe", "err", err, "msg", "cannot listen and serve", "host", cfg.MetricsHost, "port", cfg.MetricsPort)
 		}
 	}(c.logger)
 
+	// The cert rotator will notify when we can start the webhook
+	// and the metric endpoint
+	if cfg.EnableWebhook && !cfg.DisableCertRotation {
+		err = enableCertRotation(startListeners, cfg, mgr)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to enable cert rotation")
+		}
+	} else {
+		// otherwise we can go on and start them
+		close(startListeners)
+	}
+
 	return c, nil
-}
-
-func enableWebhook(mgr manager.Manager, validate config.Validate, namespace string, logger log.Logger) error {
-	level.Info(logger).Log("op", "startup", "action", "webhooks enabled")
-
-	// Used by all the webhooks
-	metallbv1beta1.MetalLBNamespace = namespace
-	metallbv1beta2.MetalLBNamespace = namespace
-	metallbv1beta1.Logger = logger
-	metallbv1beta2.Logger = logger
-	metallbv1beta1.WebhookClient = mgr.GetAPIReader()
-	metallbv1beta2.WebhookClient = mgr.GetAPIReader()
-	metallbv1beta1.Validator = config.NewValidator(validate)
-	metallbv1beta2.Validator = config.NewValidator(validate)
-
-	if err := (&metallbv1beta1.AddressPool{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "AddressPool")
-		return err
-	}
-
-	if err := (&metallbv1beta1.IPAddressPool{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "IPAddressPool")
-		return err
-	}
-
-	if err := (&metallbv1beta2.BGPPeer{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BGPPeer v1beta2")
-		return err
-	}
-
-	if err := (&metallbv1beta1.BGPAdvertisement{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BGPAdvertisement")
-		return err
-	}
-
-	if err := (&metallbv1beta1.L2Advertisement{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "L2Advertisement")
-		return err
-	}
-
-	if err := (&metallbv1beta1.Community{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "Community")
-		return err
-	}
-
-	if err := (&metallbv1beta1.BFDProfile{}).SetupWebhookWithManager(mgr); err != nil {
-		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BFDProfile")
-		return err
-	}
-
-	return nil
 }
 
 // CreateMlSecret create the memberlist secret.

--- a/internal/k8s/webhook.go
+++ b/internal/k8s/webhook.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/open-policy-agent/cert-controller/pkg/rotator"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
+	"go.universe.tf/metallb/internal/config"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func enableCertRotation(notifyFinished chan struct{}, cfg *Config, mgr manager.Manager) error {
+	webhooks := []rotator.WebhookInfo{
+		{
+			Name: validatingWebhookName,
+			Type: rotator.Validating,
+		},
+		{
+			Name: addresspoolConvertingWebhookCRD,
+			Type: rotator.CRDConversion,
+		},
+		{
+			Name: bgppeerConvertingWebhookCRD,
+			Type: rotator.CRDConversion,
+		},
+	}
+
+	level.Info(cfg.Logger).Log("op", "startup", "action", "setting up cert rotation")
+	err := rotator.AddRotator(mgr, &rotator.CertRotator{
+		SecretKey: types.NamespacedName{
+			Namespace: cfg.Namespace,
+			Name:      webhookSecretName,
+		},
+		CertDir:        cfg.CertDir,
+		CAName:         caName,
+		CAOrganization: caOrganization,
+		DNSName:        fmt.Sprintf("%s.%s.svc", cfg.CertServiceName, cfg.Namespace),
+		IsReady:        notifyFinished,
+		Webhooks:       webhooks,
+	})
+	if err != nil {
+		level.Error(cfg.Logger).Log("error", err, "unable to set up", "cert rotation")
+		return err
+	}
+	return nil
+}
+
+func enableWebhook(mgr manager.Manager, validate config.Validate, namespace string, logger log.Logger) error {
+	level.Info(logger).Log("op", "startup", "action", "webhooks enabled")
+
+	// Used by all the webhooks
+	metallbv1beta1.MetalLBNamespace = namespace
+	metallbv1beta2.MetalLBNamespace = namespace
+	metallbv1beta1.Logger = logger
+	metallbv1beta2.Logger = logger
+	metallbv1beta1.WebhookClient = mgr.GetAPIReader()
+	metallbv1beta2.WebhookClient = mgr.GetAPIReader()
+	metallbv1beta1.Validator = config.NewValidator(validate)
+	metallbv1beta2.Validator = config.NewValidator(validate)
+
+	if err := (&metallbv1beta1.AddressPool{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "AddressPool")
+		return err
+	}
+
+	if err := (&metallbv1beta1.IPAddressPool{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "IPAddressPool")
+		return err
+	}
+
+	if err := (&metallbv1beta2.BGPPeer{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BGPPeer v1beta2")
+		return err
+	}
+
+	if err := (&metallbv1beta1.BGPAdvertisement{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BGPAdvertisement")
+		return err
+	}
+
+	if err := (&metallbv1beta1.L2Advertisement{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "L2Advertisement")
+		return err
+	}
+
+	if err := (&metallbv1beta1.Community{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "Community")
+		return err
+	}
+
+	if err := (&metallbv1beta1.BFDProfile{}).SetupWebhookWithManager(mgr); err != nil {
+		level.Error(logger).Log("op", "startup", "error", err, "msg", "unable to create webhook", "webhook", "BFDProfile")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/metallb/metallb/issues/1644

Revert the change of readiness probe, and change the webhook to start the metrics endpoint only after the webhooks are patched properly and thus able to serve.
