### PR TITLE
Backport the ML_SECRET_KEY_PATH change to v0.12

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -89,6 +89,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.logLevel | string | `"info"` | Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
 | speaker.memberlist.enabled | bool | `true` |  |
 | speaker.memberlist.mlBindPort | int | `7946` |  |
+| speaker.memberlist.mlSecretKeyPath | string | `"/etc/ml_secret_key"` |  |
 | speaker.nodeSelector | object | `{}` |  |
 | speaker.podAnnotations | object | `{}` |  |
 | speaker.readinessProbe.enabled | bool | `true` |  |

--- a/charts/metallb/policy/speaker.rego
+++ b/charts/metallb/policy/speaker.rego
@@ -19,15 +19,8 @@ deny[msg] {
 # validate METALLB_ML_SECRET_KEY (memberlist)
 deny[msg] {
 	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY"
-	msg = "speaker env does not contain METALLB_ML_SECRET_KEY at env[5]"
-}
-
-deny[msg] {
-	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.name == "RELEASE-NAME-metallb-memberlist"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.key == "secretkey"
-	msg = "speaker env METALLB_ML_SECRET_KEY secretKeyRef does not equal expected value"
+	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY_PATH"
+	msg = "speaker env does not contain METALLB_ML_SECRET_KEY_PATH at env[5]"
 }
 
 # validate node selector includes builtin when custom ones are provided

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -143,8 +143,16 @@ spec:
       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
-      {{- if .Values.speaker.frr.enabled }}
+      {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled }}
       volumes:
+        {{- if .Values.speaker.memberlist.enabled }}
+        - name: memberlist
+          secret:
+            secretName: {{ include "metallb.secretName" . }}
+            defaultMode: 420
+        {{- end }}
+      {{- end }}
+        {{- if .Values.speaker.frr.enabled }}
         - name: frr-sockets
           emptyDir: {}
         - name: frr-startup
@@ -215,11 +223,8 @@ spec:
           value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
         - name: METALLB_ML_BIND_PORT
           value: "{{ .Values.speaker.memberlist.mlBindPort }}"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "metallb.secretName" . }}
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: "{{ .Values.speaker.memberlist.mlSecretKeyPath }}"
         {{- end }}
         {{- if .Values.speaker.frr.enabled }}
         - name: FRR_CONFIG_FILE
@@ -276,12 +281,15 @@ spec:
             - ALL
             add:
             - NET_RAW
-        {{- if .Values.speaker.frr.enabled }}
+        {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled }}
         volumeMounts:
+          {{- if .Values.speaker.memberlist.enabled }}
+          - name: memberlist 
+            mountPath: {{ .Values.speaker.memberlist.mlSecretKeyPath }}
+          {{- end }}
+          {{- if .Values.speaker.frr.enabled }}
           - name: reloader
             mountPath: /etc/frr_reloader
-         {{- end }}
-      {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:
           capabilities:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -294,6 +294,9 @@
                 },
                 "mlBindPort": {
                   "type": "integer"
+                },
+                "mlSecretKeyPath": {
+                  "type": "string"
                 }
               }
             },

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -187,6 +187,7 @@ speaker:
   memberlist:
     enabled: true
     mlBindPort: 7946
+    mlSecretKeyPath: "/etc/ml_secret_key"
   image:
     repository: quay.io/metallb/speaker
     tag:

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -559,11 +559,8 @@ spec:
             #  value: "7946"
             - name: METALLB_ML_LABELS
               value: "app=metallb,component=speaker"
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: memberlist
-                  key: secretkey
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: quay.io/metallb/speaker:main
           name: speaker
           volumeMounts:
@@ -603,6 +600,10 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          volumeMounts:
+          - mountPath: /etc/ml_secret_key
+            name: memberlist
+            readOnly: true
       hostNetwork: true
       shareProcessNamespace: true
       nodeSelector:
@@ -613,6 +614,11 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+      volumes:
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -357,11 +357,8 @@ spec:
         #  value: "7946"
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: memberlist
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: /etc/ml_secret_key
         image: quay.io/metallb/speaker:v0.12.1
         name: speaker
         ports:
@@ -398,6 +395,10 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -407,6 +408,11 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      volumes:
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"go.universe.tf/metallb/internal/bgp"
@@ -68,7 +69,7 @@ func main() {
 		mlBindAddr      = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
 		mlBindPort      = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
 		mlLabels        = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
-		mlSecret        = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
+		mlSecretKeyPath = flag.String("ml-secret-key-path", os.Getenv("METALLB_ML_SECRET_KEY_PATH"), "Path to where the MembeList's secret key is mounted")
 		myNode          = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
 		port            = flag.Int("port", 7472, "HTTP listening port")
 		logLevel        = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
@@ -117,7 +118,18 @@ func main() {
 	}()
 	defer level.Info(logger).Log("op", "shutdown", "msg", "done")
 
-	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, *mlSecret, *namespace, *mlLabels, stopCh)
+	var mlSecret string
+
+	if *mlSecretKeyPath != "" {
+		mlSecretBytes, err := os.ReadFile(filepath.Join(*mlSecretKeyPath, "secretkey"))
+		if err != nil {
+			level.Error(logger).Log("op", "startup", "error", err, "msg", "failed to read memberlist secret key file")
+			os.Exit(1)
+		}
+		mlSecret = string(mlSecretBytes)
+	}
+
+	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, mlSecret, *namespace, *mlLabels, stopCh)
 	if err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR brings[ the commits ](https://github.com/metallb/metallb/pull/1692)from the main branch that changes the speaker's env var from being the
memberlist secret key itself, to the path of where the secret is stored, consuming the secret from a volume mount.