### PR TITLE
CI: move the api doc consistency check to the website lane

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,6 @@ jobs:
           inv checkchanges --action="run inv gomodtidy"
           inv generatemanifests
           inv checkchanges --action="run inv generatemanifests"
-          inv generateapidocs
-          inv checkchanges --action="run inv generateapidocs"
 
   build-test-images:
     runs-on: ubuntu-22.04

--- a/.github/workflows/site-build.yaml
+++ b/.github/workflows/site-build.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'website/**'
       - 'netlify.toml'
+      - 'api/**'
     branches:
       - "main"
       - "v**"
@@ -22,6 +23,17 @@ jobs:
 
       - uses: wagoid/commitlint-github-action@v4
       
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-pip
+          sudo pip3 install invoke semver pyyaml
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -29,3 +41,8 @@ jobs:
 
       - name: Build
         run: cd ./website && hugo
+
+      - name: Check api docs
+        run: |
+          inv generateapidocs
+          inv checkchanges --action="run inv generateapidocs"

--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -120,3 +120,5 @@ type BGPPeerList struct {
 func init() {
 	SchemeBuilder.Register(&BGPPeer{}, &BGPPeerList{})
 }
+
+// blablabla this won't change the docs


### PR DESCRIPTION
Changes in the automatically generated api docs do not trigger the verification of consistency, because they live under `website` while the api live under `api`.

Because of this, we move the api check under the website lane and we trigger it also when a change under `api` occurs.

