### PR TITLE
Use errors.Is to check for a specific error

### DIFF
--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -315,18 +315,18 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 
 		},
 			ginkgo.Entry("First to one, second to two", map[int][]int{
-				0: []int{0},
-				1: []int{1, 2},
+				0: {0},
+				1: {1, 2},
 			}),
 			ginkgo.Entry("First to one, second to one, third to three", map[int][]int{
-				0: []int{0},
-				1: []int{1},
-				2: []int{0, 1, 2},
+				0: {0},
+				1: {1},
+				2: {0, 1, 2},
 			}),
 			ginkgo.Entry("First to one, second to one, third to same as first", map[int][]int{
-				0: []int{0},
-				1: []int{1},
-				2: []int{0},
+				0: {0},
+				1: {1},
+				2: {0},
 			}),
 		)
 	})

--- a/internal/bgp/native/messages.go
+++ b/internal/bgp/native/messages.go
@@ -5,6 +5,7 @@ package native
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -220,7 +221,7 @@ func readOptions(r io.Reader, ret *openResult) error {
 			Len  uint8
 		}{}
 		if err := binary.Read(r, binary.BigEndian, &hdr); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
@@ -249,7 +250,7 @@ func readCapabilities(r io.Reader, ret *openResult) error {
 			Len  uint8
 		}{}
 		if err := binary.Read(r, binary.BigEndian, &cap); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -267,7 +267,7 @@ func TestParse(t *testing.T) {
 								Nodes:               map[string]bool{},
 							},
 						},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes:         map[string]bool{},
 							AllInterfaces: true,
 						}},
@@ -284,7 +284,7 @@ func TestParse(t *testing.T) {
 								Nodes:               map[string]bool{},
 							},
 						},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes:         map[string]bool{},
 							AllInterfaces: true,
 						}},
@@ -305,7 +305,7 @@ func TestParse(t *testing.T) {
 							ipnet("40.0.0.240/32"),
 							ipnet("40.0.0.250/32"),
 						},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes:         map[string]bool{},
 							AllInterfaces: true,
 						}},
@@ -314,7 +314,7 @@ func TestParse(t *testing.T) {
 					"pool4": {
 						Name: "pool4",
 						CIDR: []*net.IPNet{ipnet("2001:db8::/64")},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes:         map[string]bool{},
 							AllInterfaces: true,
 						}},
@@ -2545,7 +2545,7 @@ func TestParse(t *testing.T) {
 								Nodes:               map[string]bool{"second": true},
 							},
 						},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes: map[string]bool{
 								"first": true,
 							},
@@ -2793,7 +2793,7 @@ func TestParse(t *testing.T) {
 								},
 							},
 						},
-						L2Advertisements: []*L2Advertisement{&L2Advertisement{
+						L2Advertisements: []*L2Advertisement{{
 							Nodes: map[string]bool{
 								"first":  true,
 								"second": true,
@@ -2959,7 +2959,7 @@ func TestContainsAdvertisement(t *testing.T) {
 		{
 			desc: "Contain",
 			advs: []*L2Advertisement{
-				&L2Advertisement{
+				{
 					Nodes: map[string]bool{
 						"nodeA": true,
 						"nodeB": true,
@@ -2967,7 +2967,7 @@ func TestContainsAdvertisement(t *testing.T) {
 					Interfaces:    []string{"eth0", "eth1"},
 					AllInterfaces: false,
 				},
-				&L2Advertisement{
+				{
 					Nodes: map[string]bool{
 						"nodeB": true,
 					},
@@ -2988,7 +2988,7 @@ func TestContainsAdvertisement(t *testing.T) {
 		{
 			desc: "Not contain: Nodes don't equal",
 			advs: []*L2Advertisement{
-				&L2Advertisement{
+				{
 					Nodes: map[string]bool{
 						"nodeA": true,
 						"nodeB": true,
@@ -3010,7 +3010,7 @@ func TestContainsAdvertisement(t *testing.T) {
 		{
 			desc: "Not contain: Interfaces don't equal",
 			advs: []*L2Advertisement{
-				&L2Advertisement{
+				{
 					Nodes: map[string]bool{
 						"nodeA": true,
 						"nodeB": true,
@@ -3032,7 +3032,7 @@ func TestContainsAdvertisement(t *testing.T) {
 		{
 			desc: "Not contain: AllInterfaces doesn't equal",
 			advs: []*L2Advertisement{
-				&L2Advertisement{
+				{
 					Nodes: map[string]bool{
 						"nodeA": true,
 						"nodeB": true,

--- a/internal/layer2/arp.go
+++ b/internal/layer2/arp.go
@@ -4,6 +4,7 @@ package layer2
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -80,7 +81,7 @@ func (a *arpResponder) processRequest() dropReason {
 			return dropReasonClosed
 		default:
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return dropReasonClosed
 		}
 		return dropReasonError

--- a/internal/layer2/ndp.go
+++ b/internal/layer2/ndp.go
@@ -3,6 +3,7 @@
 package layer2
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -104,7 +105,7 @@ func (n *ndpResponder) processRequest() dropReason {
 			return dropReasonClosed
 		default:
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return dropReasonClosed
 		}
 		return dropReasonError


### PR DESCRIPTION
- If you compare the wrapped error using the == operator, it will only compare the outermost error.Use errors.Is to check for a specific error.
- improve some code format