### PR TITLE
Fix chart of metalb  crd support version for k8s

### DIFF
--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The optional kubeVersion field can define semver constraints on supported Kubernetes versions.
 # Helm will validate the version constraints when installing the chart and fail if the cluster
 # runs an unsupported Kubernetes version.
-kubeVersion: ">= 1.14.0-0"
+kubeVersion: ">= 1.19.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -12,7 +12,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 
 ## Requirements
 
-Kubernetes: `>= 1.14.0-0`
+Kubernetes: `>= 1.19.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
When I install metallb by chart, the output:

```
$ helm install metallb -nkube-system ./ --dry-run
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(CustomResourceDefinition.spec.versions[0]): unknown field "deprecated" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion, ValidationError(CustomResourceDefinition.spec.versions[0]): unknown field "deprecationWarning" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion, ValidationError(CustomResourceDefinition.spec.versions[1]): unknown field "deprecated" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion, ValidationError(CustomResourceDefinition.spec.versions[1]): unknown field "deprecationWarning" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion]
```

Find the  field of  "deprecated"  has been supported from 1.19 version for k8s
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-deprecation

