### PR TITLE
Add task to bump image in values file and workflow to bump image in main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Helm doc generate
         uses: docker://jnorwood/helm-docs:v1.10.0
 
-      - name: Check if  docs are different
+      - name: Check if docs are different
         run: |
           if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
             echo "Please update the helm docs with the \"helm-docs\" command (https://github.com/norwoodj/helm-docs) or use \"inv helmdocs\""

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -161,3 +161,30 @@ jobs:
           else
             echo "Release already exists"
           fi
+
+  update-helm-values:
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get latest release
+        run: |
+          echo "LATEST=$(git tag --sort=v:refname  --list 'v[0-9]*' | tail -1)" >> $GITHUB_ENV
+
+      - name: Ensure .controller.image.tag is set to latest release
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.controller.image.tag = "${{ env.LATEST }}"' 'charts/metallb/values.yaml'
+
+      - name: Ensure .speaker.image.tag is set to latest release
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.speaker.image.tag = "${{ env.LATEST }}"' 'charts/metallb/values.yaml'
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Bump helm values to use latest release"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This fixes the ability to deploy the helm chart directly from the main branch. Currently when attempting to deploy, it uses the tag `0.0.0`. By adding this task and workflow, this will now do the following:

- on a release, update the values.yaml with the appropriate release for the controller and speaker images instead of solely relying on the `appVersion`.
- on a push to main, trigger a workflow that checks to make sure that `values.yaml` has the latest release tag. If it does not, the GitHub actions bot will update the file and push it to main.

Fixes #1380