### PR TITLE
Change FRR image to the quay.io repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,7 +261,7 @@ jobs:
           EOF
           rm -rf e2etest # we want to make sure we are not running current e2e by mistake
           cd metallb-v0.12.1
-          sed -i -e 's/quay.io\/frrouting\/frr:stable_7.5/frrouting\/frr:v7.5.1/g' e2etest/pkg/frr/container/container.go # replace with frr image from dockerhub since it has official image.
+          sed -i -e 's/quay.io\/frrouting\/frr:stable_7.5/quay.io\/frrouting\/frr:7.5.1/g' e2etest/pkg/frr/container/container.go # replace with frr image from dockerhub since it has official image.
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
           sudo -E env "PATH=$PATH" inv e2etest --skip-docker --use-operator --focus "$FOCUS" -e /tmp/kind_logs
 

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -110,8 +110,8 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.enabled | bool | `true` |  |
 | speaker.frr.enabled | bool | `false` |  |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
-| speaker.frr.image.repository | string | `"frrouting/frr"` |  |
-| speaker.frr.image.tag | string | `"v7.5.1"` |  |
+| speaker.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |
+| speaker.frr.image.tag | string | `"7.5.1"` |  |
 | speaker.frr.metricsPort | int | `7473` |  |
 | speaker.frr.resources | object | `{}` |  |
 | speaker.frrMetrics.resources | object | `{}` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -316,8 +316,8 @@ speaker:
   frr:
     enabled: false
     image:
-      repository: frrouting/frr
-      tag: v7.5.1
+      repository: quay.io/frrouting/frr
+      tag: 7.5.1
       pullPolicy:
     metricsPort: 7473
     resources: {}

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -29,7 +29,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:7.5.1
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -55,7 +55,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:7.5.1
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -91,7 +91,7 @@ spec:
             failureThreshold: 30
             periodSeconds: 5
         - name: reloader
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:7.5.1
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -101,7 +101,7 @@ spec:
             - name: reloader
               mountPath: /etc/frr_reloader
         - name: frr-metrics
-          image: frrouting/frr:v7.5.1
+          image: quay.io/frrouting/frr:7.5.1
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2105,7 +2105,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -2133,7 +2133,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: reloader
         volumeMounts:
         - mountPath: /var/run/frr
@@ -2146,7 +2146,7 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -2232,7 +2232,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1928,7 +1928,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -1956,7 +1956,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: reloader
         volumeMounts:
         - mountPath: /var/run/frr
@@ -1969,7 +1969,7 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -2055,7 +2055,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: frrouting/frr:v7.5.1
+        image: quay.io/frrouting/frr:7.5.1
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -27,7 +27,7 @@ const (
 	// BGP configuration directory.
 	frrConfigDir = "config/frr"
 	// FRR routing image.
-	frrImage = "frrouting/frr:v7.5.1"
+	frrImage = "quay.io/frrouting/frr:7.5.1"
 	// Host network name.
 	hostNetwork = "host"
 	// FRR container mount destination path.

--- a/internal/bgp/frr/docker_test.go
+++ b/internal/bgp/frr/docker_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 const (
-	frrImageTag = "v7.5.1"
+	frrImageTag = "7.5.1"
 )
 
 func TestMain(m *testing.M) {
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	containerHandle, err = pool.RunWithOptions(
 		&dockertest.RunOptions{
 			Name:       "frrtest",
-			Repository: "frrouting/frr",
+			Repository: "quay.io/frrouting/frr",
 			Tag:        frrImageTag,
 			Mounts:     []string{fmt.Sprintf("%s:/etc/tempfrr", frrDir)},
 		},

--- a/tasks.py
+++ b/tasks.py
@@ -483,7 +483,7 @@ def bgp_dev_env(ip_family, frr_volume_dir):
         '    docker rm -f $frr ; '
         'done', echo=True)
     run("docker run -d --privileged --network kind --rm --ulimit core=-1 --name frr --volume %s:/etc/frr "
-            "frrouting/frr:v7.5.1" % frr_volume_dir, echo=True)
+            "quay.io/frrouting/frr:7.5.1" % frr_volume_dir, echo=True)
 
     if ip_family == "ipv4":
         peer_address = run('docker inspect -f "{{ '


### PR DESCRIPTION
As the frrouting org is moving the official frr images to the quay.io registry, this PR changes the FRR image to point to quay.

Signed-off-by: liornoy <lnoy@redhat.com>