### PR TITLE
Add BGPPeer VRF support

### DIFF
--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -82,6 +82,11 @@ type BGPPeerSpec struct {
 	// To set if the BGPPeer is multi-hops away. Needed for FRR mode only.
 	// +optional
 	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty"`
+
+	// To set if we want to peer with the BGPPeer using an interface belonging to
+	// a host vrf
+	// +optional
+	VRFName string `json:"vrf,omitempty"`
 	// Add future BGP configuration here
 }
 

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -772,6 +772,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -277,6 +277,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -832,6 +832,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -832,6 +832,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -832,6 +832,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -832,6 +832,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -72,6 +72,7 @@ type SessionParameters struct {
 	CurrentNode   string
 	BFDProfile    string
 	EBGPMultiHop  bool
+	VRFName       string
 	SessionName   string
 }
 type SessionManager interface {

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -60,7 +60,21 @@ type Session interface {
 	Set(advs ...*Advertisement) error
 }
 
+type SessionParameters struct {
+	PeerAddress   string
+	SourceAddress net.IP
+	MyASN         uint32
+	RouterID      net.IP
+	PeerASN       uint32
+	HoldTime      time.Duration
+	KeepAliveTime time.Duration
+	Password      string
+	CurrentNode   string
+	BFDProfile    string
+	EBGPMultiHop  bool
+	SessionName   string
+}
 type SessionManager interface {
-	NewSession(logger log.Logger, addr string, srcAddr net.IP, myASN uint32, routerID net.IP, asn uint32, hold, keepalive time.Duration, password, myNode, bfdProfile string, ebgpMultiHop bool, name string) (Session, error)
+	NewSession(logger log.Logger, args SessionParameters) (Session, error)
 	SyncBFDProfiles(profiles map[string]*config.BFDProfile) error
 }

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -204,13 +204,14 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 		var exist bool
 		var rout *router
 
-		routerName := routerName(s.RouterID.String(), s.MyASN)
+		routerName := routerName(s.RouterID.String(), s.MyASN, s.VRFName)
 		if rout, exist = routers[routerName]; !exist {
 			rout = &router{
 				myASN:        s.MyASN,
 				neighbors:    make(map[string]*neighborConfig),
 				ipV4Prefixes: make(map[string]string),
 				ipV6Prefixes: make(map[string]string),
+				vrf:          s.VRFName,
 			}
 			if s.RouterID != nil {
 				rout.routerID = s.RouterID.String()
@@ -218,7 +219,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			routers[routerName] = rout
 		}
 
-		neighborName := neighborName(s.PeerAddress, s.PeerASN)
+		neighborName := neighborName(s.PeerAddress, s.PeerASN, s.VRFName)
 		if neighbor, exist = rout.neighbors[neighborName]; !exist {
 			host, port, err := net.SplitHostPort(s.PeerAddress)
 			if err != nil {
@@ -243,6 +244,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				Advertisements: make([]*advertisementConfig, 0),
 				BFDProfile:     s.BFDProfile,
 				EBGPMultiHop:   s.EBGPMultiHop,
+				VRFName:        s.VRFName,
 			}
 			if s.SourceAddress != nil {
 				neighbor.SrcAddr = s.SourceAddress.String()

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -60,7 +60,7 @@ func (s *session) Set(advs ...*bgp.Advertisement) error {
 	defer s.sessionManager.Unlock()
 	sessionName := sessionName(s.SourceAddress.String(), s.MyASN, s.PeerAddress, s.PeerASN)
 	if _, found := s.sessionManager.sessions[sessionName]; !found {
-		return fmt.Errorf("session not established before advertisement")
+		return fmt.Errorf("session %s not established before advertisement", sessionName)
 	}
 
 	newAdvs := []*bgp.Advertisement{}

--- a/internal/bgp/frr/frr_bfd_test.go
+++ b/internal/bgp/frr/frr_bfd_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/logging"
 	"go.universe.tf/metallb/internal/pointer"
@@ -121,7 +122,20 @@ func TestBFDWithSession(t *testing.T) {
 		t.Fatalf("Failed to sync bfd profiles %s", err)
 	}
 
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, 2*time.Second, "password", "hostname", "foo", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: 2 * time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer",
+			BFDProfile:    "foo"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -104,7 +104,19 @@ func TestSingleEBGPSessionMultiHop(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -119,7 +131,20 @@ func TestSingleEBGPSessionOneHop(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "127.0.0.2:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "127.0.0.2:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -134,7 +159,20 @@ func TestSingleIPv6EBGPSessionOneHop(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "[127:0:0::2]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "[127:0:0::2]:179",
+			SourceAddress: net.ParseIP("10:1:1::254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -149,7 +187,20 @@ func TestSingleIBGPSession(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 100, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       100,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -164,7 +215,19 @@ func TestSingleIPv6IBGPSession(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "[10:2:2::254]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 100, time.Second, time.Second, "password", "hostname", "", false, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "[10:2:2::254]:179",
+			SourceAddress: net.ParseIP("10:1:1::254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       100,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -180,7 +243,20 @@ func TestSingleSessionClose(t *testing.T) {
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -194,12 +270,38 @@ func TestTwoSessions(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer1")
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.255:179", net.ParseIP("10.3.3.254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "", true, "test-peer2")
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.4.4.255:179",
+			SourceAddress: net.ParseIP("10.3.3.254"),
+			MyASN:         300,
+			RouterID:      net.ParseIP("10.3.3.254"),
+			PeerASN:       400,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer2"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -214,17 +316,42 @@ func TestTwoIPv6Sessions(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session1, err := sessionManager.NewSession(l, "[10:2:2::254]:179", net.ParseIP("10:1:1::254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", false, "test-peer1")
+
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "[10:2:2::254]:179",
+			SourceAddress: net.ParseIP("10:1:1::254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer1"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "[10:4:4::255]:179", net.ParseIP("10:3:3::254"), 300, net.ParseIP("10.3.3.254"), 400, time.Second, time.Second, "password", "hostname", "", false, "test-peer2")
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "[10:4:4::255]:179",
+			SourceAddress: net.ParseIP("10:3:3::254"),
+			MyASN:         300,
+			RouterID:      net.ParseIP("10.3.3.254"),
+			PeerASN:       400,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer2"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session2.Close()
-
 	testCheckConfigFile(t)
 }
 
@@ -234,12 +361,37 @@ func TestTwoSessionsDuplicate(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer1")
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer2")
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer2"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -254,12 +406,38 @@ func TestTwoSessionsDuplicateRouter(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session1, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer1")
+
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session1.Close()
-	session2, err := sessionManager.NewSession(l, "10.4.4.255:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 400, time.Second, time.Second, "password", "hostname", "", true, "test-peer2")
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.4.4.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       400,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer2"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -274,7 +452,19 @@ func TestSingleAdvertisement(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -309,7 +499,20 @@ func TestSingleAdvertisementNoRouterID(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, nil, 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      nil,
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -338,7 +541,20 @@ func TestSingleAdvertisementInvalidNoPort(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+
 	if err == nil {
 		session.Close()
 		t.Fatalf("Should not be able to create session")
@@ -353,7 +569,20 @@ func TestSingleAdvertisementStop(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -387,7 +616,19 @@ func TestSingleAdvertisementChange(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -430,7 +671,20 @@ func TestSingleAdvertisementWithPeerSelector(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -466,7 +720,19 @@ func TestSingleAdvertisementNonExistingPeer(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -502,7 +768,19 @@ func TestTwoAdvertisements(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -543,13 +821,37 @@ func TestTwoAdvertisementsTwoSessions(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session.Close()
 
-	session1, err := sessionManager.NewSession(l, "10.2.2.255:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer1")
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
@@ -596,13 +898,37 @@ func TestTwoAdvertisementsTwoSessionsOneWithPeerSelector(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := NewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
-	session, err := sessionManager.NewSession(l, "10.2.2.254:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer")
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}
 	defer session.Close()
 
-	session1, err := sessionManager.NewSession(l, "10.2.2.255:179", net.ParseIP("10.1.1.254"), 100, net.ParseIP("10.1.1.254"), 200, time.Second, time.Second, "password", "hostname", "", true, "test-peer1")
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
 	if err != nil {
 		t.Fatalf("Could not create session: %s", err)
 	}

--- a/internal/bgp/frr/frr_vrf_test.go
+++ b/internal/bgp/frr/frr_vrf_test.go
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package frr
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"go.universe.tf/metallb/internal/bgp"
+	"go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/logging"
+)
+
+func TestVRFSingleEBGPSessionMultiHop(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleVRFIBGPSession(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       100,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoSessionsOneVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.4.4.255:179",
+			SourceAddress: net.ParseIP("10.3.3.254"),
+			MyASN:         300,
+			RouterID:      net.ParseIP("10.3.3.254"),
+			PeerASN:       400,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer2",
+			VRFName:       "red"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session2.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoSessionsSameIPVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer1"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+	session2, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.3.3.254"),
+			MyASN:         300,
+			RouterID:      net.ParseIP("10.3.3.254"),
+			PeerASN:       400,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer2",
+			VRFName:       "red"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session2.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleAdvertisementVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	community, _ = config.ParseCommunity("3333:4444")
+	communities = append(communities, community)
+	adv := &bgp.Advertisement{
+		Prefix:      prefix,
+		Communities: communities,
+		LocalPref:   300,
+	}
+
+	err = session.Set(adv)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleAdvertisementChangeVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+
+	adv := &bgp.Advertisement{
+		Prefix: prefix,
+	}
+
+	err = session.Set(adv)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	prefix = &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv = &bgp.Advertisement{
+		Prefix: prefix,
+	}
+
+	err = session.Set(adv)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleAdvertisementWithPeerSelectorVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	community, _ = config.ParseCommunity("3333:4444")
+	communities = append(communities, community)
+	adv := &bgp.Advertisement{
+		Prefix:      prefix,
+		Communities: communities,
+		LocalPref:   300,
+		Peers:       []string{"test-peer"},
+	}
+
+	err = session.Set(adv)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoAdvertisementsVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	adv1 := &bgp.Advertisement{
+		Prefix:      prefix1,
+		Communities: communities,
+	}
+
+	prefix2 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix: prefix2,
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoAdvertisementsTwoSessionsOneVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer1",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	adv1 := &bgp.Advertisement{
+		Prefix:      prefix1,
+		Communities: communities,
+	}
+
+	prefix2 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix:      prefix2,
+		Communities: communities,
+		LocalPref:   2,
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+	err = session1.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer1",
+		})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	adv1 := &bgp.Advertisement{
+		Prefix:      prefix1,
+		Communities: communities,
+		Peers:       []string{"test-peer"},
+	}
+
+	prefix2 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix:      prefix2,
+		Communities: communities,
+		LocalPref:   2,
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+	err = session1.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer",
+			VRFName:       "red"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	session1, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.255:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  false,
+			SessionName:   "test-peer1",
+			VRFName:       "blue",
+		})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session1.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []uint32{}
+	community, _ := config.ParseCommunity("1111:2222")
+	communities = append(communities, community)
+	adv1 := &bgp.Advertisement{
+		Prefix:      prefix1,
+		Communities: communities,
+		Peers:       []string{"test-peer"},
+	}
+
+	prefix2 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.11"),
+		Mask: classCMask,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix:      prefix2,
+		Communities: communities,
+		LocalPref:   2,
+		Peers:       []string{"test-peer1"},
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+	err = session1.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}

--- a/internal/bgp/frr/templates/filters.tmpl
+++ b/internal/bgp/frr/templates/filters.tmpl
@@ -1,6 +1,6 @@
 {{- define "localpreffilter" -}}
 {{frrIPFamily .advertisement.IPFamily}} prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}} permit {{.advertisement.Prefix}}
-route-map {{.neighbor.Addr}}-out permit {{counter .neighbor.Addr}}
+route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}}
   set local-preference {{.advertisement.LocalPref}}
   on-match next
@@ -8,7 +8,7 @@ route-map {{.neighbor.Addr}}-out permit {{counter .neighbor.Addr}}
 
 {{- define "communityfilter" -}}
 {{frrIPFamily .advertisement.IPFamily}} prefix-list {{communityPrefixList .neighbor .community}} permit {{.advertisement.Prefix}}
-route-map {{.neighbor.Addr}}-out permit {{counter .neighbor.Addr}}
+route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{communityPrefixList .neighbor .community}}
   set community {{.community}} additive
   on-match next
@@ -20,7 +20,7 @@ route-map {{.neighbor.Addr}}-out permit {{counter .neighbor.Addr}}
      deny all the others.*/ -}}
 {{- define "neighborfilters" -}}
 
-route-map {{.neighbor.Addr}}-in deny 20
+route-map {{.neighbor.ID}}-in deny 20
 {{- range $a := .neighbor.Advertisements }}
 {{/* Advertisements for which we must enable set the local pref */}}
 {{- if not (eq $a.LocalPref 0)}}
@@ -35,9 +35,9 @@ route-map {{.neighbor.Addr}}-in deny 20
 {{frrIPFamily $a.IPFamily}} prefix-list {{allowedPrefixList $.neighbor}} permit {{$a.Prefix}}
 {{- end }}
 
-route-map {{$.neighbor.Addr}}-out permit {{counter $.neighbor.Addr}}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
   match ip address prefix-list {{allowedPrefixList $.neighbor}}
-route-map {{$.neighbor.Addr}}-out permit {{counter $.neighbor.Addr}}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
   match ipv6 address prefix-list {{allowedPrefixList $.neighbor}}
 
 ip prefix-list {{allowedPrefixList $.neighbor }} deny any

--- a/internal/bgp/frr/templates/frr.tmpl
+++ b/internal/bgp/frr/templates/frr.tmpl
@@ -19,14 +19,14 @@ hostname {{.Hostname}}
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 
-{{- range .Routers }}
+{{- range $r := .Routers }}
 {{- range .Neighbors }}
-{{template "neighborfilters" dict "neighbor" .}}
+{{template "neighborfilters" dict "neighbor" . "router" $r}}
 {{- end }}
 {{- end }}
 
 {{range $r := .Routers -}}
-router bgp {{$r.MyASN}}
+router bgp {{$r.MyASN}}{{ if $r.VRF }} vrf {{$r.VRF}}{{end}}
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast

--- a/internal/bgp/frr/templates/neighboripfamily.tmpl
+++ b/internal/bgp/frr/templates/neighboripfamily.tmpl
@@ -2,12 +2,12 @@
 {{/* no bgp default ipv4-unicast prevents peering if no address families are defined. We declare an ipv4 one for the peer to make the pairing happen */}}
   address-family ipv4 unicast
     neighbor {{.Addr}} activate
-    neighbor {{.Addr}} route-map {{.Addr}}-in in
-    neighbor {{.Addr}} route-map {{.Addr}}-out out
+    neighbor {{.Addr}} route-map {{.ID}}-in in
+    neighbor {{.Addr}} route-map {{.ID}}-out out
   exit-address-family
   address-family ipv6 unicast
     neighbor {{.Addr}} activate
-    neighbor {{.Addr}} route-map {{.Addr}}-in in
-    neighbor {{.Addr}} route-map {{.Addr}}-out out
+    neighbor {{.Addr}} route-map {{.ID}}-in in
+    neighbor {{.Addr}} route-map {{.ID}}-out out
   exit-address-family
 {{- end -}}

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
@@ -1,0 +1,45 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.11/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
@@ -1,0 +1,60 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes
+  set local-preference 300
+  on-match next
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 2
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 3
+  match ip address prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes
+  set community 3333:4444 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+route-map 10.2.2.254-red-out permit 4
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelectorVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelectorVRF.golden
@@ -1,0 +1,60 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes
+  set local-preference 300
+  on-match next
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 2
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 3
+  match ip address prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes
+  set community 3333:4444 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+route-map 10.2.2.254-red-out permit 4
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
@@ -1,0 +1,38 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 100
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
@@ -1,0 +1,121 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.254-out permit 2
+  match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
+  set local-preference 2
+  on-match next
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+route-map 10.2.2.254-out permit 3
+  match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.254-out permit 4
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+route-map 10.2.2.255-red-in deny 20
+
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.255-red-out permit 1
+  match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-red-out permit 2
+  match ip address prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes
+  set local-preference 2
+  on-match next
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-red-out permit 3
+  match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.255-red-out permit 4
+  match ip address prefix-list 10.2.2.255-red-pl-ipv4
+route-map 10.2.2.255-red-out permit 5
+  match ipv6 address prefix-list 10.2.2.255-red-pl-ipv4
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.255-red-pl-ipv4 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+    network 172.16.1.11/24
+  exit-address-family
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.255 remote-as 200
+  neighbor 10.2.2.255 port 179
+  neighbor 10.2.2.255 timers 1 1
+  neighbor 10.2.2.255 password password
+  neighbor 10.2.2.255 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-red-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-red-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+    network 172.16.1.11/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF.golden
@@ -1,0 +1,112 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.255-in deny 20
+
+ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-out permit 1
+  match ip address prefix-list 10.2.2.255-2-ipv4-localpref-prefixes
+  set local-preference 2
+  on-match next
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-out permit 2
+  match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.255-out permit 3
+  match ip address prefix-list 10.2.2.255-pl-ipv4
+route-map 10.2.2.255-out permit 4
+  match ipv6 address prefix-list 10.2.2.255-pl-ipv4
+
+ip prefix-list 10.2.2.255-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
+route-map 10.2.2.254-red-in deny 20
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.254-red-out permit 2
+  match ip address prefix-list 10.2.2.254-red-2-ipv4-localpref-prefixes
+  set local-preference 2
+  on-match next
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+route-map 10.2.2.254-red-out permit 3
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.254-red-out permit 4
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.255 remote-as 200
+  neighbor 10.2.2.255 port 179
+  neighbor 10.2.2.255 timers 1 1
+  neighbor 10.2.2.255 password password
+  neighbor 10.2.2.255 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.11/24
+  exit-address-family
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+    network 172.16.1.11/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector.golden
@@ -1,0 +1,98 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.255-blue-in deny 20
+
+ip prefix-list 10.2.2.255-blue-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-blue-out permit 1
+  match ip address prefix-list 10.2.2.255-blue-2-ipv4-localpref-prefixes
+  set local-preference 2
+  on-match next
+ip prefix-list 10.2.2.255-blue-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+route-map 10.2.2.255-blue-out permit 2
+  match ip address prefix-list 10.2.2.255-blue-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.255-blue-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.255-blue-out permit 3
+  match ip address prefix-list 10.2.2.255-blue-pl-ipv4
+route-map 10.2.2.255-blue-out permit 4
+  match ipv6 address prefix-list 10.2.2.255-blue-pl-ipv4
+
+ip prefix-list 10.2.2.255-blue-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.255-blue-pl-ipv4 deny any
+route-map 10.2.2.254-red-in deny 20
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+route-map 10.2.2.254-red-out permit 2
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 3
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf blue
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.255 remote-as 200
+  neighbor 10.2.2.255 port 179
+  neighbor 10.2.2.255 timers 1 1
+  neighbor 10.2.2.255 password password
+  neighbor 10.2.2.255 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-blue-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-blue-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.255 activate
+    neighbor 10.2.2.255 route-map 10.2.2.255-blue-in in
+    neighbor 10.2.2.255 route-map 10.2.2.255-blue-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.11/24
+  exit-address-family
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
@@ -1,0 +1,54 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+route-map 10.2.2.254-red-out permit 2
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 3
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+    network 172.16.1.11/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
@@ -1,0 +1,71 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+route-map 10.4.4.255-red-in deny 20
+
+route-map 10.4.4.255-red-out permit 1
+  match ip address prefix-list 10.4.4.255-red-pl-ipv4
+route-map 10.4.4.255-red-out permit 2
+  match ipv6 address prefix-list 10.4.4.255-red-pl-ipv4
+
+ip prefix-list 10.4.4.255-red-pl-ipv4 deny any
+ipv6 prefix-list 10.4.4.255-red-pl-ipv4 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+router bgp 300 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.3.3.254
+  neighbor 10.4.4.255 remote-as 400
+  neighbor 10.4.4.255 ebgp-multihop
+  neighbor 10.4.4.255 port 179
+  neighbor 10.4.4.255 timers 1 1
+  neighbor 10.4.4.255 password password
+  neighbor 10.4.4.255 update-source 10.3.3.254
+
+  address-family ipv4 unicast
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-red-in in
+    neighbor 10.4.4.255 route-map 10.4.4.255-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.4.4.255 activate
+    neighbor 10.4.4.255 route-map 10.4.4.255-red-in in
+    neighbor 10.4.4.255 route-map 10.4.4.255-red-out out
+  exit-address-family
+

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
@@ -1,0 +1,71 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+route-map 10.2.2.254-red-in deny 20
+
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+router bgp 300 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.3.3.254
+  neighbor 10.2.2.254 remote-as 400
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.3.3.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+

--- a/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
@@ -1,0 +1,39 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-red-in deny 20
+
+route-map 10.2.2.254-red-out permit 1
+  match ip address prefix-list 10.2.2.254-red-pl-ipv4
+route-map 10.2.2.254-red-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+router bgp 100 vrf red
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-red-out out
+  exit-address-family
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,8 @@ type Peer struct {
 	BFDProfile string
 	// Optional ebgp peer is multi-hops away.
 	EBGPMultiHop bool
+	// Optional name of the vrf to establish the session from
+	VRF string
 	// TODO: more BGP session settings
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -416,6 +416,7 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 		Password:      password,
 		BFDProfile:    p.Spec.BFDProfile,
 		EBGPMultiHop:  p.Spec.EBGPMultiHop,
+		VRF:           p.Spec.VRFName,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,7 @@ func TestParse(t *testing.T) {
 							RouterID:     "10.20.30.40",
 							SrcAddress:   "10.20.30.40",
 							EBGPMultiHop: true,
+							VRFName:      "foo",
 						},
 					},
 					{
@@ -228,6 +229,7 @@ func TestParse(t *testing.T) {
 						RouterID:      net.ParseIP("10.20.30.40"),
 						NodeSelectors: []labels.Selector{labels.Everything()},
 						EBGPMultiHop:  true,
+						VRF:           "foo",
 					},
 					{
 						Name:          "peer2",

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -30,6 +30,9 @@ func DiscardFRROnly(c ClusterResources) error {
 		if p.Spec.KeepaliveTime.Duration != 0 {
 			return fmt.Errorf("peer %s has keepalive-time set on native bgp mode", p.Spec.Address)
 		}
+		if p.Spec.VRFName != "" {
+			return fmt.Errorf("peer %s has vrf set on native bgp mode", p.Spec.Address)
+		}
 	}
 	if len(c.BFDProfiles) > 0 {
 		return errors.New("bfd profiles section set")

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -216,7 +216,23 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := c.sessionManager.NewSession(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.SrcAddr, p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.KeepaliveTime, p.cfg.Password, c.myNode, p.cfg.BFDProfile, p.cfg.EBGPMultiHop, p.cfg.Name)
+			s, err := c.sessionManager.NewSession(c.logger,
+				bgp.SessionParameters{
+					PeerAddress:   net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))),
+					SourceAddress: p.cfg.SrcAddr,
+					MyASN:         p.cfg.MyASN,
+					RouterID:      routerID,
+					PeerASN:       p.cfg.ASN,
+					HoldTime:      p.cfg.HoldTime,
+					KeepAliveTime: p.cfg.KeepaliveTime,
+					Password:      p.cfg.Password,
+					CurrentNode:   c.myNode,
+					BFDProfile:    p.cfg.BFDProfile,
+					EBGPMultiHop:  p.cfg.EBGPMultiHop,
+					SessionName:   p.cfg.Name,
+				},
+			)
+
 			if err != nil {
 				level.Error(l).Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -230,6 +230,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 					BFDProfile:    p.cfg.BFDProfile,
 					EBGPMultiHop:  p.cfg.EBGPMultiHop,
 					SessionName:   p.cfg.Name,
+					VRFName:       p.cfg.VRF,
 				},
 			)
 

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"sync"
 	"testing"
-	"time"
 
 	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
@@ -106,20 +105,20 @@ type fakeBGPSessionManager struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGPSessionManager) NewSession(_ log.Logger, addr string, _ net.IP, _ uint32, _ net.IP, _ uint32, _ time.Duration, _ time.Duration, _, _, _ string, _ bool, name string) (bgp.Session, error) {
+func (f *fakeBGPSessionManager) NewSession(_ log.Logger, args bgp.SessionParameters) (bgp.Session, error) {
 	f.Lock()
 	defer f.Unlock()
 
-	if _, ok := f.gotAds[addr]; ok {
-		f.t.Errorf("Tried to create already existing BGP session to %q", addr)
+	if _, ok := f.gotAds[args.PeerAddress]; ok {
+		f.t.Errorf("Tried to create already existing BGP session to %q", args.PeerAddress)
 		return nil, errors.New("invariant violation")
 	}
 	// Nil because we haven't programmed any routes for it yet, but
 	// the key now exists in the map.
-	f.gotAds[addr] = nil
+	f.gotAds[args.PeerAddress] = nil
 	return &fakeSession{
 		f:    f,
-		addr: addr,
+		addr: args.PeerAddress,
 	}, nil
 }
 

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -947,6 +947,19 @@ bool
 <p>To set if the BGPPeer is multi-hops away. Needed for FRR mode only.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>vrf</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>To set if we want to peer with the BGPPeer using an interface belonging to
+a host vrf</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>


### PR DESCRIPTION
Here we add a VRF optional field to the BGPPeer to indicate the session we want to establish with the given peer must happen from an interface belonging to a linux VRF