### PR TITLE
Implement ip pool selector logic for service

### DIFF
--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["services"]
+  resources: ["services", "namespaces"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["services/status"]
@@ -47,7 +47,7 @@ metadata:
     {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["services", "endpoints", "nodes"]
+  resources: ["services", "endpoints", "nodes", "namespaces"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -1541,6 +1541,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list
@@ -1640,6 +1641,7 @@ rules:
   - services
   - endpoints
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1512,6 +1512,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list
@@ -1599,6 +1600,7 @@ rules:
   - services
   - endpoints
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -1541,6 +1541,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list
@@ -1640,6 +1641,7 @@ rules:
   - services
   - endpoints
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1512,6 +1512,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list
@@ -1599,6 +1600,7 @@ rules:
   - services
   - endpoints
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
       - ""
     resources:
       - services
+      - namespaces
     verbs:
       - get
       - list
@@ -96,6 +97,7 @@ rules:
       - services
       - endpoints
       - nodes
+      - namespaces
     verbs:
       - get
       - list

--- a/controller/main.go
+++ b/controller/main.go
@@ -42,7 +42,7 @@ type service interface {
 
 type controller struct {
 	client service
-	pools  map[string]*config.Pool
+	pools  *config.Pools
 	ips    *allocator.Allocator
 }
 
@@ -58,7 +58,7 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		return controllers.SyncStateReprocessAll
 	}
 
-	if c.pools == nil {
+	if c.pools == nil || c.pools.ByName == nil {
 		// Config hasn't been read, nothing we can do just yet.
 		level.Debug(l).Log("event", "noConfig", "msg", "not processing, still waiting for config")
 		return controllers.SyncStateSuccess
@@ -112,11 +112,11 @@ func (c *controller) deleteBalancer(l log.Logger, name string) {
 	}
 }
 
-func (c *controller) SetPools(l log.Logger, pools map[string]*config.Pool) controllers.SyncState {
+func (c *controller) SetPools(l log.Logger, pools *config.Pools) controllers.SyncState {
 	level.Debug(l).Log("event", "startUpdate", "msg", "start of config update")
 	defer level.Debug(l).Log("event", "endUpdate", "msg", "end of config update")
 
-	if pools == nil {
+	if pools == nil || pools.ByName == nil {
 		level.Error(l).Log("op", "setConfig", "error", "no MetalLB configuration in cluster", "msg", "configuration is missing, MetalLB will not function")
 		return controllers.SyncStateErrorNoRetry
 	}

--- a/controller/service.go
+++ b/controller/service.go
@@ -148,7 +148,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	}
 
 	pool := c.ips.Pool(key)
-	if pool == "" || c.pools[pool] == nil {
+	if pool == "" || c.pools == nil || c.pools.IsEmpty(pool) {
 		level.Error(l).Log("bug", "true", "ip", lbIPs, "msg", "internal error: allocated IP has no matching address pool")
 		c.client.Errorf(svc, "InternalError", "allocated an IP that has no pool")
 		c.clearServiceState(key, svc)
@@ -214,7 +214,7 @@ func (c *controller) allocateIPs(key string, svc *v1.Service) ([]net.IP, error) 
 	}
 
 	// Okay, in that case just bruteforce across all pools.
-	return c.ips.Allocate(key, serviceIPFamily, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+	return c.ips.Allocate(key, svc, serviceIPFamily, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 }
 
 func (c *controller) isServiceAllocated(key string) bool {

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -16,6 +16,8 @@ import (
 	"go.universe.tf/metallb/e2etest/pkg/service"
 	internalconfig "go.universe.tf/metallb/internal/config"
 
+	testservice "go.universe.tf/metallb/e2etest/pkg/service"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -81,6 +83,10 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				svc.Name = "singleip1"
 			})
 			framework.ExpectNoError(err)
+			defer func() {
+				testservice.Delete(cs, svc1)
+			}()
+
 			gomega.Consistently(func() int {
 				s, err := cs.CoreV1().Services(svc1.Namespace).Get(context.Background(), svc1.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
@@ -115,5 +121,268 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 					err := cs.CoreV1().Services(svc.Namespace).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
 					return err
 				}))
+	})
+
+	ginkgo.Context("IPV4 - Validate service allocation in address pools", func() {
+		ginkgo.AfterEach(func() {
+			// Clean previous configuration.
+			err := ConfigUpdater.Clean()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("with namespace", func() {
+			namespacePoolWithLowerPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			namespacePoolWithHigherPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			defaultPool := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-3"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.20.0/32",
+					},
+				},
+			}
+			resources := internalconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespacePoolWithHigherPriority, defaultPool},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-2")
+			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-3")
+			defer func() {
+				testservice.Delete(cs, svc1)
+				testservice.Delete(cs, svc2)
+				testservice.Delete(cs, svc3)
+			}()
+
+			// The createWithBackend method always wait for service to acquire an ingress IP, so
+			// just validate service ingress ip address are assigned from appropriate ip
+			// address pool.
+			ginkgo.By("validate LoadBalancer IP is allocated from 1st higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolWithHigherPriority}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from 2nd higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority}, e2eservice.GetIngressPoint(
+				&svc2.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+				&svc3.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("with namespace and namespace labels", func() {
+			namespacePoolWithLowerPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-label-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			namespaceLabelPoolWithHigherPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-label-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10, NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: f.Namespace.Labels}}},
+				},
+			}
+			defaultPool := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-label-pool-3"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.20.0/32",
+					},
+				},
+			}
+
+			resources := internalconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespaceLabelPoolWithHigherPriority, defaultPool},
+			}
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-1")
+			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-2")
+			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-3")
+			defer func() {
+				testservice.Delete(cs, svc1)
+				testservice.Delete(cs, svc2)
+				testservice.Delete(cs, svc3)
+			}()
+
+			// The createWithBackend method always wait for service to acquire an ingress IP, so
+			// just validate service ingress ip address are assigned from appropriate ip
+			// address pool.
+			ginkgo.By("validate LoadBalancer IP is allocated from 1st higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespaceLabelPoolWithHigherPriority}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from 2nd higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority}, e2eservice.GetIngressPoint(
+				&svc2.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+				&svc3.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("with service label", func() {
+			svcLabelPoolWithLowerPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-svc-label-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20,
+						ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"test": "e2e"}}}},
+				},
+			}
+			svcLabelPoolWithHigherPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-svc-label-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10,
+						ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"test": "e2e"}}}},
+				},
+			}
+			defaultPool := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-svc-label-pool-3"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.20.0/32",
+					},
+				},
+			}
+
+			resources := internalconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{svcLabelPoolWithLowerPriority, svcLabelPoolWithHigherPriority, defaultPool},
+			}
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			svcTweakWithLabel := func(svc *corev1.Service) {
+				if svc.Labels == nil {
+					svc.Labels = make(map[string]string)
+				}
+				svc.Labels["test"] = "e2e"
+			}
+			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-1", svcTweakWithLabel)
+			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-2", svcTweakWithLabel)
+			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-3", svcTweakWithLabel)
+			defer func() {
+				testservice.Delete(cs, svc1)
+				testservice.Delete(cs, svc2)
+				testservice.Delete(cs, svc3)
+			}()
+
+			// The createWithBackend method always wait for service to acquire an ingress IP, so
+			// just validate service ingress ip address are assigned from appropriate ip
+			// address pool.
+			ginkgo.By("validate LoadBalancer IP is allocated from 1st higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{svcLabelPoolWithHigherPriority}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from 2nd higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{svcLabelPoolWithLowerPriority}, e2eservice.GetIngressPoint(
+				&svc2.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+				&svc3.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("with namespace and service label", func() {
+			namespacePoolWithLowerPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-svc-label-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			svcLabelPoolWithHigherPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-svc-label-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10,
+						ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"test": "e2e"}}}},
+				},
+			}
+			defaultPool := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-svc-label-pool-3"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.20.0/32",
+					},
+				},
+			}
+
+			resources := internalconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, svcLabelPoolWithHigherPriority, defaultPool},
+			}
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			svcTweakWithLabel := func(svc *corev1.Service) {
+				if svc.Labels == nil {
+					svc.Labels = make(map[string]string)
+				}
+				svc.Labels["test"] = "e2e"
+			}
+			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-1", svcTweakWithLabel)
+			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-2", svcTweakWithLabel)
+			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-3", svcTweakWithLabel)
+			defer func() {
+				testservice.Delete(cs, svc1)
+				testservice.Delete(cs, svc2)
+				testservice.Delete(cs, svc3)
+			}()
+
+			// The createWithBackend method always wait for service to acquire an ingress IP, so
+			// just validate service ingress ip address are assigned from appropriate ip
+			// address pool.
+			ginkgo.By("validate LoadBalancer IP is allocated from 1st higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{svcLabelPoolWithHigherPriority}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from 2nd higher priority address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority}, e2eservice.GetIngressPoint(
+				&svc2.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+				&svc3.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+		})
 	})
 })

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -195,6 +195,18 @@ func TestNodeEvent(t *testing.T) {
 		g.Expect(err).To(BeNil())
 	}()
 
+	// count for update on namespace events
+	var initialConfigUpdateCount int
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(5 * time.Second)
+		mutex.Lock()
+		initialConfigUpdateCount = configUpdate
+		mutex.Unlock()
+	}()
+	wg.Wait()
 	// test new node event.
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
@@ -208,7 +220,7 @@ func TestNodeEvent(t *testing.T) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		return configUpdate
-	}, 5*time.Second, 200*time.Millisecond).Should(Equal(1))
+	}, 5*time.Second, 200*time.Millisecond).Should(Equal(initialConfigUpdateCount + 1))
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()
@@ -234,7 +246,7 @@ func TestNodeEvent(t *testing.T) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		return configUpdate
-	}, 5*time.Second, 200*time.Millisecond).Should(Equal(1))
+	}, 5*time.Second, 200*time.Millisecond).Should(Equal(initialConfigUpdateCount + 1))
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()
@@ -260,7 +272,7 @@ func TestNodeEvent(t *testing.T) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		return configUpdate
-	}, 5*time.Second, 200*time.Millisecond).Should(Equal(2))
+	}, 5*time.Second, 200*time.Millisecond).Should(Equal(initialConfigUpdateCount + 2))
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()

--- a/internal/k8s/controllers/pool_controller_test.go
+++ b/internal/k8s/controllers/pool_controller_test.go
@@ -97,7 +97,7 @@ func TestPoolController(t *testing.T) {
 
 		cmpOpt := cmpopts.IgnoreUnexported(metallbcfg.Pool{})
 
-		mockHandler := func(l log.Logger, pools map[string]*config.Pool) SyncState {
+		mockHandler := func(l log.Logger, pools *config.Pools) SyncState {
 			if !cmp.Equal(expectedCfg.Pools, pools, cmpOpt) {
 				t.Errorf("test %s failed, handler called with unexpected config: %s", test.desc, cmp.Diff(expectedCfg.Pools, pools, cmpOpt))
 			}

--- a/internal/k8s/listener.go
+++ b/internal/k8s/listener.go
@@ -16,7 +16,7 @@ type Listener struct {
 	sync.Mutex
 	ServiceChanged func(log.Logger, string, *v1.Service, epslices.EpsOrSlices) controllers.SyncState
 	ConfigChanged  func(log.Logger, *config.Config) controllers.SyncState
-	PoolChanged    func(log.Logger, map[string]*config.Pool) controllers.SyncState
+	PoolChanged    func(log.Logger, *config.Pools) controllers.SyncState
 	NodeChanged    func(log.Logger, *v1.Node) controllers.SyncState
 }
 
@@ -38,7 +38,7 @@ func (l *Listener) NodeHandler(logger log.Logger, node *v1.Node) controllers.Syn
 	return l.NodeChanged(logger, node)
 }
 
-func (l *Listener) PoolHandler(logger log.Logger, pools map[string]*config.Pool) controllers.SyncState {
+func (l *Listener) PoolHandler(logger log.Logger, pools *config.Pools) controllers.SyncState {
 	l.Lock()
 	defer l.Unlock()
 	return l.PoolChanged(logger, pools)

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -267,7 +267,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -277,7 +277,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,
@@ -575,7 +575,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -592,7 +592,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -642,7 +642,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -659,7 +659,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -707,7 +707,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -725,7 +725,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -781,7 +781,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -791,7 +791,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -996,7 +996,7 @@ func TestBGPSpeaker(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -1006,7 +1006,7 @@ func TestBGPSpeaker(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test2",
 			svc: &v1.Service{
@@ -1138,7 +1138,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -1148,7 +1148,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,
@@ -1482,7 +1482,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -1499,7 +1499,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -1555,7 +1555,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -1565,7 +1565,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test1",
 			svc: &v1.Service{
@@ -1772,7 +1772,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						BGPAdvertisements: []*config.BGPAdvertisement{
@@ -1782,7 +1782,7 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			balancer: "test2",
 			svc: &v1.Service{
@@ -1897,7 +1897,7 @@ func TestNodeSelectors(t *testing.T) {
 						NodeSelectors: []labels.Selector{labels.Everything()},
 					},
 				},
-				Pools: pools,
+				Pools: &config.Pools{ByName: pools},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,
@@ -1919,7 +1919,7 @@ func TestNodeSelectors(t *testing.T) {
 						},
 					},
 				},
-				Pools: pools,
+				Pools: &config.Pools{ByName: pools},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,
@@ -1970,7 +1970,7 @@ func TestNodeSelectors(t *testing.T) {
 						},
 					},
 				},
-				Pools: pools,
+				Pools: &config.Pools{ByName: pools},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,
@@ -2009,7 +2009,7 @@ func TestNodeSelectors(t *testing.T) {
 						},
 					},
 				},
-				Pools: pools,
+				Pools: &config.Pools{ByName: pools},
 			},
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4:0": nil,

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -363,12 +363,12 @@ func TestShouldAnnounce(t *testing.T) {
 			desc:     "One service, two endpoints, one host, controller 1 should announce",
 			balancer: "test1",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -412,12 +412,12 @@ func TestShouldAnnounce(t *testing.T) {
 			desc:     "One service, two endpoints, one host, neither endpoint is ready, no controller should announce",
 			balancer: "test1",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -460,12 +460,12 @@ func TestShouldAnnounce(t *testing.T) {
 			desc:     "One service, two endpoints across two hosts, controller2 should announce",
 			balancer: "test1",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -508,7 +508,7 @@ func TestShouldAnnounce(t *testing.T) {
 			desc:     "One service, two endpoints across two hosts, advertisement only on node 1, controller1 should announce",
 			balancer: "test1",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: []*config.L2Advertisement{
@@ -519,7 +519,7 @@ func TestShouldAnnounce(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -560,12 +560,12 @@ func TestShouldAnnounce(t *testing.T) {
 		}, {
 			desc: "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -607,12 +607,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -656,12 +656,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "Two services each with two endpoints across across two hosts, controller 1 should announce the second, controller 2 the first",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -731,12 +731,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, controller 2 should not announce for the service with the not ready endpoint",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -808,12 +808,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -887,12 +887,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -938,12 +938,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -989,12 +989,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 1 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1042,12 +1042,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1095,12 +1095,12 @@ func TestShouldAnnounce(t *testing.T) {
 		{
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1161,8 +1161,8 @@ func TestShouldAnnounce(t *testing.T) {
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
-			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools["default"], svc, test.eps[lbIP_s])
-			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools["default"], svc, test.eps[lbIP_s])
+			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
+			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -1223,12 +1223,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			desc:     "One service, two endpoints, one host, controller 1 should announce",
 			balancer: "test1",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1277,12 +1277,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service, two endpoints, one host, neither endpoint is ready, no controller should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1331,12 +1331,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service, two endpoints across two hosts, controller2 should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1385,12 +1385,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1439,12 +1439,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1493,12 +1493,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "Two services each with two endpoints across across two hosts, each controller should announce one service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1583,12 +1583,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, each controller should announce one service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1673,12 +1673,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1763,12 +1763,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1830,12 +1830,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1893,12 +1893,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -1956,12 +1956,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 1 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -2019,12 +2019,12 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		}, {
 			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
 			config: &config.Config{
-				Pools: map[string]*config.Pool{
+				Pools: &config.Pools{ByName: map[string]*config.Pool{
 					"default": {
 						CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 						L2Advertisements: advertisementsForNode,
 					},
-				},
+				}},
 			},
 			svcs: []*v1.Service{
 				{
@@ -2096,8 +2096,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
-			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools["default"], svc, test.eps[lbIP_s])
-			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools["default"], svc, test.eps[lbIP_s])
+			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
+			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -2310,12 +2310,12 @@ func TestShouldAnnounceNodeSelector(t *testing.T) {
 		}
 
 		cfg := config.Config{
-			Pools: map[string]*config.Pool{
+			Pools: &config.Pools{ByName: map[string]*config.Pool{
 				"default": {
 					CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
 					L2Advertisements: test.L2Advertisements,
 				},
-			},
+			}},
 		}
 		if c1.SetConfig(l, &cfg) == controllers.SyncStateError {
 			t.Errorf("%q: SetConfig failed", test.desc)
@@ -2333,8 +2333,8 @@ func TestShouldAnnounceNodeSelector(t *testing.T) {
 
 		lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 		lbIP_s := lbIP.String()
-		response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], &svc, test.eps[lbIP_s])
-		response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], &svc, test.eps[lbIP_s])
+		response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIP_s])
+		response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIP_s])
 		if response1 != test.c1ExpectedResult[lbIP_s] {
 			t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 		}
@@ -2378,7 +2378,7 @@ func TestClusterPolicy(t *testing.T) {
 	l := log.NewNopLogger()
 
 	cfg := &config.Config{
-		Pools: map[string]*config.Pool{
+		Pools: &config.Pools{ByName: map[string]*config.Pool{
 			"default": {
 				CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 				L2Advertisements: []*config.L2Advertisement{
@@ -2390,7 +2390,7 @@ func TestClusterPolicy(t *testing.T) {
 					},
 				},
 			},
-		},
+		}},
 	}
 
 	if c1.SetConfig(l, cfg) == controllers.SyncStateError {
@@ -2467,11 +2467,11 @@ func TestClusterPolicy(t *testing.T) {
 		}
 
 		lbIP := net.ParseIP(ip)
-		response1svc1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], svc1, eps1)
-		response2svc1 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], svc1, eps1)
+		response1svc1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], svc1, eps1)
+		response2svc1 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], svc1, eps1)
 
-		response1svc2 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], svc2, eps2)
-		response2svc2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools["default"], svc2, eps2)
+		response1svc2 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], svc2, eps2)
+		response2svc2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], svc2, eps2)
 
 		// We check that only one speaker announces the service, so their response must be different
 		if response1svc1 == response2svc1 {

--- a/speaker/speaker_test.go
+++ b/speaker/speaker_test.go
@@ -58,11 +58,11 @@ func TestLoadBalancerCreation(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Pools: map[string]*config.Pool{
+		Pools: &config.Pools{ByName: map[string]*config.Pool{
 			"default": {
 				CIDR: []*net.IPNet{ipnet("10.20.30.0/24")},
 			},
-		},
+		}},
 	}
 
 	state := c.SetConfig(logger, cfg)


### PR DESCRIPTION
This changes ip allocation logic when ip pools are configured with namespace, service/namespace label selectors so that ip are allocated from desired pools based on its priority before it tries to allocate from other ip pools.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>