### PR TITLE
Assignement tests: make the generic pool broader

### DIFF
--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-3"},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/32",
+						"192.168.20.0/24",
 					},
 				},
 			}
@@ -212,7 +212,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-label-pool-3"},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/32",
+						"192.168.20.0/24",
 					},
 				},
 			}
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-svc-label-pool-3"},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/32",
+						"192.168.20.0/24",
 					},
 				},
 			}
@@ -341,7 +341,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-svc-label-pool-3"},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/32",
+						"192.168.20.0/24",
 					},
 				},
 			}


### PR DESCRIPTION
If there is a service of type loadbalancer in the cluster we are testing against, it will steal the single ip we expect to be assigned to our services. For this reason, we broaden the number of ips available for the default svc in order to have free ips available for our test svc.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>
