### PR TITLE
Enable adding of additional Labels to speaker+controller

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -27,6 +27,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.image.pullPolicy | string | `nil` |  |
 | controller.image.repository | string | `"quay.io/metallb/controller"` |  |
 | controller.image.tag | string | `nil` |  |
+| controller.labels | object | `{}` |  |
 | controller.livenessProbe.enabled | bool | `true` |  |
 | controller.livenessProbe.failureThreshold | int | `3` |  |
 | controller.livenessProbe.initialDelaySeconds | int | `10` |  |
@@ -119,6 +120,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
+| speaker.labels | object | `{}` |  |
 | speaker.livenessProbe.enabled | bool | `true` |  |
 | speaker.livenessProbe.failureThreshold | int | `3` |  |
 | speaker.livenessProbe.initialDelaySeconds | int | `10` |  |

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- range $key, $value := .Values.controller.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.controller.strategy }}
   strategy: {{- toYaml .Values.controller.strategy | nindent 4 }}
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "metallb.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- range $key, $value := .Values.controller.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.controller.runtimeClassName }}
       runtimeClassName: {{ . | quote }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -110,6 +110,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: speaker
+    {{- range $key, $value := .Values.speaker.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.speaker.updateStrategy }}
   updateStrategy: {{- toYaml .Values.speaker.updateStrategy | nindent 4 }}
@@ -135,6 +138,9 @@ spec:
       labels:
         {{- include "metallb.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: speaker
+        {{- range $key, $value := .Values.speaker.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.speaker.runtimeClassName }}
       runtimeClassName: {{ .Values.speaker.runtimeClassName }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -233,6 +233,7 @@ controller:
   runtimeClassName: ""
   affinity: {}
   podAnnotations: {}
+  labels: {}
   livenessProbe:
     enabled: true
     failureThreshold: 3
@@ -294,6 +295,7 @@ speaker:
   ## Selects which runtime class will be used by the pod.
   runtimeClassName: ""
   podAnnotations: {}
+  labels: {}
   livenessProbe:
     enabled: true
     failureThreshold: 3


### PR DESCRIPTION
Hi Metallb Team,
we have several labels that we like to add to our k8s resources. Some are purely for humans, while others are technically relevant (f.e. tracing, NetworkPolicies).
I noticed that your helm chart does not offer this functionality, so I wanted to help by adding a little code that enables users to specify additionaLabels in the values.yaml which will be picked up by the speaker+controller Daemonsets.

If there is anything missing or you disagree with the solution, I'm always open to feedback :) 

Also: Thanks for providing a helm chart in the first place!
