### PR TITLE
remove io/ioutil for advanced golang

### DIFF
--- a/configmaptocrs/conversion_test.go
+++ b/configmaptocrs/conversion_test.go
@@ -5,8 +5,9 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -33,7 +34,7 @@ func TestGenerateResourcesWithConfigData(t *testing.T) {
 
 func testGenerate(t *testing.T, testDir string, testOnlyData bool) {
 	tests := []string{}
-	files, err := ioutil.ReadDir(testDir)
+	files, err := os.ReadDir(testDir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +46,7 @@ func testGenerate(t *testing.T, testDir string, testOnlyData bool) {
 
 	for _, tc := range tests {
 		t.Run(tc, func(t *testing.T) {
-			log.SetOutput(ioutil.Discard)
+			log.SetOutput(io.Discard)
 
 			res := new(bytes.Buffer)
 			// Override the container's internal path.
@@ -61,12 +62,12 @@ func testGenerate(t *testing.T, testDir string, testOnlyData bool) {
 			goldenFile := filepath.Join(testDir, strings.TrimSuffix(tc, path.Ext(tc))+".golden")
 			if *update {
 				t.Log("update golden file")
-				if err := ioutil.WriteFile(goldenFile, res.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(goldenFile, res.Bytes(), 0644); err != nil {
 					t.Fatalf("test %s failed to update golden file: %s", tc, err)
 				}
 			}
 
-			expected, err := ioutil.ReadFile(goldenFile)
+			expected, err := os.ReadFile(goldenFile)
 			if err != nil {
 				t.Fatalf("test %s failed reading .golden file: %s", tc, err)
 			}

--- a/configmaptocrs/main.go
+++ b/configmaptocrs/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -111,7 +110,7 @@ func readConfig(origin string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	raw, err := ioutil.ReadAll(f)
+	raw, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s: %v", origin, err)
 	}

--- a/controller/main.go
+++ b/controller/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -148,7 +147,7 @@ func main() {
 	level.Info(logger).Log("version", version.Version(), "commit", version.CommitHash(), "branch", version.Branch(), "goversion", version.GoString(), "msg", "MetalLB controller starting "+version.String())
 
 	if *namespace == "" {
-		bs, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		bs, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if err != nil {
 			level.Error(logger).Log("op", "startup", "msg", "Unable to get namespace from pod service account data, please specify --namespace or METALLB_NAMESPACE", "error", err)
 			os.Exit(1)

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -4,7 +4,6 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -158,7 +157,7 @@ func ConfigureExisting(c ...Config) ([]*FRR, error) {
 // start creates a new FRR container on the host and returns the corresponding *FRR.
 // A situation where a non-nil container and an error are returned is possible.
 func start(cfg Config) (*FRR, error) {
-	testDirName, err := ioutil.TempDir("", "frr-conf")
+	testDirName, err := os.MkdirTemp("", "frr-conf")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -5,7 +5,6 @@ package frr
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -278,7 +277,7 @@ func templateConfig(data interface{}) (string, error) {
 // writeConfigFile writes the FRR configuration file (represented as a string)
 // to 'filename'.
 func writeConfig(config string, filename string) error {
-	return ioutil.WriteFile(filename, []byte(config), 0644)
+	return os.WriteFile(filename, []byte(config), 0644)
 }
 
 // reloadConfig requests that FRR reloads the configuration file. This is

--- a/internal/bgp/frr/docker_test.go
+++ b/internal/bgp/frr/docker_test.go
@@ -5,7 +5,6 @@ package frr
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -32,7 +31,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to create dockertest pool %s", err)
 	}
 
-	frrDir, err = ioutil.TempDir("/tmp", "frr_integration")
+	frrDir, err = os.MkdirTemp("/tmp", "frr_integration")
 	if err != nil {
 		log.Fatalf("failed to create temp dir %s", err)
 	}

--- a/internal/bgp/native/messages.go
+++ b/internal/bgp/native/messages.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -279,7 +278,7 @@ func readCapabilities(r io.Reader, ret *openResult) error {
 		default:
 			// TODO: only ignore capabilities that we know are fine to
 			// ignore.
-			if _, err := io.Copy(ioutil.Discard, &lr); err != nil {
+			if _, err := io.Copy(io.Discard, &lr); err != nil {
 				return err
 			}
 		}

--- a/internal/bgp/native/messages_test.go
+++ b/internal/bgp/native/messages_test.go
@@ -4,8 +4,8 @@ package native
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,7 +37,7 @@ func TestPcapInterop(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, m := range ms {
-		bs, err := ioutil.ReadFile(m)
+		bs, err := os.ReadFile(m)
 		if err != nil {
 			t.Fatalf("read %q: %s", m, err)
 		}

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -436,7 +435,7 @@ func (s *session) consumeBGP(conn io.ReadCloser) {
 			level.Error(s.logger).Log("event", "peerNotification", "error", err, "msg", "peer sent notification, closing session")
 			return
 		}
-		if _, err := io.Copy(ioutil.Discard, io.LimitReader(conn, int64(hdr.Len)-19)); err != nil {
+		if _, err := io.Copy(io.Discard, io.LimitReader(conn, int64(hdr.Len)-19)); err != nil {
 			// TODO: propagate
 			return
 		}

--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -3,7 +3,6 @@
 package layer2
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -82,7 +81,7 @@ func (a *Announce) updateInterfaces() {
 		if _, err = os.Stat("/sys/class/net/" + ifi.Name + "/master"); !os.IsNotExist(err) {
 			continue
 		}
-		f, err := ioutil.ReadFile("/sys/class/net/" + ifi.Name + "/flags")
+		f, err := os.ReadFile("/sys/class/net/" + ifi.Name + "/flags")
 		if err == nil {
 			flags, _ := strconv.ParseUint(string(f)[:len(string(f))-1], 0, 32)
 			// NOARP flag

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -93,7 +92,7 @@ func main() {
 	level.Info(logger).Log("version", version.Version(), "commit", version.CommitHash(), "branch", version.Branch(), "goversion", version.GoString(), "msg", "MetalLB speaker starting "+version.String())
 
 	if *namespace == "" {
-		bs, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		bs, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if err != nil {
 			level.Error(logger).Log("op", "startup", "msg", "Unable to get namespace from pod service account data, please specify --namespace or METALLB_NAMESPACE", "error", err)
 			os.Exit(1)


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
/kind cleanup

