### PR TITLE
CI: wait after deploying the operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,6 +303,7 @@ jobs:
           sed -i 's/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:dev-amd64/g' bin/metallb-operator.yaml
           sed -i 's/native/frr/g' bin/metallb-operator.yaml
           kubectl apply -f bin/metallb-operator.yaml
+          sleep 30s
 
 
       - name: MetalLB E2E Tests with Operator Deployment


### PR DESCRIPTION
We must ensure the operator is running and can serve the webhook before applying the metallb resource.
