### PR TITLE
l2 ndp: ignore link local unicast address of ipv6

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -98,7 +98,7 @@ func (a *Announce) updateInterfaces() {
 			if !ok {
 				continue
 			}
-			if ipaddr.IP.To4() != nil || !ipaddr.IP.IsLinkLocalUnicast() {
+			if ipaddr.IP.To4() != nil || ipaddr.IP.IsLinkLocalUnicast() {
 				continue
 			}
 			keepNDP[ifi.Index] = true


### PR DESCRIPTION
we should ingore link local unicast address of ipv6, Or when a interface no ipv6 global address and have dadfailed link local unicast address of ipv6, speaker stop works.

Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

we hit an issue that speaker stop works, due to ipv6 dadfailed linkLocalUnicast address of ipv6, see https://blog.tankywoo.com/2013/09/27/ipv6-dadfailed-problem.html

I knew https://github.com/metallb/metallb/pull/1726 can be fix this issue, But in fact, we should really ignore the ipv6 local link address, speaker don't need to focus on ipv6 linkLocalUnicast.