### PR TITLE
Only add neighbors in their own family

### DIFF
--- a/internal/bgp/frr/templates/neighboripfamily.tmpl
+++ b/internal/bgp/frr/templates/neighboripfamily.tmpl
@@ -1,13 +1,17 @@
 {{- define "neighborenableipfamily"}}
 {{/* no bgp default ipv4-unicast prevents peering if no address families are defined. We declare an ipv4 one for the peer to make the pairing happen */}}
+{{if eq (frrIPFamily .IPFamily) "ip"}}
   address-family ipv4 unicast
     neighbor {{.Addr}} activate
     neighbor {{.Addr}} route-map {{.ID}}-in in
     neighbor {{.Addr}} route-map {{.ID}}-out out
   exit-address-family
+{{- end -}}
+{{if eq (frrIPFamily .IPFamily) "ipv6"}}
   address-family ipv6 unicast
     neighbor {{.Addr}} activate
     neighbor {{.Addr}} route-map {{.ID}}-in in
     neighbor {{.Addr}} route-map {{.ID}}-out out
   exit-address-family
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
This change alone will make ipv4 over ipv6 and
ipv6 over ipv4 advertisements impossible.
The behaviour as follows:
- IPv4 neighbors will only be added to the ipv4 address family
- IPv6 neighbors will only be added to the ipv6 address family

Possible improvements:
- Extend advertisements to allow neighbors to be added to the other address family

 Fixed  #1736 