### PR TITLE
L2: avoid having one failure on responder disable l2

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -109,7 +109,7 @@ func (a *Announce) updateInterfaces() {
 			resp, err := newARPResponder(a.logger, &ifi, a.shouldAnnounce)
 			if err != nil {
 				level.Error(l).Log("op", "createARPResponder", "error", err, "msg", "failed to create ARP responder")
-				return
+				continue
 			}
 			a.arps[ifi.Index] = resp
 			level.Info(l).Log("event", "createARPResponder", "msg", "created ARP responder for interface")
@@ -118,7 +118,7 @@ func (a *Announce) updateInterfaces() {
 			resp, err := newNDPResponder(a.logger, &ifi, a.shouldAnnounce)
 			if err != nil {
 				level.Error(l).Log("op", "createNDPResponder", "error", err, "msg", "failed to create NDP responder")
-				return
+				continue
 			}
 			a.ndps[ifi.Index] = resp
 			level.Info(l).Log("event", "createNDPResponder", "msg", "created NDP responder for interface")

--- a/internal/layer2/ip_advertisement.go
+++ b/internal/layer2/ip_advertisement.go
@@ -43,6 +43,9 @@ func (i1 *IPAdvertisement) Equal(i2 *IPAdvertisement) bool {
 }
 
 func (i *IPAdvertisement) MatchInterfaces(intfs ...string) bool {
+	if i.allInterfaces {
+		return true
+	}
 	for _, intf := range intfs {
 		if i.matchInterface(intf) {
 			return true


### PR DESCRIPTION
If a responder fails to be set (i.e. ndp on a ipv4 only node), then the list of interfaces is not being built.
That results in l2 mode entirely not working. Here we make the mechanism a bit more robust by continuing on errors.

Fixes https://github.com/metallb/metallb/issues/1727