### PR TITLE
Add documentation for ip pool service allocation

### DIFF
--- a/configsamples/ipaddresspool_with_selector.yaml
+++ b/configsamples/ipaddresspool_with_selector.yaml
@@ -1,0 +1,20 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ippool-ns-service-alloc-sample
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.20.0/24
+  avoidBuggyIPs: true
+  serviceAllocation:
+    priority: 50
+    namespaces:
+      - namespace-a
+      - namespace-b
+    namespaceSelectors:
+      - matchLabels:
+          foo: bar
+    serviceSelectors:
+      - matchExpressions:
+          - {key: app, operator: In, values: [bar]}

--- a/website/content/configuration/_advanced_ipaddresspool_configuration.md
+++ b/website/content/configuration/_advanced_ipaddresspool_configuration.md
@@ -48,6 +48,57 @@ To specify a single IP address in a pool, use `/32` in the CIDR notation
 (e.g. `42.176.25.64/32`).
 {{% /notice %}}
 
+### Reduce scope of address allocation to specific Namespace and Service
+
+This option can be used to reduce the scope of particular IPAddressPool
+to set of namespaces and services, by adding an optional namespace
+and/or service selectors.
+This is useful for mutitenant context in which there is a need for pinning
+IPAddressPool to specific namespace/service.
+
+```yaml
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ippool-ns-service-alloc-sample
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.20.0/24
+  avoidBuggyIPs: true
+  serviceAllocation:
+    priority: 50
+    namespaces:
+      - namespace-a
+      - namespace-b
+    namespaceSelectors:
+      - matchLabels:
+          foo: bar
+    serviceSelectors:
+      - matchExpressions:
+          - {key: app, operator: In, values: [bar]}
+```
+
+The above IPAddressPool example is pinned to Service(s) which has a label
+matching with expression `key: app, operator: In, values: [bar]` created
+either in `namespace-a` or `namespace-b` or any namespace has a label
+`foo:bar`.
+
+Given a service, if multiple matching IPAddressPool are available MetalLB
+will check for the availability of IPs sorting the matching IPAddressPool
+by priority, starting from the highest to the lowest. A lower number for
+priority field equals a higher priority. If multiple IPAddressPool have
+the same priority, the choice will be random.
+When not specifying a priority / setting priority 0 is considered as lowest
+priority and will be used for assignment only if the pools with priority
+can't be used.
+
+{{% notice note %}}
+When a service explicitly chooses an IPAddressPool via `metallb.universe.tf/address-pool`
+annotation or an IP address via `spec.loadBalancerIP` or `metallb.universe.tf/loadBalancerIPs`
+annotation which doesn't match the service will stay in pending.
+{{% /notice %}}
+
 ### Handling buggy networks
 
 Some old consumer network equipment mistakenly blocks IP addresses


### PR DESCRIPTION
This adds web content for ip pool with service allocation feature and a sample yaml file for such configuration.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>