### PR TITLE
E2E: Reduce default ip pool scope to namespace

### DIFF
--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -148,16 +148,17 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10, Namespaces: []string{f.Namespace.Name}},
 				},
 			}
-			defaultPool := metallbv1beta1.IPAddressPool{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-3"},
+			namespacePoolNoPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ns-%s-ip-pool", f.Namespace.Name)},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/24",
+						"192.168.20.0/32",
 					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Namespaces: []string{f.Namespace.Name}},
 				},
 			}
 			resources := internalconfig.ClusterResources{
-				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespacePoolWithHigherPriority, defaultPool},
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespacePoolWithHigherPriority, namespacePoolNoPriority},
 			}
 
 			err := ConfigUpdater.Update(resources)
@@ -184,7 +185,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				&svc2.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
-			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolNoPriority}, e2eservice.GetIngressPoint(
 				&svc3.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 		})
@@ -208,17 +209,18 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 10, NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: f.Namespace.Labels}}},
 				},
 			}
-			defaultPool := metallbv1beta1.IPAddressPool{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-label-pool-3"},
+			namespacePoolNoPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ns-%s-ip-pool", f.Namespace.Name)},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/24",
+						"192.168.20.0/32",
 					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Namespaces: []string{f.Namespace.Name}},
 				},
 			}
 
 			resources := internalconfig.ClusterResources{
-				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespaceLabelPoolWithHigherPriority, defaultPool},
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, namespaceLabelPoolWithHigherPriority, namespacePoolNoPriority},
 			}
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
@@ -244,7 +246,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				&svc2.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
-			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolNoPriority}, e2eservice.GetIngressPoint(
 				&svc3.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 		})
@@ -270,17 +272,18 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 						ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"test": "e2e"}}}},
 				},
 			}
-			defaultPool := metallbv1beta1.IPAddressPool{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-svc-label-pool-3"},
+			namespacePoolNoPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ns-%s-ip-pool", f.Namespace.Name)},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/24",
+						"192.168.20.0/32",
 					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Namespaces: []string{f.Namespace.Name}},
 				},
 			}
 
 			resources := internalconfig.ClusterResources{
-				Pools: []metallbv1beta1.IPAddressPool{svcLabelPoolWithLowerPriority, svcLabelPoolWithHigherPriority, defaultPool},
+				Pools: []metallbv1beta1.IPAddressPool{svcLabelPoolWithLowerPriority, svcLabelPoolWithHigherPriority, namespacePoolNoPriority},
 			}
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
@@ -312,7 +315,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				&svc2.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
-			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolNoPriority}, e2eservice.GetIngressPoint(
 				&svc3.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 		})
@@ -337,17 +340,18 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 						ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"test": "e2e"}}}},
 				},
 			}
-			defaultPool := metallbv1beta1.IPAddressPool{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-svc-label-pool-3"},
+			namespacePoolNoPriority := metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ns-%s-ip-pool", f.Namespace.Name)},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
 					Addresses: []string{
-						"192.168.20.0/24",
+						"192.168.20.0/32",
 					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Namespaces: []string{f.Namespace.Name}},
 				},
 			}
 
 			resources := internalconfig.ClusterResources{
-				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, svcLabelPoolWithHigherPriority, defaultPool},
+				Pools: []metallbv1beta1.IPAddressPool{namespacePoolWithLowerPriority, svcLabelPoolWithHigherPriority, namespacePoolNoPriority},
 			}
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
@@ -379,7 +383,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 				&svc2.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 			ginkgo.By("validate LoadBalancer IP is allocated from default address pool")
-			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{defaultPool}, e2eservice.GetIngressPoint(
+			err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{namespacePoolNoPriority}, e2eservice.GetIngressPoint(
 				&svc3.Status.LoadBalancer.Ingress[0]))
 			framework.ExpectNoError(err)
 		})


### PR DESCRIPTION
This changes default ip pool scope only to test namespace so that it avoids ip assignment to a service outside test namespace which is already waiting for lb ip address then it leads bigger churn of ip pool reconcile attempts while running the tests.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>