### PR TITLE
Fix duplicate role, rolebinding metallb-prometheus

### DIFF
--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -79,7 +79,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-podmonitor-prometheus
 rules:
   - apiGroups:
       - ""
@@ -93,11 +93,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-podmonitor-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-podmonitor-prometheus
 subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.serviceAccount }}

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -167,7 +167,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-servicemonitor-prometheus
 rules:
   - apiGroups:
       - ""
@@ -183,11 +183,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-servicemonitor-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "metallb.fullname" . }}-prometheus
+  name: {{ template "metallb.fullname" . }}-servicemonitor-prometheus
 subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.serviceMonitor.enabled == true" .Values.prometheus.serviceAccount }}


### PR DESCRIPTION
Fixed #1694

The metallb helm chart installation fails when
`.Values.prometheus.rbacPrometheus` is true and
`.Values.prometheus.serviceAccount` is specified.

The error message is Error: INSTALLATION FAILED:
 roles.rbac.authorization.k8s.io "metallb-prometheus" already exists

This happens because both podmonitor.yaml and servicemonitor.yaml define a `Role` called `metallb-prometheus` and a`RoleBinding` resource called `metallb-prometheus`

This PR renames the role and rolebindings for podmonitor to `metallb-podmonitor-prometheus`
and the role and rolebindings for servicemonitor to `metallb-servicemonitor-prometheus`

