### PR TITLE
Extend FRR BGP Prometheus metrics collection

### DIFF
--- a/frr-metrics/collector/bgp.go
+++ b/frr-metrics/collector/bgp.go
@@ -21,6 +21,34 @@ var (
 		nil,
 	)
 
+	prefixesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, bgpstats.Prefixes.Name),
+		bgpstats.Prefixes.Help,
+		bgpstats.Labels,
+		nil,
+	)
+
+	opensSentDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "opens_sent"),
+		"Number of BGP open messages sent",
+		bgpstats.Labels,
+		nil,
+	)
+
+	opensReceivedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "opens_received"),
+		"Number of BGP open messages received",
+		bgpstats.Labels,
+		nil,
+	)
+
+	notificationsSentDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "notifications_sent"),
+		"Number of BGP notification messages sent",
+		bgpstats.Labels,
+		nil,
+	)
+
 	updatesSentDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, bgpstats.UpdatesSent.Name),
 		bgpstats.UpdatesSent.Help,
@@ -28,9 +56,44 @@ var (
 		nil,
 	)
 
-	prefixesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, bgpstats.Prefixes.Name),
-		bgpstats.Prefixes.Help,
+	updatesReceivedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "updates_total_received"),
+		"Number of BGP UPDATE messages received",
+		bgpstats.Labels,
+		nil,
+	)
+
+	keepalivesSentDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "keepalives_sent"),
+		"Number of BGP keepalive messages sent",
+		bgpstats.Labels,
+		nil,
+	)
+
+	keepalivesReceivedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "keepalives_received"),
+		"Number of BGP keepalive messages received",
+		bgpstats.Labels,
+		nil,
+	)
+
+	routeRefreshSentedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "route_refresh_sent"),
+		"Number of BGP route refresh messages sent",
+		bgpstats.Labels,
+		nil,
+	)
+
+	totalSentDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "total_sent"),
+		"Number of total BGP messages sent",
+		bgpstats.Labels,
+		nil,
+	)
+
+	totalReceivedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(bgpstats.Namespace, bgpstats.Subsystem, "total_received"),
+		"Number of total BGP messages received",
 		bgpstats.Labels,
 		nil,
 	)
@@ -48,8 +111,17 @@ func NewBGP(l log.Logger) *bgp {
 
 func (c *bgp) Describe(ch chan<- *prometheus.Desc) {
 	ch <- sessionUpDesc
-	ch <- updatesSentDesc
 	ch <- prefixesDesc
+	ch <- opensSentDesc
+	ch <- opensReceivedDesc
+	ch <- notificationsSentDesc
+	ch <- updatesSentDesc
+	ch <- updatesReceivedDesc
+	ch <- keepalivesSentDesc
+	ch <- keepalivesReceivedDesc
+	ch <- routeRefreshSentedDesc
+	ch <- totalSentDesc
+	ch <- totalReceivedDesc
 }
 
 func (c *bgp) Collect(ch chan<- prometheus.Metric) {
@@ -71,8 +143,17 @@ func updateNeighborsMetrics(ch chan<- prometheus.Metric, neighbors []*bgpfrr.Nei
 		peerLabel := fmt.Sprintf("%s:%d", n.Ip.String(), n.Port)
 
 		ch <- prometheus.MustNewConstMetric(sessionUpDesc, prometheus.GaugeValue, float64(sessionUp), peerLabel)
-		ch <- prometheus.MustNewConstMetric(updatesSentDesc, prometheus.CounterValue, float64(n.UpdatesSent), peerLabel)
 		ch <- prometheus.MustNewConstMetric(prefixesDesc, prometheus.GaugeValue, float64(n.PrefixSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(opensSentDesc, prometheus.CounterValue, float64(n.MsgStats.OpensSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(opensReceivedDesc, prometheus.CounterValue, float64(n.MsgStats.OpensReceived), peerLabel)
+		ch <- prometheus.MustNewConstMetric(notificationsSentDesc, prometheus.CounterValue, float64(n.MsgStats.NotificationsSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(updatesSentDesc, prometheus.CounterValue, float64(n.MsgStats.UpdatesSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(updatesReceivedDesc, prometheus.CounterValue, float64(n.MsgStats.UpdatesReceived), peerLabel)
+		ch <- prometheus.MustNewConstMetric(keepalivesSentDesc, prometheus.CounterValue, float64(n.MsgStats.KeepalivesSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(keepalivesReceivedDesc, prometheus.CounterValue, float64(n.MsgStats.KeepalivesReceived), peerLabel)
+		ch <- prometheus.MustNewConstMetric(routeRefreshSentedDesc, prometheus.CounterValue, float64(n.MsgStats.RouteRefreshSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(totalSentDesc, prometheus.CounterValue, float64(n.MsgStats.TotalSent), peerLabel)
+		ch <- prometheus.MustNewConstMetric(totalReceivedDesc, prometheus.CounterValue, float64(n.MsgStats.TotalReceived), peerLabel)
 	}
 }
 

--- a/frr-metrics/collector/bgp_test.go
+++ b/frr-metrics/collector/bgp_test.go
@@ -16,37 +16,91 @@ var (
 	# HELP metallb_bgp_announced_prefixes_total Number of prefixes currently being advertised on the BGP session
 	# TYPE metallb_bgp_announced_prefixes_total gauge
 	metallb_bgp_announced_prefixes_total{peer="{{ .NeighborIP }}"} {{ .AnnouncedPrefixes }}
+	# HELP metallb_bgp_keepalives_received Number of BGP keepalive messages received
+	# TYPE metallb_bgp_keepalives_received counter
+	metallb_bgp_keepalives_received{peer="{{ .NeighborIP }}"} {{ .KeepalivesReceived }}
+	# HELP metallb_bgp_keepalives_sent Number of BGP keepalive messages sent
+	# TYPE metallb_bgp_keepalives_sent counter
+	metallb_bgp_keepalives_sent{peer="{{ .NeighborIP }}"} {{ .KeepalivesSent }}
+	# HELP metallb_bgp_notifications_sent Number of BGP notification messages sent
+	# TYPE metallb_bgp_notifications_sent counter
+	metallb_bgp_notifications_sent{peer="{{ .NeighborIP }}"} {{ .NotificationsSent }}
+	# HELP metallb_bgp_opens_received Number of BGP open messages received
+	# TYPE metallb_bgp_opens_received counter
+	metallb_bgp_opens_received{peer="{{ .NeighborIP }}"} {{ .OpensReceived }}
+	# HELP metallb_bgp_opens_sent Number of BGP open messages sent
+	# TYPE metallb_bgp_opens_sent counter
+	metallb_bgp_opens_sent{peer="{{ .NeighborIP }}"} {{ .OpensSent }}
+	# HELP metallb_bgp_route_refresh_sent Number of BGP route refresh messages sent
+	# TYPE metallb_bgp_route_refresh_sent counter
+	metallb_bgp_route_refresh_sent{peer="{{ .NeighborIP }}"} {{ .RouteRefreshSent }}
 	# HELP metallb_bgp_session_up BGP session state (1 is up, 0 is down)
 	# TYPE metallb_bgp_session_up gauge
 	metallb_bgp_session_up{peer="{{ .NeighborIP }}"} {{ .SessionUp }}
+	# HELP metallb_bgp_total_received Number of total BGP messages received
+	# TYPE metallb_bgp_total_received counter
+	metallb_bgp_total_received{peer="{{ .NeighborIP }}"} {{ .TotalReceived }}
+	# HELP metallb_bgp_total_sent Number of total BGP messages sent
+	# TYPE metallb_bgp_total_sent counter
+	metallb_bgp_total_sent{peer="{{ .NeighborIP }}"} {{ .TotalSent }}
 	# HELP metallb_bgp_updates_total Number of BGP UPDATE messages sent
 	# TYPE metallb_bgp_updates_total counter
 	metallb_bgp_updates_total{peer="{{ .NeighborIP }}"} {{ .UpdatesTotal }}
+	# HELP metallb_bgp_updates_total_received Number of BGP UPDATE messages received
+	# TYPE metallb_bgp_updates_total_received counter
+	metallb_bgp_updates_total_received{peer="{{ .NeighborIP }}"} {{ .UpdatesTotalReceived }}
 	`
 
 	tests = []struct {
-		desc              string
-		vtyshOutput       string
-		neighborIP        string
-		announcedPrefixes int
-		sessionUp         int
-		updatesTotal      int
+		desc                 string
+		vtyshOutput          string
+		neighborIP           string
+		announcedPrefixes    int
+		sessionUp            int
+		updatesTotal         int
+		updatesTotalReceived int
+		keepalivesSent       int
+		keepalivesReceived   int
+		opensSent            int
+		opensReceived        int
+		routeRefreshSent     int
+		notificationsSent    int
+		totalSent            int
+		totalReceived        int
 	}{
 		{
-			desc:              "Output contains only IPv4 advertisements",
-			vtyshOutput:       neighborsIPv4Only,
-			neighborIP:        "172.18.0.4:179",
-			announcedPrefixes: 3,
-			sessionUp:         1,
-			updatesTotal:      2,
+			desc:                 "Output contains only IPv4 advertisements",
+			vtyshOutput:          neighborsIPv4Only,
+			neighborIP:           "172.18.0.4:179",
+			announcedPrefixes:    3,
+			sessionUp:            1,
+			updatesTotal:         3,
+			updatesTotalReceived: 3,
+			keepalivesSent:       4,
+			keepalivesReceived:   4,
+			opensSent:            1,
+			opensReceived:        1,
+			routeRefreshSent:     5,
+			notificationsSent:    2,
+			totalSent:            15,
+			totalReceived:        15,
 		},
 		{
-			desc:              "Output contains mixed IPv4 and IPv6 advertisements",
-			vtyshOutput:       neighborsDual,
-			neighborIP:        "172.18.0.4:180",
-			announcedPrefixes: 6,
-			sessionUp:         1,
-			updatesTotal:      5,
+			desc:                 "Output contains mixed IPv4 and IPv6 advertisements",
+			vtyshOutput:          neighborsDual,
+			neighborIP:           "172.18.0.4:180",
+			announcedPrefixes:    6,
+			sessionUp:            1,
+			updatesTotal:         3,
+			updatesTotalReceived: 3,
+			keepalivesSent:       4,
+			keepalivesReceived:   4,
+			opensSent:            1,
+			opensReceived:        1,
+			routeRefreshSent:     5,
+			notificationsSent:    2,
+			totalSent:            15,
+			totalReceived:        15,
 		},
 	}
 	neighborsIPv4Only = `
@@ -122,18 +176,18 @@ var (
 			"depthOutq":0,
 			"opensSent":1,
 			"opensRecv":1,
-			"notificationsSent":0,
-			"notificationsRecv":0,
-			"updatesSent":2,
-			"updatesRecv":2,
-			"keepalivesSent":19,
-			"keepalivesRecv":19,
-			"routeRefreshSent":0,
-			"routeRefreshRecv":0,
+			"notificationsSent":2,
+			"notificationsRecv":2,
+			"updatesSent":3,
+			"updatesRecv":3,
+			"keepalivesSent":4,
+			"keepalivesRecv":4,
+			"routeRefreshSent":5,
+			"routeRefreshRecv":5,
 			"capabilitySent":0,
 			"capabilityRecv":0,
-			"totalSent":22,
-			"totalRecv":22
+			"totalSent":15,
+			"totalRecv":15
 		  },
 		  "minBtwnAdvertisementRunsTimerMsecs":0,
 		  "addressFamilyInfo":{
@@ -258,18 +312,18 @@ var (
 			"depthOutq":0,
 			"opensSent":1,
 			"opensRecv":1,
-			"notificationsSent":0,
-			"notificationsRecv":0,
-			"updatesSent":5,
-			"updatesRecv":5,
-			"keepalivesSent":19,
-			"keepalivesRecv":19,
-			"routeRefreshSent":0,
-			"routeRefreshRecv":0,
+			"notificationsSent":2,
+			"notificationsRecv":2,
+			"updatesSent":3,
+			"updatesRecv":3,
+			"keepalivesSent":4,
+			"keepalivesRecv":4,
+			"routeRefreshSent":5,
+			"routeRefreshRecv":5,
 			"capabilitySent":0,
 			"capabilityRecv":0,
-			"totalSent":25,
-			"totalRecv":25
+			"totalSent":15,
+			"totalRecv":15
 		  },
 		  "minBtwnAdvertisementRunsTimerMsecs":0,
 		  "addressFamilyInfo":{
@@ -325,10 +379,19 @@ func TestCollect(t *testing.T) {
 
 			var w bytes.Buffer
 			err = tmpl.Execute(&w, map[string]interface{}{
-				"NeighborIP":        tc.neighborIP,
-				"AnnouncedPrefixes": tc.announcedPrefixes,
-				"SessionUp":         tc.sessionUp,
-				"UpdatesTotal":      tc.updatesTotal,
+				"NeighborIP":           tc.neighborIP,
+				"AnnouncedPrefixes":    tc.announcedPrefixes,
+				"SessionUp":            tc.sessionUp,
+				"UpdatesTotal":         tc.updatesTotal,
+				"UpdatesTotalReceived": tc.updatesTotalReceived,
+				"KeepalivesReceived":   tc.keepalivesReceived,
+				"KeepalivesSent":       tc.keepalivesSent,
+				"NotificationsSent":    tc.notificationsSent,
+				"OpensReceived":        tc.opensReceived,
+				"OpensSent":            tc.opensSent,
+				"RouteRefreshSent":     tc.routeRefreshSent,
+				"TotalReceived":        tc.totalReceived,
+				"TotalSent":            tc.totalSent,
 			})
 
 			if err != nil {

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -16,10 +16,10 @@ type Neighbor struct {
 	Connected      bool
 	LocalAS        string
 	RemoteAS       string
-	UpdatesSent    int
 	PrefixSent     int
 	Port           int
 	RemoteRouterID string
+	MsgStats       MessageStats
 }
 
 type Route struct {
@@ -32,18 +32,29 @@ type Route struct {
 const bgpConnected = "Established"
 
 type FRRNeighbor struct {
-	RemoteAs       int    `json:"remoteAs"`
-	LocalAs        int    `json:"localAs"`
-	RemoteRouterID string `json:"remoteRouterId"`
-	BgpVersion     int    `json:"bgpVersion"`
-	BgpState       string `json:"bgpState"`
-	PortForeign    int    `json:"portForeign"`
-	MessageStats   struct {
-		UpdatesSent int `json:"updatesSent"`
-	} `json:"messageStats"`
+	RemoteAs          int          `json:"remoteAs"`
+	LocalAs           int          `json:"localAs"`
+	RemoteRouterID    string       `json:"remoteRouterId"`
+	BgpVersion        int          `json:"bgpVersion"`
+	BgpState          string       `json:"bgpState"`
+	PortForeign       int          `json:"portForeign"`
+	MsgStats          MessageStats `json:"messageStats"`
 	AddressFamilyInfo map[string]struct {
 		SentPrefixCounter int `json:"sentPrefixCounter"`
 	} `json:"addressFamilyInfo"`
+}
+
+type MessageStats struct {
+	OpensSent          int `json:"opensSent"`
+	OpensReceived      int `json:"opensRecv"`
+	NotificationsSent  int `json:"notificationsSent"`
+	UpdatesSent        int `json:"updatesSent"`
+	UpdatesReceived    int `json:"updatesRecv"`
+	KeepalivesSent     int `json:"keepalivesSent"`
+	KeepalivesReceived int `json:"keepalivesRecv"`
+	RouteRefreshSent   int `json:"routeRefreshSent"`
+	TotalSent          int `json:"totalSent"`
+	TotalReceived      int `json:"totalRecv"`
 }
 
 type IPInfo struct {
@@ -117,10 +128,10 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			Connected:      connected,
 			LocalAS:        strconv.Itoa(n.LocalAs),
 			RemoteAS:       strconv.Itoa(n.RemoteAs),
-			UpdatesSent:    n.MessageStats.UpdatesSent,
 			PrefixSent:     prefixSent,
 			Port:           n.PortForeign,
 			RemoteRouterID: n.RemoteRouterID,
+			MsgStats:       n.MsgStats,
 		}, nil
 	}
 	return nil, errors.New("no peers were returned")
@@ -154,10 +165,10 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			Connected:      connected,
 			LocalAS:        strconv.Itoa(n.LocalAs),
 			RemoteAS:       strconv.Itoa(n.RemoteAs),
-			UpdatesSent:    n.MessageStats.UpdatesSent,
 			PrefixSent:     prefixSent,
 			Port:           n.PortForeign,
 			RemoteRouterID: n.RemoteRouterID,
+			MsgStats:       n.MsgStats,
 		})
 	}
 	return res, nil

--- a/internal/bgp/frr/parse_test.go
+++ b/internal/bgp/frr/parse_test.go
@@ -8,7 +8,22 @@ import (
 	"net"
 	"sort"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+var expectedStats = MessageStats{
+	OpensSent:          1,
+	OpensReceived:      2,
+	NotificationsSent:  3,
+	UpdatesSent:        4,
+	UpdatesReceived:    5,
+	KeepalivesSent:     6,
+	KeepalivesReceived: 7,
+	RouteRefreshSent:   8,
+	TotalSent:          9,
+	TotalReceived:      10,
+}
 
 func TestNeighbour(t *testing.T) {
 	sample := `{
@@ -41,20 +56,20 @@ func TestNeighbour(t *testing.T) {
       "messageStats":{
         "depthInq":0,
         "depthOutq":0,
-        "opensSent":0,
-        "opensRecv":0,
-        "notificationsSent":0,
+        "opensSent":1,
+        "opensRecv":2,
+        "notificationsSent":3,
         "notificationsRecv":0,
-        "updatesSent":%d,
-        "updatesRecv":0,
-        "keepalivesSent":0,
-        "keepalivesRecv":0,
-        "routeRefreshSent":0,
+        "updatesSent":4,
+        "updatesRecv":5,
+        "keepalivesSent":6,
+        "keepalivesRecv":7,
+        "routeRefreshSent":8,
         "routeRefreshRecv":0,
         "capabilitySent":0,
         "capabilityRecv":0,
-        "totalSent":0,
-        "totalRecv":0
+        "totalSent":9,
+        "totalRecv":10
       },
       "minBtwnAdvertisementRunsTimerMsecs":0,
       "addressFamilyInfo":{
@@ -90,7 +105,6 @@ func TestNeighbour(t *testing.T) {
 		remoteAS       string
 		localAS        string
 		status         string
-		updatesSent    int
 		ipv4PrefixSent int
 		ipv6PrefixSent int
 		port           int
@@ -102,7 +116,6 @@ func TestNeighbour(t *testing.T) {
 			"64512",
 			"64512",
 			"Established",
-			1,
 			1,
 			0,
 			179,
@@ -116,7 +129,6 @@ func TestNeighbour(t *testing.T) {
 			"Active",
 			0,
 			0,
-			0,
 			180,
 			"",
 		},
@@ -128,7 +140,6 @@ func TestNeighbour(t *testing.T) {
 			"Established",
 			2,
 			1,
-			1,
 			181,
 			"",
 		},
@@ -136,7 +147,7 @@ func TestNeighbour(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := ParseNeighbour(fmt.Sprintf(sample, tt.neighborIP, tt.remoteAS, tt.localAS, tt.status, tt.updatesSent, tt.ipv4PrefixSent, tt.ipv6PrefixSent, tt.port))
+			n, err := ParseNeighbour(fmt.Sprintf(sample, tt.neighborIP, tt.remoteAS, tt.localAS, tt.status, tt.ipv4PrefixSent, tt.ipv6PrefixSent, tt.port))
 			if err != nil {
 				t.Fatal("Failed to parse ", err)
 			}
@@ -155,9 +166,6 @@ func TestNeighbour(t *testing.T) {
 			if tt.status != "Established" && n.Connected == true {
 				t.Fatal("Expected connected", false, "got", n.Connected)
 			}
-			if tt.updatesSent != n.UpdatesSent {
-				t.Fatal("Expected updates sent", tt.updatesSent, "got", n.UpdatesSent)
-			}
 			if tt.ipv4PrefixSent+tt.ipv6PrefixSent != n.PrefixSent {
 				t.Fatal("Expected prefix sent", tt.ipv4PrefixSent+tt.ipv6PrefixSent, "got", n.PrefixSent)
 			}
@@ -166,6 +174,9 @@ func TestNeighbour(t *testing.T) {
 			}
 			if n.RemoteRouterID != "0.0.0.0" {
 				t.Fatal("Expected remote routerid 0.0.0.0")
+			}
+			if !cmp.Equal(expectedStats, n.MsgStats) {
+				t.Fatal("unexpected BGP messages stats (-want +got)\n", cmp.Diff(expectedStats, n.MsgStats))
 			}
 		})
 	}
@@ -202,20 +213,20 @@ const threeNeighbours = `
     "messageStats":{
       "depthInq":0,
       "depthOutq":0,
-      "opensSent":0,
-      "opensRecv":0,
-      "notificationsSent":0,
+      "opensSent":1,
+      "opensRecv":2,
+      "notificationsSent":3,
       "notificationsRecv":0,
-      "updatesSent":0,
-      "updatesRecv":0,
-      "keepalivesSent":0,
-      "keepalivesRecv":0,
-      "routeRefreshSent":0,
+      "updatesSent":4,
+      "updatesRecv":5,
+      "keepalivesSent":6,
+      "keepalivesRecv":7,
+      "routeRefreshSent":8,
       "routeRefreshRecv":0,
       "capabilitySent":0,
       "capabilityRecv":0,
-      "totalSent":0,
-      "totalRecv":0
+      "totalSent":9,
+      "totalRecv":10
     },
     "minBtwnAdvertisementRunsTimerMsecs":0,
     "addressFamilyInfo":{
@@ -264,20 +275,20 @@ const threeNeighbours = `
     "messageStats":{
       "depthInq":0,
       "depthOutq":0,
-      "opensSent":0,
-      "opensRecv":0,
-      "notificationsSent":0,
+      "opensSent":1,
+      "opensRecv":2,
+      "notificationsSent":3,
       "notificationsRecv":0,
-      "updatesSent":0,
-      "updatesRecv":0,
-      "keepalivesSent":0,
-      "keepalivesRecv":0,
-      "routeRefreshSent":0,
+      "updatesSent":4,
+      "updatesRecv":5,
+      "keepalivesSent":6,
+      "keepalivesRecv":7,
+      "routeRefreshSent":8,
       "routeRefreshRecv":0,
       "capabilitySent":0,
       "capabilityRecv":0,
-      "totalSent":0,
-      "totalRecv":0
+      "totalSent":9,
+      "totalRecv":10
     },
     "minBtwnAdvertisementRunsTimerMsecs":0,
     "addressFamilyInfo":{
@@ -326,20 +337,20 @@ const threeNeighbours = `
     "messageStats":{
       "depthInq":0,
       "depthOutq":0,
-      "opensSent":0,
-      "opensRecv":0,
-      "notificationsSent":0,
+      "opensSent":1,
+      "opensRecv":2,
+      "notificationsSent":3,
       "notificationsRecv":0,
-      "updatesSent":0,
-      "updatesRecv":0,
-      "keepalivesSent":0,
-      "keepalivesRecv":0,
-      "routeRefreshSent":0,
+      "updatesSent":4,
+      "updatesRecv":5,
+      "keepalivesSent":6,
+      "keepalivesRecv":7,
+      "routeRefreshSent":8,
       "routeRefreshRecv":0,
       "capabilitySent":0,
       "capabilityRecv":0,
-      "totalSent":0,
-      "totalRecv":0
+      "totalSent":9,
+      "totalRecv":10
     },
     "minBtwnAdvertisementRunsTimerMsecs":0,
     "addressFamilyInfo":{
@@ -433,19 +444,19 @@ const threeNeighbours = `
       "depthInq":0,
       "depthOutq":0,
       "opensSent":1,
-      "opensRecv":1,
-      "notificationsSent":0,
+      "opensRecv":2,
+      "notificationsSent":3,
       "notificationsRecv":0,
-      "updatesSent":1,
-      "updatesRecv":0,
-      "keepalivesSent":1,
-      "keepalivesRecv":1,
-      "routeRefreshSent":0,
+      "updatesSent":4,
+      "updatesRecv":5,
+      "keepalivesSent":6,
+      "keepalivesRecv":7,
+      "routeRefreshSent":8,
       "routeRefreshRecv":0,
       "capabilitySent":0,
       "capabilityRecv":0,
-      "totalSent":3,
-      "totalRecv":2
+      "totalSent":9,
+      "totalRecv":10
     },
     "minBtwnAdvertisementRunsTimerMsecs":0,
     "addressFamilyInfo":{
@@ -499,6 +510,12 @@ func TestNeighbours(t *testing.T) {
 	}
 	if !nn[2].Ip.Equal(net.ParseIP("172.18.0.4")) {
 		t.Fatal("neighbour ip not matching")
+	}
+
+	for i, n := range nn {
+		if !cmp.Equal(expectedStats, n.MsgStats) {
+			t.Fatal("unexpected BGP messages stats for neightbor", i, "(-want +got)\n", cmp.Diff(expectedStats, n.MsgStats))
+		}
 	}
 }
 


### PR DESCRIPTION
This commit extends the number of metrics we collect about BGP sessions
using FRR.

The following additional metrics are extracted from the FRR's vtysh
"show bgp neighbors" command.
- OpensSent
- OpensReceived
- NotificationsSent
- UpdatesSent
- UpdatesReceived
- KeepalivesSent
- KeepalivesReceived
- RouteRefreshSent
- TotalSent
- TotalReceived

All of the metrics above are counters of different BGP messages and
they are collected per BGP neighbor.

Note:
The choice of the metric name: "updates_total_received"
was made to keep backward compatibility with the already existing `bgpstats.UpdatesSent.Name`