### PR TITLE
WIP: E2E tests: add VRF support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,6 +167,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install kernel modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install linux-modules-extra-$(uname -r)
+
       - name: Setup
         uses: ./.github/workflows/composite/setup
 
@@ -267,6 +272,11 @@ jobs:
         shell: bash
 
     steps:
+      - name: Install kernel modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install linux-modules-extra-$(uname -r)
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -333,6 +343,11 @@ jobs:
       - helm
       - commitlint
     steps:
+      - name: Install kernel modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install linux-modules-extra-$(uname -r)
+
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	multiHopNetwork      = "multi-hop-net"
+	kindNetwork          = "kind"
 	vrfNetwork           = "vrf-net"
 	vrfName              = "red"
 	metalLBASN           = 64512
@@ -27,20 +28,14 @@ const (
 )
 
 var (
-	containersNetwork string
-	hostIPv4          string
-	hostIPv6          string
-	multiHopRoutes    map[string]container.NetworkSettings
-	FRRContainers     []*frrcontainer.FRR
-	VRFFRRContainers  []*frrcontainer.FRR
+	hostIPv4         string
+	hostIPv6         string
+	multiHopRoutes   map[string]container.NetworkSettings
+	FRRContainers    []*frrcontainer.FRR
+	VRFFRRContainers []*frrcontainer.FRR
 )
 
 func init() {
-	if _, res := os.LookupEnv("RUN_FRR_CONTAINER_ON_HOST_NETWORK"); res {
-		containersNetwork = "host"
-	} else {
-		containersNetwork = "kind"
-	}
 
 	if ip := os.Getenv("PROVISIONING_HOST_EXTERNAL_IPV4"); len(ip) != 0 {
 		hostIPv4 = ip
@@ -50,173 +45,129 @@ func init() {
 	}
 }
 
-// InfraSetup brings up the external container mimicking external routers, and set up the routing needed for
-// testing.
-func InfraSetup(ipv4Addresses, ipv6Addresses []string, externalContainers string, cs *clientset.Clientset) ([]*frrcontainer.FRR, []*frrcontainer.FRR, error) {
-	/*
-		We have 2 ways in which we setup the containers for the tests:
-		1 - The user requested the containers to use the 'host' network
-		so we spin up only one ibgp container.
-		2 - The user specified (or didn't at all) a container network that
-		is not 'host'. In that case he needs to supply 2 IPs for the containers.
-		Then we spin up a total of 4 containers:
-		  * ibgp container that uses the first IP, a single-hop away from our speakers (1st).
-		  * ebgp container that uses the second IP, a single-hop away from our speakers,
-		    and is connected to another containers network "multi-hop-net" (2nd).
-		  * two ibgp/ebgp containers connected to the "multi-hop-net", multi-hops away
-		    from our speakers (3rd,4th).
-		We then wire these networks by adding static routes to both the speaker nodes
-		containers (we're using kind) and the ibgp/ebgp containers connected to multi-hop-net,
-		using the 2nd container as a gateway.
-
-		See `e2etest/README.md` for more details.
-	*/
-
-	ibgpSingleHopContainerConfig := frrcontainer.Config{
-		Name: "ibgp-single-hop",
-		Neighbor: frrconfig.NeighborConfig{
-			ASN:      metalLBASN,
-			Password: "ibgp-test",
-			MultiHop: false,
-		},
-		Router: frrconfig.RouterConfig{
-			ASN:      metalLBASN,
-			BGPPort:  179,
-			Password: "ibgp-test",
-		},
-		Network:  containersNetwork,
-		HostIPv4: hostIPv4,
-		HostIPv6: hostIPv6,
+func ExternalContainersSetup(externalContainers string, cs *clientset.Clientset) ([]*frrcontainer.FRR, error) {
+	err := validateContainersNames(externalContainers)
+	if err != nil {
+		return nil, err
 	}
-	ibgpMultiHopContainerConfig := frrcontainer.Config{
-		Name: "ibgp-multi-hop",
-		Neighbor: frrconfig.NeighborConfig{
-			ASN:      metalLBASN,
-			Password: "ibgp-test",
-			MultiHop: true,
-		},
-		Router: frrconfig.RouterConfig{
-			ASN:      metalLBASN,
-			BGPPort:  180,
-			Password: "ibgp-test",
-		},
-		Network:  multiHopNetwork,
-		HostIPv4: hostIPv4,
-		HostIPv6: hostIPv6,
-	}
-	ebgpMultiHopContainerConfig := frrcontainer.Config{
-		Name: "ebgp-multi-hop",
-		Neighbor: frrconfig.NeighborConfig{
-			ASN:      metalLBASN,
-			Password: "ebgp-test",
-			MultiHop: true,
-		},
-		Router: frrconfig.RouterConfig{
-			ASN:      externalASN,
-			BGPPort:  180,
-			Password: "ebgp-test",
-		},
-		Network:  multiHopNetwork,
-		HostIPv4: hostIPv4,
-		HostIPv6: hostIPv6,
-	}
-	ebgpSingleHopContainerConfig := frrcontainer.Config{
-		Name:    "ebgp-single-hop",
-		Network: containersNetwork,
-		Neighbor: frrconfig.NeighborConfig{
-			ASN:      metalLBASN,
-			MultiHop: false,
-		},
-		Router: frrconfig.RouterConfig{
-			ASN:     externalASN,
-			BGPPort: 179,
-		},
+	names := strings.Split(externalContainers, ",")
+	configs := externalContainersConfigs()
+	toApply := make(map[string]frrcontainer.Config)
+	for _, n := range names {
+		if c, ok := configs[n]; ok {
+			toApply[n] = c
+		}
 	}
 
-	ebgpSingleHopContainerVRFConfig := frrcontainer.Config{
-		Name:    "ebgp-vrf-single-hop",
-		Network: vrfNetwork,
-		Neighbor: frrconfig.NeighborConfig{
-			ASN:      metalLBASN,
-			MultiHop: false,
-		},
-		Router: frrconfig.RouterConfig{
-			ASN:     externalASN,
-			BGPPort: 179,
-			VRF:     "red",
-		},
+	res, err := frrcontainer.ConfigureExisting(toApply)
+	if err != nil {
+		return nil, err
 	}
 
-	if externalContainers != "" {
-		err := validateContainersNames(externalContainers)
+	if containsMultiHop(res) {
+		err = multiHopSetUp(res, cs)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-
-		configs, err := configsFor(externalContainers, ibgpSingleHopContainerConfig, ibgpMultiHopContainerConfig,
-			ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig, ebgpSingleHopContainerVRFConfig)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		res, err := frrcontainer.ConfigureExisting(configs...)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if containsMultiHop(res) {
-			err = multiHopSetUp(res, cs)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-		return res, []*frrcontainer.FRR{}, nil
 	}
-	if containersNetwork == "host" {
-		res, err := frrcontainer.Create(ibgpSingleHopContainerConfig)
-		if err != nil {
-			return nil, nil, err
-		}
-		return res, []*frrcontainer.FRR{}, nil
-	}
+	return res, nil
+}
 
+func HostContainerSetup() ([]*frrcontainer.FRR, error) {
+	config := hostnetContainerConfig()
+	res, err := frrcontainer.Create(config)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+/*
+	When leveraging the kind network we spin up a total of 4 containers:
+	  * ibgp container that uses the first IP, a single-hop away from our speakers (1st).
+	  * ebgp container that uses the second IP, a single-hop away from our speakers,
+	    and is connected to another containers network "multi-hop-net" (2nd).
+	  * two ibgp/ebgp containers connected to the "multi-hop-net", multi-hops away
+	    from our speakers (3rd,4th).
+	We then wire these networks by adding static routes to both the speaker nodes
+	containers (we're using kind) and the ibgp/ebgp containers connected to multi-hop-net,
+	using the 2nd container as a gateway.
+
+	See `e2etest/README.md` for more details.
+*/
+
+func KindnetContainersSetup(ipv4Addresses, ipv6Addresses []string, cs *clientset.Clientset) ([]*frrcontainer.FRR, error) {
 	Expect(len(ipv4Addresses)).Should(BeNumerically(">=", 2))
 	Expect(len(ipv6Addresses)).Should(BeNumerically(">=", 2))
 
-	ibgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[0]
-	ibgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[0]
-	ebgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[1]
-	ebgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[1]
+	configs := frrContainersConfigs(ipv4Addresses, ipv6Addresses)
 
 	var out string
 	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "create", multiHopNetwork, "--ipv6",
 		"--driver=bridge", "--subnet=172.30.0.0/16", "--subnet=fc00:f853:ccd:e798::/64")
 	if err != nil && !strings.Contains(out, "already exists") {
-		return nil, nil, errors.Wrapf(err, "failed to create %s: %s", multiHopNetwork, out)
+		return nil, errors.Wrapf(err, "failed to create %s: %s", multiHopNetwork, out)
 	}
 
-	out, err = executor.Host.Exec(executor.ContainerRuntime, "network", "create", vrfNetwork, "--ipv6",
-		"--driver=bridge", "--subnet=172.31.0.0/16", "--subnet=fc00:f853:ccd:e799::/64")
-	if err != nil && !strings.Contains(out, "already exists") {
-		return nil, nil, errors.Wrapf(err, "failed to create %s: %s", vrfNetwork, out)
-	}
-
-	containers, err := frrcontainer.Create(ibgpSingleHopContainerConfig, ibgpMultiHopContainerConfig,
-		ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig)
+	containers, err := frrcontainer.Create(configs)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	vrfContainers, err := frrcontainer.Create(ebgpSingleHopContainerVRFConfig)
 
 	err = multiHopSetUp(containers, cs)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+	return containers, nil
+}
+
+/*
+	In order to test MetalLB's announcemnet via VRFs, we:
+
+	* create an additional "vrf-net" docker network
+	* for each node, create a vrf named "red" and move the interface in that vrf
+	* create a new frr container belonging to that network
+	* by doing so, the frr container is reacheable only from "inside" the vrf
+*/
+
+func VRFContainersSetup(cs *clientset.Clientset) ([]*frrcontainer.FRR, error) {
+	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "create", vrfNetwork, "--ipv6",
+		"--driver=bridge", "--subnet=172.31.0.0/16", "--subnet=fc00:f853:ccd:e799::/64")
+	if err != nil && !strings.Contains(out, "already exists") {
+		return nil, errors.Wrapf(err, "failed to create %s: %s", vrfNetwork, out)
+	}
+
+	config := vrfContainersConfig()
+
+	vrfContainers, err := frrcontainer.Create(config)
+	if err != nil {
+		return nil, err
 	}
 	err = vrfSetup(cs)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return containers, vrfContainers, nil
+	return vrfContainers, nil
+}
+
+// InfraTearDown tears down the containers and the routes needed for bgp testing.
+func InfraTearDown(cs *clientset.Clientset, containers []*frrcontainer.FRR) error {
+	err := frrcontainer.Delete(containers)
+	if err != nil {
+		return err
+	}
+
+	err = multiHopTearDown(cs)
+	if err != nil {
+		return err
+	}
+
+	err = vrfTeardown(cs)
+	if err == nil {
+		return err
+	}
+
+	return nil
 }
 
 // multiHopSetUp connects the ebgp-single-hop container to the multi-hop-net network,
@@ -234,7 +185,7 @@ func multiHopSetUp(containers []*frrcontainer.FRR, cs *clientset.Clientset) erro
 
 	for _, c := range containers {
 		if c.Network == multiHopNetwork {
-			err = container.AddMultiHop(c, c.Network, containersNetwork, multiHopRoutes)
+			err = container.AddMultiHop(c, c.Network, kindNetwork, multiHopRoutes)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to set up the multi-hop network for container %s", c.Name)
 			}
@@ -267,24 +218,167 @@ func vrfSetup(cs *clientset.Clientset) error {
 	return nil
 }
 
-// InfraTearDown tears down the containers and the routes needed for bgp testing.
-func InfraTearDown(cs *clientset.Clientset, containers []*frrcontainer.FRR) error {
-	err := frrcontainer.Delete(containers)
-	if err != nil {
-		return err
+func externalContainersConfigs() map[string]frrcontainer.Config {
+	res := make(map[string]frrcontainer.Config)
+	res["ibgp-single-hop"] = frrcontainer.Config{
+		Name: "ibgp-single-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ibgp-test",
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      metalLBASN,
+			BGPPort:  179,
+			Password: "ibgp-test",
+		},
 	}
-
-	err = multiHopTearDown(cs)
-	if err != nil {
-		return err
+	res["ibgp-multi-hop"] = frrcontainer.Config{
+		Name: "ibgp-multi-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ibgp-test",
+			MultiHop: true,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      metalLBASN,
+			BGPPort:  180,
+			Password: "ibgp-test",
+		},
 	}
-
-	err = vrfTeardown(cs)
-	if err == nil {
-		return err
+	res["ebgp-multi-hop"] = frrcontainer.Config{
+		Name: "ebgp-multi-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ebgp-test",
+			MultiHop: true,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      externalASN,
+			BGPPort:  180,
+			Password: "ebgp-test",
+		},
 	}
+	res["ebgp-single-hop"] = frrcontainer.Config{
+		Name: "ebgp-single-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:     externalASN,
+			BGPPort: 179,
+		},
+	}
+	return res
+}
 
-	return nil
+func hostnetContainerConfig() map[string]frrcontainer.Config {
+	res := make(map[string]frrcontainer.Config)
+	res["ibgp-single-hop"] = frrcontainer.Config{
+		Name: "ibgp-single-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ibgp-test",
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      metalLBASN,
+			BGPPort:  179,
+			Password: "ibgp-test",
+		},
+		Network:  "host",
+		HostIPv4: hostIPv4,
+		HostIPv6: hostIPv6,
+	}
+	return res
+}
+
+func frrContainersConfigs(ipv4Addresses, ipv6Addresses []string) map[string]frrcontainer.Config {
+	res := make(map[string]frrcontainer.Config)
+	res["ibgp-single-hop"] = frrcontainer.Config{
+		Name: "ibgp-single-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ibgp-test",
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      metalLBASN,
+			BGPPort:  179,
+			Password: "ibgp-test",
+		},
+		Network:     kindNetwork,
+		HostIPv4:    hostIPv4,
+		HostIPv6:    hostIPv6,
+		IPv4Address: ipv4Addresses[0],
+		IPv6Address: ipv6Addresses[0],
+	}
+	res["ibgp-multi-hop"] = frrcontainer.Config{
+		Name: "ibgp-multi-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ibgp-test",
+			MultiHop: true,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      metalLBASN,
+			BGPPort:  180,
+			Password: "ibgp-test",
+		},
+		Network:  multiHopNetwork,
+		HostIPv4: hostIPv4,
+		HostIPv6: hostIPv6,
+	}
+	res["ebgp-multi-hop"] = frrcontainer.Config{
+		Name: "ebgp-multi-hop",
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			Password: "ebgp-test",
+			MultiHop: true,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:      externalASN,
+			BGPPort:  180,
+			Password: "ebgp-test",
+		},
+		Network:  multiHopNetwork,
+		HostIPv4: hostIPv4,
+		HostIPv6: hostIPv6,
+	}
+	res["ebgp-single-hop"] = frrcontainer.Config{
+		Name:    "ebgp-single-hop",
+		Network: kindNetwork,
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:     externalASN,
+			BGPPort: 179,
+		},
+		IPv4Address: ipv4Addresses[0],
+		IPv6Address: ipv6Addresses[0],
+	}
+	return res
+}
+
+func vrfContainersConfig() map[string]frrcontainer.Config {
+	res := make(map[string]frrcontainer.Config)
+	res["ebgp-vrf-single-hop"] = frrcontainer.Config{
+		Name:    "ebgp-vrf-single-hop",
+		Network: vrfNetwork,
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:     externalASN,
+			BGPPort: 179,
+			VRF:     "red",
+		},
+	}
+	return res
 }
 
 func multiHopTearDown(cs *clientset.Clientset) error {
@@ -304,7 +398,7 @@ func multiHopTearDown(cs *clientset.Clientset) error {
 	}
 	for _, pod := range speakerPods {
 		nodeExec := executor.ForContainer(pod.Spec.NodeName)
-		err = container.DeleteMultiHop(nodeExec, containersNetwork, multiHopNetwork, multiHopRoutes)
+		err = container.DeleteMultiHop(nodeExec, kindNetwork, multiHopNetwork, multiHopRoutes)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to delete multihop routes for pod %s", pod.ObjectMeta.Name)
 		}
@@ -353,7 +447,7 @@ func addMultiHopToNodes(cs *clientset.Clientset) error {
 	}
 	for _, pod := range speakerPods {
 		nodeExec := executor.ForContainer(pod.Spec.NodeName)
-		err := container.AddMultiHop(nodeExec, containersNetwork, multiHopNetwork, multiHopRoutes)
+		err := container.AddMultiHop(nodeExec, kindNetwork, multiHopNetwork, multiHopRoutes)
 		if err != nil {
 			return err
 		}
@@ -386,22 +480,6 @@ func validateContainersNames(containerNames string) error {
 	}
 
 	return nil
-}
-
-// configsFor returns the frr configs corresponding to the given comma separated list of containers names.
-func configsFor(containerNames string, frrContainersConfigs ...frrcontainer.Config) ([]frrcontainer.Config, error) {
-	var configs []frrcontainer.Config
-	names := strings.Split(containerNames, ",")
-	for _, n := range names {
-		for _, containerCfg := range frrContainersConfigs {
-			if n == containerCfg.Name {
-				configs = append(configs, containerCfg)
-				break
-			}
-		}
-	}
-
-	return configs, nil
 }
 
 // containsMultiHop returns true if the given containers list include a multi-hop container.

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -19,6 +19,8 @@ import (
 
 const (
 	multiHopNetwork      = "multi-hop-net"
+	vrfNetwork           = "vrf-net"
+	vrfName              = "red"
 	metalLBASN           = 64512
 	externalASN          = 4200000000
 	nextHopContainerName = "ebgp-single-hop"
@@ -30,6 +32,7 @@ var (
 	hostIPv6          string
 	multiHopRoutes    map[string]container.NetworkSettings
 	FRRContainers     []*frrcontainer.FRR
+	VRFFRRContainers  []*frrcontainer.FRR
 )
 
 func init() {
@@ -49,7 +52,7 @@ func init() {
 
 // InfraSetup brings up the external container mimicking external routers, and set up the routing needed for
 // testing.
-func InfraSetup(ipv4Addresses, ipv6Addresses []string, externalContainers string, cs *clientset.Clientset) ([]*frrcontainer.FRR, error) {
+func InfraSetup(ipv4Addresses, ipv6Addresses []string, externalContainers string, cs *clientset.Clientset) ([]*frrcontainer.FRR, []*frrcontainer.FRR, error) {
 	/*
 		We have 2 ways in which we setup the containers for the tests:
 		1 - The user requested the containers to use the 'host' network
@@ -130,65 +133,90 @@ func InfraSetup(ipv4Addresses, ipv6Addresses []string, externalContainers string
 		},
 	}
 
-	var res []*frrcontainer.FRR
-	var err error
+	ebgpSingleHopContainerVRFConfig := frrcontainer.Config{
+		Name:    "ebgp-vrf-single-hop",
+		Network: vrfNetwork,
+		Neighbor: frrconfig.NeighborConfig{
+			ASN:      metalLBASN,
+			MultiHop: false,
+		},
+		Router: frrconfig.RouterConfig{
+			ASN:     externalASN,
+			BGPPort: 179,
+			VRF:     "red",
+		},
+	}
+
 	if externalContainers != "" {
 		err := validateContainersNames(externalContainers)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		configs, err := configsFor(externalContainers, ibgpSingleHopContainerConfig, ibgpMultiHopContainerConfig,
-			ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig)
+			ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig, ebgpSingleHopContainerVRFConfig)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		res, err = frrcontainer.ConfigureExisting(configs...)
+		res, err := frrcontainer.ConfigureExisting(configs...)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if containsMultiHop(res) {
 			err = multiHopSetUp(res, cs)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
-	} else if containersNetwork == "host" {
-		res, err = frrcontainer.Create(ibgpSingleHopContainerConfig)
+		return res, []*frrcontainer.FRR{}, nil
+	}
+	if containersNetwork == "host" {
+		res, err := frrcontainer.Create(ibgpSingleHopContainerConfig)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-	} else {
-		Expect(len(ipv4Addresses)).Should(BeNumerically(">=", 2))
-		Expect(len(ipv6Addresses)).Should(BeNumerically(">=", 2))
-
-		ibgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[0]
-		ibgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[0]
-		ebgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[1]
-		ebgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[1]
-
-		var out string
-		out, err = executor.Host.Exec(executor.ContainerRuntime, "network", "create", multiHopNetwork, "--ipv6",
-			"--driver=bridge", "--subnet=172.30.0.0/16", "--subnet=fc00:f853:ccd:e798::/64")
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create %s: %s", multiHopNetwork, out)
-		}
-
-		res, err = frrcontainer.Create(ibgpSingleHopContainerConfig, ibgpMultiHopContainerConfig,
-			ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		err = multiHopSetUp(res, cs)
-		if err != nil {
-			return nil, err
-		}
+		return res, []*frrcontainer.FRR{}, nil
 	}
 
-	return res, nil
+	Expect(len(ipv4Addresses)).Should(BeNumerically(">=", 2))
+	Expect(len(ipv6Addresses)).Should(BeNumerically(">=", 2))
+
+	ibgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[0]
+	ibgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[0]
+	ebgpSingleHopContainerConfig.IPv4Address = ipv4Addresses[1]
+	ebgpSingleHopContainerConfig.IPv6Address = ipv6Addresses[1]
+
+	var out string
+	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "create", multiHopNetwork, "--ipv6",
+		"--driver=bridge", "--subnet=172.30.0.0/16", "--subnet=fc00:f853:ccd:e798::/64")
+	if err != nil && !strings.Contains(out, "already exists") {
+		return nil, nil, errors.Wrapf(err, "failed to create %s: %s", multiHopNetwork, out)
+	}
+
+	out, err = executor.Host.Exec(executor.ContainerRuntime, "network", "create", vrfNetwork, "--ipv6",
+		"--driver=bridge", "--subnet=172.31.0.0/16", "--subnet=fc00:f853:ccd:e799::/64")
+	if err != nil && !strings.Contains(out, "already exists") {
+		return nil, nil, errors.Wrapf(err, "failed to create %s: %s", vrfNetwork, out)
+	}
+
+	containers, err := frrcontainer.Create(ibgpSingleHopContainerConfig, ibgpMultiHopContainerConfig,
+		ebgpMultiHopContainerConfig, ebgpSingleHopContainerConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	vrfContainers, err := frrcontainer.Create(ebgpSingleHopContainerVRFConfig)
+
+	err = multiHopSetUp(containers, cs)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = vrfSetup(cs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return containers, vrfContainers, nil
 }
 
 // multiHopSetUp connects the ebgp-single-hop container to the multi-hop-net network,
@@ -221,8 +249,27 @@ func multiHopSetUp(containers []*frrcontainer.FRR, cs *clientset.Clientset) erro
 	return nil
 }
 
+func vrfSetup(cs *clientset.Clientset) error {
+	speakerPods, err := metallb.SpeakerPods(cs)
+	if err != nil {
+		return err
+	}
+	for _, pod := range speakerPods {
+		err := addContainerToNetwork(pod.Spec.NodeName, vrfNetwork)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to connect %s to %s", pod.Spec.NodeName, vrfNetwork)
+		}
+
+		err = container.AddNetworkToVRF(pod.Spec.NodeName, vrfNetwork, vrfName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // InfraTearDown tears down the containers and the routes needed for bgp testing.
-func InfraTearDown(containers []*frrcontainer.FRR, cs *clientset.Clientset) error {
+func InfraTearDown(cs *clientset.Clientset, containers []*frrcontainer.FRR) error {
 	err := frrcontainer.Delete(containers)
 	if err != nil {
 		return err
@@ -230,6 +277,11 @@ func InfraTearDown(containers []*frrcontainer.FRR, cs *clientset.Clientset) erro
 
 	err = multiHopTearDown(cs)
 	if err != nil {
+		return err
+	}
+
+	err = vrfTeardown(cs)
+	if err == nil {
 		return err
 	}
 
@@ -260,6 +312,31 @@ func multiHopTearDown(cs *clientset.Clientset) error {
 
 	}
 
+	return nil
+}
+
+func vrfTeardown(cs *clientset.Clientset) error {
+	_, err := executor.Host.Exec(executor.ContainerRuntime, "network", "inspect", vrfNetwork)
+	if err != nil {
+		return nil
+	}
+
+	speakerPods, err := metallb.SpeakerPods(cs)
+	if err != nil {
+		return nil
+	}
+
+	for _, pod := range speakerPods {
+		err := removeContainerFromNetwork(pod.Spec.NodeName, vrfNetwork)
+		if err != nil {
+			return err
+		}
+	}
+
+	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "rm", vrfNetwork)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to remove %s: %s", multiHopNetwork, out)
+	}
 	return nil
 }
 
@@ -338,4 +415,38 @@ func containsMultiHop(frrContainers []*frrcontainer.FRR) bool {
 	}
 
 	return multiHop
+}
+
+func addContainerToNetwork(containerName, network string) error {
+	networks, err := container.Networks(containerName)
+	if err != nil {
+		return err
+	}
+	if _, ok := networks[network]; ok {
+		return nil
+	}
+
+	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "connect",
+		network, containerName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to connect %s to %s: %s", containerName, network, out)
+	}
+	return nil
+}
+
+func removeContainerFromNetwork(containerName, network string) error {
+	networks, err := container.Networks(containerName)
+	if err != nil {
+		return err
+	}
+	if _, ok := networks[network]; !ok {
+		return nil
+	}
+
+	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "disconnect",
+		network, containerName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to disconnect %s from %s: %s", containerName, network, out)
+	}
+	return nil
 }

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -222,10 +222,9 @@ func InfraSetup(ipv4Addresses, ipv6Addresses []string, externalContainers string
 // multiHopSetUp connects the ebgp-single-hop container to the multi-hop-net network,
 // and creates the required static routes between the multi-hop containers and the speaker pods.
 func multiHopSetUp(containers []*frrcontainer.FRR, cs *clientset.Clientset) error {
-	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "connect",
-		multiHopNetwork, nextHopContainerName)
+	err := addContainerToNetwork(nextHopContainerName, multiHopNetwork)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to connect %s to %s: %s", nextHopContainerName, multiHopNetwork, out)
+		return errors.Wrapf(err, "Failed to connect %s to %s", nextHopContainerName, multiHopNetwork)
 	}
 
 	multiHopRoutes, err = container.Networks(nextHopContainerName)

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -137,7 +137,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	v4Addresses := strings.Split(ipv4ForContainers, ",")
 	v6Addresses := strings.Split(ipv6ForContainers, ",")
-	bgptests.FRRContainers, err = bgptests.InfraSetup(v4Addresses, v6Addresses, external_containers, cs)
+	bgptests.FRRContainers, bgptests.VRFFRRContainers, err = bgptests.InfraSetup(v4Addresses, v6Addresses, external_containers, cs)
 	framework.ExpectNoError(err)
 
 	clientconfig, err := framework.LoadConfig()
@@ -181,7 +181,8 @@ var _ = ginkgo.AfterSuite(func() {
 	cs, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
 
-	err = bgptests.InfraTearDown(bgptests.FRRContainers, cs)
+	toTearDown := append(bgptests.FRRContainers, bgptests.VRFFRRContainers...)
+	err = bgptests.InfraTearDown(cs, toTearDown)
 	framework.ExpectNoError(err)
 	err = updater.Clean()
 	framework.ExpectNoError(err)

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -58,7 +58,8 @@ var (
 	prometheusNamespace string
 	nodeNics            string
 	localNics           string
-	external_containers string
+	externalContainers  string
+	runOnHost           bool
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -86,8 +87,12 @@ func handleFlags() {
 	flag.BoolVar(&useOperator, "use-operator", false, "set this to true to run the tests using operator custom resources")
 	flag.StringVar(&reportPath, "report-path", "/tmp/report", "the path to be used to dump test failure information")
 	flag.StringVar(&prometheusNamespace, "prometheus-namespace", "monitoring", "the namespace prometheus is running in (if running)")
-	flag.StringVar(&external_containers, "external-containers", "", "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)")
+	flag.StringVar(&externalContainers, "external-containers", "", "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)")
 	flag.Parse()
+
+	if _, res := os.LookupEnv("RUN_FRR_CONTAINER_ON_HOST_NETWORK"); res {
+		runOnHost = true
+	}
 }
 
 func TestMain(m *testing.M) {
@@ -137,8 +142,20 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	v4Addresses := strings.Split(ipv4ForContainers, ",")
 	v6Addresses := strings.Split(ipv6ForContainers, ",")
-	bgptests.FRRContainers, bgptests.VRFFRRContainers, err = bgptests.InfraSetup(v4Addresses, v6Addresses, external_containers, cs)
-	framework.ExpectNoError(err)
+
+	switch {
+	case externalContainers != "":
+		bgptests.FRRContainers, err = bgptests.ExternalContainersSetup(externalContainers, cs)
+		framework.ExpectNoError(err)
+	case runOnHost:
+		bgptests.FRRContainers, err = bgptests.HostContainerSetup()
+		framework.ExpectNoError(err)
+	default:
+		bgptests.FRRContainers, err = bgptests.KindnetContainersSetup(v4Addresses, v6Addresses, cs)
+		framework.ExpectNoError(err)
+		bgptests.VRFFRRContainers, err = bgptests.VRFContainersSetup(cs)
+		framework.ExpectNoError(err)
+	}
 
 	clientconfig, err := framework.LoadConfig()
 	framework.ExpectNoError(err)

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -90,6 +90,7 @@ type RouterConfig struct {
 	AcceptV6Neighbors []*NeighborConfig
 	BGPPort           uint16
 	Password          string
+	VRF               string
 }
 
 type NeighborConfig struct {

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -59,11 +59,11 @@ type Config struct {
 }
 
 // Create creates a set of frr containers corresponding to the given configurations.
-func Create(c ...Config) ([]*FRR, error) {
+func Create(configs map[string]Config) ([]*FRR, error) {
 	m := sync.Mutex{}
 	frrContainers := make([]*FRR, 0)
 	g := new(errgroup.Group)
-	for _, conf := range c {
+	for _, conf := range configs {
 		conf := conf
 		g.Go(func() error {
 			toFind := map[string]bool{
@@ -136,7 +136,7 @@ func PairWithNodes(cs clientset.Interface, c *FRR, ipFamily ipfamily.Family, mod
 
 // ConfigureExisting validates that the existing frr containers that correspond to the
 // given configurations are up and running, and returns the corresponding *FRRs.
-func ConfigureExisting(c ...Config) ([]*FRR, error) {
+func ConfigureExisting(c map[string]Config) ([]*FRR, error) {
 	frrContainers := make([]*FRR, 0)
 	for _, cfg := range c {
 		err := containerIsRunning(cfg.Name)

--- a/e2etest/pkg/routes/interfaces.go
+++ b/e2etest/pkg/routes/interfaces.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+)
+
+type InterfaceAddress struct {
+	Ifname   string `json:"ifname"`
+	AddrInfo []struct {
+		Family    string `json:"family"`
+		Local     string `json:"local"`
+		Prefixlen int    `json:"prefixlen"`
+		Scope     string `json:"scope"`
+	} `json:"addr_info"`
+}
+
+func InterfaceForAddress(exec executor.Executor, ipv4Address, ipv6Address string) (string, error) {
+	jsonAddr, err := exec.Exec("ip", "-j", "a")
+	if err != nil {
+		return "", err
+	}
+	res, err := findInterfaceWithAddresses(jsonAddr, ipv4Address, ipv6Address)
+	if err != nil {
+		return "", err
+	}
+	return res, nil
+}
+
+type InterfaceLink struct {
+	Ifname string `json:"ifname"`
+	Master string `json:"master"`
+}
+
+type InterfaceNotFoundErr struct {
+	interfaceName string
+}
+
+func (e *InterfaceNotFoundErr) Error() string {
+	return fmt.Sprintf("interface %s not found", e.interfaceName)
+}
+
+func InterfaceExists(exec executor.Executor, intf string) error {
+	interfaces, err := ipLink(exec)
+	if err != nil {
+		return err
+	}
+	for _, i := range interfaces {
+		if i.Ifname == intf {
+			return nil
+		}
+	}
+	return &InterfaceNotFoundErr{interfaceName: intf}
+}
+
+func CreateVRF(exec executor.Executor, vrfName string) error {
+	out, err := exec.Exec("ip", "link", "add", vrfName, "type", "vrf", "table", "2")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create vrf %s : %s", vrfName, out)
+	}
+	out, err = exec.Exec("ip", "link", "set", "dev", vrfName, "up")
+	if err != nil {
+		return errors.Wrapf(err, "failed to set vrf %s up : %s", vrfName, out)
+	}
+	return nil
+}
+
+func AddInterfaceToVRF(exec executor.Executor, intf, vrf, ipv6Address string) error {
+	links, err := ipLink(exec)
+	if err != nil {
+		return err
+	}
+	for _, l := range links {
+		if l.Ifname != intf {
+			continue
+		}
+		if l.Master != "" && l.Master != vrf {
+			return fmt.Errorf("interface %s already has a master %s different from %s", intf, l.Master, vrf)
+		}
+		if l.Master == vrf { // Already set
+			return nil
+		}
+	}
+	out, err := exec.Exec("ip", "link", "set", "dev", intf, "master", vrf)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set master %s to %s : %s", vrf, intf, out)
+	}
+	// we need this because moving the interface to the vrf removes the v6 IP
+	out, err = exec.Exec("ip", "-6", "addr", "add", ipv6Address+"/64", "dev", intf)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set master %s to %s : %s", vrf, intf, out)
+	}
+	return nil
+}
+
+func findInterfaceWithAddresses(jsonIPOutput string, ipv4Address, ipv6Address string) (string, error) {
+	var interfaces []InterfaceAddress
+	err := json.Unmarshal([]byte(jsonIPOutput), &interfaces)
+	if err != nil {
+		return "", err
+	}
+
+	foundV4, foundV6 := false, false
+	for _, i := range interfaces {
+		for _, info := range i.AddrInfo {
+			if info.Family == "inet" && info.Local == ipv4Address {
+				foundV4 = true
+			}
+			if info.Family == "inet6" && info.Scope == "global" && info.Local == ipv6Address {
+				foundV6 = true
+			}
+		}
+		if foundV4 && !foundV6 {
+			return "", fmt.Errorf("interface %s has v4 address %s but not v6 address %s", i.Ifname, ipv4Address, ipv6Address)
+		}
+		if !foundV4 && foundV6 {
+			return "", fmt.Errorf("interface %s does not have v4 address %s but has v6 address %s", i.Ifname, ipv4Address, ipv6Address)
+		}
+		if foundV4 && foundV6 {
+			return i.Ifname, nil
+		}
+	}
+	return "", fmt.Errorf("could not find interface on with ipv4 addres %s and ipv6 address %s", ipv4Address, ipv6Address)
+}
+
+func ipLink(exec executor.Executor) ([]InterfaceLink, error) {
+	links, err := exec.Exec("ip", "-j", "l")
+	if err != nil {
+		return nil, err
+	}
+	var interfaces []InterfaceLink
+	err = json.Unmarshal([]byte(links), &interfaces)
+	if err != nil {
+		return nil, err
+	}
+	return interfaces, nil
+}

--- a/e2etest/pkg/routes/interfaces_test.go
+++ b/e2etest/pkg/routes/interfaces_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routes
+
+import (
+	"testing"
+)
+
+func TestInterfacesForAddr(t *testing.T) {
+	output :=
+		`[{"ifindex":1,"ifname":"lo","flags":["LOOPBACK","UP","LOWER_UP"],"mtu":65536,"qdisc":"noqueue","operstate":"UNKNOWN","group":"default","txqlen":1000,"link_type":"loopback","address":"00:00:00:00:00:00","broadcast":"00:00:00:00:00:00","addr_info":[{"family":"inet","local":"127.0.0.1","prefixlen":8,"scope":"host","label":"lo","valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"::1","prefixlen":128,"scope":"host","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":2,"link_index":2,"ifname":"veth4b6ac7a6","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"noqueue","operstate":"UP","group":"default","link_type":"ether","address":"c6:ba:7c:49:bf:05","broadcast":"ff:ff:ff:ff:ff:ff","link_netnsid":1,"addr_info":[{"family":"inet","local":"10.244.1.1","prefixlen":32,"scope":"global","label":"veth4b6ac7a6","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":6,"link_index":7,"ifname":"eth0","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"noqueue","operstate":"UP","group":"default","link_type":"ether","address":"02:42:ac:12:00:02","broadcast":"ff:ff:ff:ff:ff:ff","link_netnsid":0,"addr_info":[{"family":"inet","local":"172.18.0.2","prefixlen":16,"broadcast":"172.18.255.255","scope":"global","label":"eth0","valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fc00:f853:ccd:e793::2","prefixlen":64,"scope":"global","nodad":true,"valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fe80::42:acff:fe12:2","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":14,"link_index":15,"ifname":"eth1","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"noqueue","operstate":"UP","group":"default","link_type":"ether","address":"02:42:ac:13:00:03","broadcast":"ff:ff:ff:ff:ff:ff","link_netnsid":0,"addr_info":[{"family":"inet","local":"172.19.0.3","prefixlen":16,"broadcast":"172.19.255.255","scope":"global","label":"eth1","valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fc00:f853:ccd:e791::3","prefixlen":64,"scope":"global","nodad":true,"valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fe80::42:acff:fe13:3","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]`
+
+	cases := []struct {
+		description       string
+		ipv4Address       string
+		ipv6Address       string
+		expectedInterface string
+		expectsError      bool
+	}{
+		{
+			description:       "eth1, should find",
+			ipv4Address:       "172.19.0.3",
+			ipv6Address:       "fc00:f853:ccd:e791::3",
+			expectedInterface: "eth1",
+		},
+		{
+			description:  "eth1, v4 not matching",
+			ipv4Address:  "172.19.0.4",
+			ipv6Address:  "fc00:f853:ccd:e791::3",
+			expectsError: true,
+		},
+		{
+			description:  "eth1, v6 not matching",
+			ipv4Address:  "172.19.0.3",
+			ipv6Address:  "fc00:f853:ccd:e791::4",
+			expectsError: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			intf, err := findInterfaceWithAddresses(output, tt.ipv4Address, tt.ipv6Address)
+			if tt.expectsError && err == nil {
+				t.Errorf("expected error, but got %s", intf)
+			}
+			if !tt.expectsError && err != nil {
+				t.Errorf("did not expect error but got %v", err)
+			}
+			if intf != tt.expectedInterface {
+				t.Errorf("interface different from what expected %s - %s", intf, tt.expectedInterface)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Here we change the e2e tests infrastructure to:
- add a new docker network to the nodes
- wrap the interface corresponding to that docker network in a vrf named "red"
- create a new container reacheable only from that network

Then, we refactor the infra_setup logic in order to split it in pieces that return the related containers instead of having a single entry point.

This does not extend the tests or add VRF support to metallb, but lays the ground to test and validate it.

Note: this PR is marked as WIP only because MetalLB is not tested e2e