### PR TITLE
CI: enable ci on merge group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   pull_request:
     paths-ignore:
       - 'configsamples/**'


### PR DESCRIPTION
Adding the whole CI lanes to be triggered when merge_group as per the merge queues docs.
This should speed up the way we merge prs by creating queues that rely on CI (see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue )