### PR TITLE
E2E VRF: validate multi hop via vrf

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -323,8 +323,18 @@ jobs:
           sed -i 's/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:dev-amd64/g' bin/metallb-operator.yaml
           sed -i 's/native/frr/g' bin/metallb-operator.yaml
           kubectl apply -f bin/metallb-operator.yaml
-          sleep 30s
 
+      - name: Ensure MetalLB operator is ready
+        run: |
+          COUNT=0
+          while [ "$(kubectl get pods -n metallb-system -l control-plane='controller-manager' -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
+            sleep 5
+            COUNT=$((COUNT+1))
+            if [[ $COUNT -gt 15 ]] ; then
+              exit 1;
+            fi
+            echo "Waiting for operator pod to be ready."
+          done
 
       - name: MetalLB E2E Tests with Operator Deployment
         run: |

--- a/e2etest/README.md
+++ b/e2etest/README.md
@@ -31,7 +31,8 @@ Be sure to cleanup any previously created development clusters using `inv dev-en
 ## BGP tests network topology
 
 In order to test the multiple scenarios required for BGP, three different containers are required.
-The following diagram describes the networks, the pods and the containers involved.
+The following diagram describes the network connectivity using the regular kind network, the pods
+and the containers involved.
 
 ```
   ┌────────────────────────────────────────────┐
@@ -61,6 +62,37 @@ The following diagram describes the networks, the pods and the containers involv
                        │  fc00:f853:ccd:e798::/64                         │
                        └──────────────────────────────────────────────────┘
 ```
+
+The same layout is replicated to validate external routers reacheable via a VRF.
+
+So, on top of what's described above, there is another set of 4 containers meant
+to be reached using an interface hosted inside a vrf created on the node:
+
+```none
+                                                                                           ┌─────────────────────┐
+                                                                                           │                     │
+                                                                                           │                     │
+                                                                                        ┌──┤  ibgp-vrf-multi-hop │
+                                           ┌──────────────────────┐                     │  │                     │
+                                           │                      │                     │  │                     │
+                                           │                      │                     │  └─────────────────────┘
+┌───────────────────────┐               ┌──┤  ebgp-vrf-single-hop ├─────────────────────┤
+│                       │               │  │                      │                     │  ┌─────────────────────┐
+│                       │               │  │                      │   vrf-multihop-net  │  │                     │
+│   ┌─────────┐         │               │  └──────────────────────┘                     │  │                     │
+│   │         │  ┌──────┤               │                                               └──┤  ebgp-vrf-multi-hop │
+│   │ Speaker │  │      │               │                                                  │                     │
+│   │         │  │   ───┼───────────────┤                                                  │                     │
+│   └─────────┘  │   VRF│  vrf-net      │  ┌──────────────────────┐                        └─────────────────────┘
+│                │      │               │  │                      │
+│                └──────┤               │  │                      │
+│                       │               └──┤  ibgp-vrf-single-hop │
+│                  Node │                  │                      │
+│                       │                  │                      │
+└───────────────────────┘                  └──────────────────────┘
+
+```
+
 
 The above diagram is implemented in `infra_setup.go`.
 

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -113,7 +113,8 @@ func validateServiceNoWait(cs clientset.Interface, svc *corev1.Service, nodes []
 		}
 
 		// The BGP routes will not match the nodes if static routes were added.
-		if !(c.Network == multiHopNetwork) {
+		if c.Network != defaultNextHopSettings.multiHopNetwork &&
+			c.Network != vrfNextHopSettings.multiHopNetwork {
 			advertised := routes.ForIP(ingressIP, c)
 			err = routes.MatchNodes(nodes, advertised, serviceIPFamily, c.RouterConfig.VRF)
 			if err != nil {

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -204,9 +204,12 @@ var _ = ginkgo.AfterSuite(func() {
 	cs, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
 
-	toTearDown := append(bgptests.FRRContainers, bgptests.VRFFRRContainers...)
-	err = bgptests.InfraTearDown(cs, toTearDown)
+	err = bgptests.InfraTearDown(cs)
 	framework.ExpectNoError(err)
+	if !bgpNativeMode {
+		err = bgptests.InfraTearDownVRF(cs)
+		framework.ExpectNoError(err)
+	}
 	err = updater.Clean()
 	framework.ExpectNoError(err)
 

--- a/e2etest/pkg/netdev/netdev.go
+++ b/e2etest/pkg/netdev/netdev.go
@@ -58,7 +58,7 @@ func Exists(exec executor.Executor, intf string) error {
 	return &NotFoundErr{interfaceName: intf}
 }
 
-func CreateVRF(exec executor.Executor, vrfName string) error {
+func CreateVRF(exec executor.Executor, vrfName, routingTable string) error {
 	err := Exists(exec, vrfName)
 	// The interface is already there, not doing anything
 	if err == nil {
@@ -69,7 +69,7 @@ func CreateVRF(exec executor.Executor, vrfName string) error {
 		return err
 	}
 
-	out, err := exec.Exec("ip", "link", "add", vrfName, "type", "vrf", "table", "2")
+	out, err := exec.Exec("ip", "link", "add", vrfName, "type", "vrf", "table", routingTable)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create vrf %s : %s", vrfName, out)
 	}

--- a/e2etest/pkg/routes/patch.go
+++ b/e2etest/pkg/routes/patch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Add route to target via for the given Executor.
-func Add(exec executor.Executor, target, via string) error {
+func Add(exec executor.Executor, target, via, routingTable string) error {
 	_, dst, err := net.ParseCIDR(target)
 	if err != nil {
 		return err
@@ -19,10 +19,14 @@ func Add(exec executor.Executor, target, via string) error {
 	gw := net.ParseIP(via)
 
 	cmd := "ip"
-	args := []string{"route", "add", dst.String(), "via", gw.String()}
+	args := []string{"route", "add"}
 	if dst.IP.To4() == nil {
-		args = []string{"-6", "route", "add", dst.String(), "via", gw.String()}
+		args = []string{"-6", "route", "add"}
 	}
+	if routingTable != "" {
+		args = append(args, "table", routingTable)
+	}
+	args = append(args, dst.String(), "via", gw.String())
 	out, err := exec.Exec(cmd, args...)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to add route %s %s %s", cmd, args, out)
@@ -32,7 +36,7 @@ func Add(exec executor.Executor, target, via string) error {
 }
 
 // Delete route to target via for the given Executor.
-func Delete(exec executor.Executor, target, via string) error {
+func Delete(exec executor.Executor, target, via, routingTable string) error {
 	_, dst, err := net.ParseCIDR(target)
 	if err != nil {
 		return err
@@ -41,10 +45,14 @@ func Delete(exec executor.Executor, target, via string) error {
 	gw := net.ParseIP(via)
 
 	cmd := "ip"
-	args := []string{"route", "del", dst.String(), "via", gw.String()}
+	args := []string{"route", "del"}
 	if dst.IP.To4() == nil {
-		args = []string{"-6", "route", "del", dst.String(), "via", gw.String()}
+		args = []string{"-6", "route", "del"}
 	}
+	if routingTable != "" {
+		args = append(args, "table", routingTable)
+	}
+	args = append(args, dst.String(), "via", gw.String())
 	out, err := exec.Exec(cmd, args...)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to delete route %s", out)

--- a/tasks.py
+++ b/tasks.py
@@ -544,6 +544,10 @@ def dev_env_cleanup(ctx, name="kind", frr_volume_dir=""):
         '    docker rm -f $frr ; '
         'done', hide=True)
 
+    run('for frr in $(docker ps -a -f name=vrf --format {{.Names}}) ; do '
+        '    docker rm -f $frr ; '
+        'done', hide=True)
+
     # cleanup bgp configs
     dev_env_dir = os.getcwd() + "/dev-env/bgp"
     if frr_volume_dir == "":


### PR DESCRIPTION
Extending the set of containers with another two reacheabile via multihop through the interface in the vrf.

The multihop setup function is made generic so that can be applied to the containers in vrf too.