### PR TITLE
Disable manual ip address pool selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,7 @@ jobs:
           EOF
           rm -rf e2etest # we want to make sure we are not running current e2e by mistake
           cd metallb-v0.12.1
+          sed -i -e 's/quay.io\/frrouting\/frr:stable_7.5/frrouting\/frr:v7.5.1/g' e2etest/pkg/frr/container/container.go # replace with frr image from dockerhub since it has official image.
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
           sudo -E env "PATH=$PATH" inv e2etest --skip-docker --use-operator --focus "$FOCUS" -e /tmp/kind_logs
 

--- a/controller/service.go
+++ b/controller/service.go
@@ -94,7 +94,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	if len(lbIPs) != 0 {
 		// This assign is idempotent if the config is consistent,
 		// otherwise it'll fail and tell us why.
-		if err = c.ips.Assign(key, lbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+		if err = c.ips.Assign(key, svc, lbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
 			level.Info(l).Log("event", "clearAssignment", "error", err, "msg", "current IP not allowed by config, clearing")
 			c.clearServiceState(key, svc)
 			lbIPs = []net.IP{}
@@ -198,7 +198,7 @@ func (c *controller) allocateIPs(key string, svc *v1.Service) ([]net.IP, error) 
 		if serviceIPFamily != desiredLbIPFamily {
 			return nil, fmt.Errorf("requested loadBalancer IP(s) %q does not match the ipFamily of the service", desiredLbIPs)
 		}
-		if err := c.ips.Assign(key, desiredLbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
+		if err := c.ips.Assign(key, svc, desiredLbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
 			return nil, err
 		}
 		return desiredLbIPs, nil
@@ -206,7 +206,7 @@ func (c *controller) allocateIPs(key string, svc *v1.Service) ([]net.IP, error) 
 	// Otherwise, did the user ask for a specific pool?
 	desiredPool := svc.Annotations[annotationAddressPool]
 	if desiredPool != "" {
-		ips, err := c.ips.AllocateFromPool(key, serviceIPFamily, desiredPool, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
+		ips, err := c.ips.AllocateFromPool(key, svc, serviceIPFamily, desiredPool, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -72,7 +72,8 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 	// only question we have to answer is: can we fit all allocated
 	// IPs into address pools under the new configuration?
 	for svc, alloc := range a.allocated {
-		if poolFor(pools.ByName, alloc.ips) == "" {
+		pool := poolFor(pools.ByName, alloc.ips)
+		if pool == nil {
 			return fmt.Errorf("new config not compatible with assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
 		}
 	}
@@ -90,9 +91,12 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 	// Need to rearrange existing pool mappings and counts
 	for svc, alloc := range a.allocated {
 		pool := poolFor(a.pools.ByName, alloc.ips)
-		if pool != alloc.pool {
+		if pool == nil {
+			return fmt.Errorf("can't retrieve new pool for assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
+		}
+		if pool.Name != alloc.pool {
 			a.Unassign(svc)
-			alloc.pool = pool
+			alloc.pool = pool.Name
 			// Use the internal assign, we know for a fact the IP is
 			// still usable.
 			a.assign(svc, alloc)
@@ -136,20 +140,23 @@ func (a *Allocator) assign(svc string, alloc *alloc) {
 
 // Assign assigns the requested ip to svc, if the assignment is
 // permissible by sharingKey and backendKey.
-func (a *Allocator) Assign(svc string, ips []net.IP, ports []Port, sharingKey, backendKey string) error {
+func (a *Allocator) Assign(svcKey string, svc *v1.Service, ips []net.IP, ports []Port, sharingKey, backendKey string) error {
 	pool := poolFor(a.pools.ByName, ips)
-	if pool == "" {
+	if pool == nil {
 		return fmt.Errorf("%q is not allowed in config", ips)
 	}
 	sk := &key{
 		sharing: sharingKey,
 		backend: backendKey,
 	}
+	if !a.isPoolCompatibleWithService(pool, svc) {
+		return fmt.Errorf("pool %s not compatible for ip assignment", pool.Name)
+	}
 	// Check the dual-stack constraints:
 	// - Two addresses
 	// - Different families, ipv4 and ipv6
 	if len(ips) > 2 {
-		return fmt.Errorf("More than two addresses %q", ips)
+		return fmt.Errorf("more than two addresses %q", ips)
 	}
 	if len(ips) == 2 && (ipfamily.ForAddress(ips[0]) == ipfamily.ForAddress(ips[1])) {
 		return fmt.Errorf("%q %q has the same family", ips[0], ips[1])
@@ -159,7 +166,7 @@ func (a *Allocator) Assign(svc string, ips []net.IP, ports []Port, sharingKey, b
 		// Does the IP already have allocs? If so, needs to be the same
 		// sharing key, and have non-overlapping ports. If not, the
 		// proposed IP needs to be allowed by configuration.
-		if err := a.checkSharing(svc, ip.String(), ports, sk); err != nil {
+		if err := a.checkSharing(svcKey, ip.String(), ports, sk); err != nil {
 			return err
 		}
 	}
@@ -170,7 +177,7 @@ func (a *Allocator) Assign(svc string, ips []net.IP, ports []Port, sharingKey, b
 	// an allocation" block above). Unassigning is idempotent, so it's
 	// unconditionally safe to do.
 	alloc := &alloc{
-		pool:  pool,
+		pool:  pool.Name,
 		ips:   ips,
 		ports: make([]Port, len(ports)),
 		key:   *sk,
@@ -178,7 +185,7 @@ func (a *Allocator) Assign(svc string, ips []net.IP, ports []Port, sharingKey, b
 	for i, port := range ports {
 		alloc.ports[i] = port
 	}
-	a.assign(svc, alloc)
+	a.assign(svcKey, alloc)
 	return nil
 }
 
@@ -215,8 +222,8 @@ func (a *Allocator) Unassign(svc string) bool {
 }
 
 // AllocateFromPool assigns an available IP from pool to service.
-func (a *Allocator) AllocateFromPool(svc string, serviceIPFamily ipfamily.Family, poolName string, ports []Port, sharingKey, backendKey string) ([]net.IP, error) {
-	if alloc := a.allocated[svc]; alloc != nil {
+func (a *Allocator) AllocateFromPool(svcKey string, svc *v1.Service, serviceIPFamily ipfamily.Family, poolName string, ports []Port, sharingKey, backendKey string) ([]net.IP, error) {
+	if alloc := a.allocated[svcKey]; alloc != nil {
 		// Handle the case where the svc has already been assigned an IP but from the wrong family.
 		// This "should-not-happen" since the "serviceIPFamily" is an immutable field in services.
 		allocIPsFamily, err := ipfamily.ForAddressesIPs(alloc.ips)
@@ -226,7 +233,7 @@ func (a *Allocator) AllocateFromPool(svc string, serviceIPFamily ipfamily.Family
 		if allocIPsFamily != serviceIPFamily {
 			return nil, fmt.Errorf("IP for wrong family assigned alloc %s service family %s", allocIPsFamily, serviceIPFamily)
 		}
-		if err := a.Assign(svc, alloc.ips, ports, sharingKey, backendKey); err != nil {
+		if err := a.Assign(svcKey, svc, alloc.ips, ports, sharingKey, backendKey); err != nil {
 			return nil, err
 		}
 		return alloc.ips, nil
@@ -253,7 +260,7 @@ func (a *Allocator) AllocateFromPool(svc string, serviceIPFamily ipfamily.Family
 			// Not the right ip-family
 			continue
 		}
-		ip := a.getIPFromCIDR(cidr, pool.AvoidBuggyIPs, svc, ports, sharingKey, backendKey)
+		ip := a.getIPFromCIDR(cidr, pool.AvoidBuggyIPs, svcKey, ports, sharingKey, backendKey)
 		if ip != nil {
 			ips = append(ips, ip)
 			delete(ipfamilySel, cidrIPFamily)
@@ -264,7 +271,7 @@ func (a *Allocator) AllocateFromPool(svc string, serviceIPFamily ipfamily.Family
 		// Woops, run out of IPs :( Fail.
 		return nil, fmt.Errorf("no available IPs in pool %q for %s IPFamily", poolName, serviceIPFamily)
 	}
-	err := a.Assign(svc, ips, ports, sharingKey, backendKey)
+	err := a.Assign(svcKey, svc, ips, ports, sharingKey, backendKey)
 	if err != nil {
 		return nil, err
 	}
@@ -274,14 +281,14 @@ func (a *Allocator) AllocateFromPool(svc string, serviceIPFamily ipfamily.Family
 // Allocate assigns any available and assignable IP to service.
 func (a *Allocator) Allocate(svcKey string, svc *v1.Service, serviceIPFamily ipfamily.Family, ports []Port, sharingKey, backendKey string) ([]net.IP, error) {
 	if alloc := a.allocated[svcKey]; alloc != nil {
-		if err := a.Assign(svcKey, alloc.ips, ports, sharingKey, backendKey); err != nil {
+		if err := a.Assign(svcKey, svc, alloc.ips, ports, sharingKey, backendKey); err != nil {
 			return nil, err
 		}
 		return alloc.ips, nil
 	}
 	pinnedPools := a.sortedPoolsForService(svc)
 	for _, pool := range pinnedPools {
-		if ips, err := a.AllocateFromPool(svcKey, serviceIPFamily, pool.Name, ports, sharingKey, backendKey); err == nil {
+		if ips, err := a.AllocateFromPool(svcKey, svc, serviceIPFamily, pool.Name, ports, sharingKey, backendKey); err == nil {
 			return ips, nil
 		}
 	}
@@ -289,7 +296,7 @@ func (a *Allocator) Allocate(svcKey string, svc *v1.Service, serviceIPFamily ipf
 		if !pool.AutoAssign || pool.ServiceAllocations != nil {
 			continue
 		}
-		if ips, err := a.AllocateFromPool(svcKey, serviceIPFamily, pool.Name, ports, sharingKey, backendKey); err == nil {
+		if ips, err := a.AllocateFromPool(svcKey, svc, serviceIPFamily, pool.Name, ports, sharingKey, backendKey); err == nil {
 			return ips, nil
 		}
 	}
@@ -340,11 +347,31 @@ func (a *Allocator) sortedPoolsForService(svc *v1.Service) []*config.Pool {
 	return append(priorityPools, noPriorityPools...)
 }
 
+func (a *Allocator) isPoolCompatibleWithService(p *config.Pool, svc *v1.Service) bool {
+	if p.ServiceAllocations != nil && p.ServiceAllocations.Namespaces.Len() > 0 &&
+		!p.ServiceAllocations.Namespaces.Has(svc.Namespace) {
+		return false
+	}
+	if p.ServiceAllocations != nil && len(p.ServiceAllocations.ServiceSelectors) > 0 {
+		svcLabels := labels.Set(svc.Labels)
+		for _, svcSelector := range p.ServiceAllocations.ServiceSelectors {
+			if svcSelector.Matches(svcLabels) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
 // Pool returns the pool from which service's IP was allocated. If
 // service has no IP allocated, "" is returned.
 func (a *Allocator) Pool(svc string) string {
 	if alloc := a.allocated[svc]; alloc != nil {
-		return poolFor(a.pools.ByName, alloc.ips)
+		pool := poolFor(a.pools.ByName, alloc.ips)
+		if pool != nil {
+			return pool.Name
+		}
 	}
 	return ""
 }
@@ -404,8 +431,8 @@ func poolCount(p *config.Pool) int64 {
 }
 
 // poolFor returns the pool that owns the requested IPs, or "" if none.
-func poolFor(pools map[string]*config.Pool, ips []net.IP) string {
-	for pname, p := range pools {
+func poolFor(pools map[string]*config.Pool, ips []net.IP) *config.Pool {
+	for _, p := range pools {
 		cnt := 0
 		for _, ip := range ips {
 			if p.AvoidBuggyIPs && ipConfusesBuggyFirmwares(ip) {
@@ -419,10 +446,10 @@ func poolFor(pools map[string]*config.Pool, ips []net.IP) string {
 			}
 		}
 		if cnt == len(ips) {
-			return pname
+			return p
 		}
 	}
-	return ""
+	return nil
 }
 
 // ipConfusesBuggyFirmwares returns true if ip is an IPv4 address ending in 0 or 255.


### PR DESCRIPTION
In case we want to have the cluster administrator enforce the multi tenancy configurability of metallb, we need to disable the option for users to pin to a specific pool.
Hence this enhances ip address pool crd to disable manual ip address pool selection when its ip addresses are requested through service metallb.universe.tf/loadBalancerIPs or metallb.universe.tf/address-pool annotation.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>