### PR TITLE
E2E: don't exit if not able to find multihopRoutes

### DIFF
--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -203,7 +203,7 @@ func InfraTearDownVRF(cs *clientset.Clientset) error {
 
 func infraTearDown(cs *clientset.Clientset, containers []*frrcontainer.FRR, nextHop nextHopSettings, filter func(*frrcontainer.FRR) bool) error {
 	multiHopRoutes, err := container.Networks(nextHop.nextHopContainerName)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "No such object") {
 		return err
 	}
 


### PR DESCRIPTION
When running on host mode, the nexthop container is not running so getting the routes will fail. So, we check if the the routes are not fetched because the container is not there, and in case we continue and not error.

This fixes the error on aftersuite when running the tests in host mode.