### PR TITLE
change priorityClassName of speaker  to system-node-critical

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -466,6 +466,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.speaker.affinity }}
+      priorityClassName: system-cluster-critical
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Since mertallb is a base service, we should make it as stable as possible,there set priorityClassName:system-node-critical

Set to `priorityClassName=system-node-critical` so that it cannot be evicted easily