### PR TITLE
Hide the bgp password from logs

### DIFF
--- a/frr-reloader/frr-reloader.sh
+++ b/frr-reloader/frr-reloader.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -o pipefail
+
 cleanup() {
   echo "Caught an exit signal.."
   clean_files
@@ -14,14 +17,14 @@ reload_frr() {
   kill_sleep
 
   echo "Checking the configuration file syntax"
-  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" ; then
+  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" 2>&1 | sed 's/password.*/password <retracted>/g'; then
     echo "Syntax error spotted: aborting.. $SECONDS seconds"
     echo -n "$(date +%s) failure"  > "$STATUSFILE"
     return
   fi
 
   echo "Applying the configuration file"
-  if ! python3 /usr/lib/frr/frr-reload.py --reload --overwrite --stdout "$FILE_TO_RELOAD" ; then
+  if ! python3 /usr/lib/frr/frr-reload.py --reload --overwrite --stdout "$FILE_TO_RELOAD" 2>&1 | sed 's/password.*/password <retracted>/g'; then
     echo "Failed to fully apply configuration file $SECONDS seconds"
     echo -n "$(date +%s) failure"  > "$STATUSFILE"
     return

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
@@ -126,7 +125,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	level.Debug(r.Logger).Log("controller", "ConfigReconciler", "rendered config", spew.Sdump(cfg))
+	level.Debug(r.Logger).Log("controller", "ConfigReconciler", "rendered config", dumpConfig(cfg))
 
 	res := r.Handler(r.Logger, cfg)
 	switch res {

--- a/internal/k8s/controllers/dump.go
+++ b/internal/k8s/controllers/dump.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/davecgh/go-spew/spew"
+	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/metallb/internal/config"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -13,7 +14,7 @@ import (
 func dumpClusterResources(c *config.ClusterResources) string {
 	withNoSecret := config.ClusterResources{
 		Pools:              c.Pools,
-		Peers:              c.Peers,
+		Peers:              sanitizeBGPPeer(c.Peers...),
 		BFDProfiles:        c.BFDProfiles,
 		L2Advs:             c.L2Advs,
 		BGPAdvs:            c.BGPAdvs,
@@ -29,10 +30,31 @@ func dumpClusterResources(c *config.ClusterResources) string {
 	return dumpResource(withNoSecret)
 }
 
+func dumpConfig(cfg *config.Config) string {
+	toDump := *cfg
+	toDump.Peers = make([]*config.Peer, 0)
+	for _, p := range cfg.Peers {
+		p1 := *p
+		p1.Password = "<retracted>"
+		toDump.Peers = append(toDump.Peers, &p1)
+	}
+	return spew.Sdump(toDump)
+}
+
 func dumpResource(i interface{}) string {
 	toDump, err := json.Marshal(i)
 	if err != nil {
 		return spew.Sdump(i)
 	}
 	return string(toDump)
+}
+
+func sanitizeBGPPeer(peers ...metallbv1beta2.BGPPeer) []metallbv1beta2.BGPPeer {
+	res := make([]metallbv1beta2.BGPPeer, 0)
+	for _, p := range peers {
+		toAdd := p.DeepCopy()
+		toAdd.Spec.Password = "<retracted>"
+		res = append(res, *toAdd)
+	}
+	return res
 }


### PR DESCRIPTION
We expose the password in the logs in two places:
- when the speaker container dumps the configuration, because an error happened or because the log level is raised to debug
- in the reloader container, every time an frr configuration gets generated

Here, in both places we replace the password before logging.