### PR TITLE
Update commitlint to deal with empty body

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,6 +5,12 @@ module.exports = {
        // Warn on lines longer than 72 chars. We usually don't want them for
        // text, but links are fine if they exceed. So, just warn.
        'body-max-line-length': [1, 'always', 72],
+       // Ensure message body is not empty
+       'body-empty': [2, 'never'],
+       // Avoid having the 'Signed-off-by' message pass
+       // for the body text by ensuring that the body
+       // ends with a period.
+       'body-full-stop': [2, 'always', '.'],
        // Ensure the header line doesn't end with a period.
        'header-full-stop': [2, 'never'],
     },


### PR DESCRIPTION
Adds configurations in order to deal with the
empty commit body. Also ensures that those who
add commits with `git commit -s -m`  don't pass
this check solely by providing their signature.

Signed-off-by: Tyler Auerbeck <tylerauerbeck@users.noreply.github.com>

Resolves #1206 