### PR TITLE
Improve golangci-lint configurations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           args: -exclude-dir e2etest -severity medium ./...
 
       - name: Golang Vulncheck
-        uses: Templum/govulncheck-action@v0.0.9
+        uses: Templum/govulncheck-action@v0.10.0
         with:
           skip-upload: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
   - unparam
   - whitespace
   - revive
+  - unused
+  - wastedassign
 linters-settings:
   errcheck:
     exclude: .golangci.exclude

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,15 +7,13 @@ linters:
   - gofmt
   - ginkgolinter
   - dogsled
-  #- exportloopref        #bugs
-  #- goconst              #stye  - fixes required
-  - gocritic             #style - fixes required
-  #- gomnd                #style - fixes required
-  - misspell             #style - fixes required
+  - exportloopref
+  - gocritic
+  - misspell
   - nolintlint
   - stylecheck
   - unconvert
-  - unparam              # still 1 fix
+  - unparam
   - whitespace
 linters-settings:
   errcheck:
@@ -26,14 +24,6 @@ linters-settings:
     exclude:
     - 'SPDX-License-Identifier.*'
     - '\+groupName.*'
-  exhaustive:
-    ignore-enum-types: "syscall.Errno.+"
-    check:
-      - switch
-      - map
-  goconst:
-    min-len: 2
-    min-occurrences: 2
   misspell:
     locale: US
     ignore-words:
@@ -49,6 +39,6 @@ linters-settings:
       - exitAfterDefer
 issues:
   exclude-rules:
-    - path: '/api'
-    linters:
-      - stylecheck
+    - path: 'api'
+      linters:
+        - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   - godot
   - goimports
   - gofmt
+  - ginkgolinter
 linters-settings:
   errcheck:
     exclude: .golangci.exclude

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,18 +6,12 @@ linters:
   - goimports
   - gofmt
   - ginkgolinter
-  #- dogsled              #style
-  #- dupl                 #style - fixes required
+  - dogsled
   #- exportloopref        #bugs
-  #- exhaustive           #bugs  - fixes required
-  #- funlen               #style - fixes required
   #- goconst              #stye  - fixes required
-  #- gocritic             #style - fixes required
+  - gocritic             #style - fixes required
   #- gomnd                #style - fixes required
-  #- gosec                #bugs  - fixes required
-  #- lll                  #style - fixes required
-  #- misspell             #style - fixes required
-  #- nakedret             #style - fixes required
+  - misspell             #style - fixes required
   - nolintlint
   - stylecheck
   - unconvert
@@ -42,6 +36,9 @@ linters-settings:
     min-occurrences: 2
   misspell:
     locale: US
+    ignore-words:
+      - neighbours
+      - neighbour
   stylecheck:
     dot-import-whitelist:
     - github.com/onsi/ginkgo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,9 @@ linters:
   #- misspell             #style - fixes required
   #- nakedret             #style - fixes required
   #- nolintlint
-  #- stylecheck           #style - fixes required
-  - unconvert            #style - fixes required
-  - unparam # still 1 fix
+  - stylecheck
+  - unconvert
+  - unparam              # still 1 fix
   - whitespace
 linters-settings:
   errcheck:
@@ -42,8 +42,16 @@ linters-settings:
     min-occurrences: 2
   misspell:
     locale: US
-  # lll:
-  #   line-length: 140
-  # funlen: 
-  #   lines: 100
-  #   statements: 50
+  stylecheck:
+    dot-import-whitelist:
+    - github.com/onsi/ginkgo
+    - github.com/onsi/gomega
+  gocritic:
+    disabled-checks:
+      - captLocal
+      - exitAfterDefer
+issues:
+  exclude-rules:
+    - path: '/api'
+    linters:
+      - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  issues-exit-code: 2
 linters:
   enable:
   - godot
@@ -18,8 +20,8 @@ linters:
   #- nakedret             #style - fixes required
   #- nolintlint
   #- stylecheck           #style - fixes required
-  #- unconvert            #style - fixes required
-  #- unparam
+  - unconvert            #style - fixes required
+  - unparam # still 1 fix
   - whitespace
 linters-settings:
   errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,23 @@ linters:
   - goimports
   - gofmt
   - ginkgolinter
+  #- dogsled              #style
+  #- dupl                 #style - fixes required
+  #- exportloopref        #bugs
+  #- exhaustive           #bugs  - fixes required
+  #- funlen               #style - fixes required
+  #- goconst              #stye  - fixes required
+  #- gocritic             #style - fixes required
+  #- gomnd                #style - fixes required
+  #- gosec                #bugs  - fixes required
+  #- lll                  #style - fixes required
+  #- misspell             #style - fixes required
+  #- nakedret             #style - fixes required
+  #- nolintlint
+  #- stylecheck           #style - fixes required
+  #- unconvert            #style - fixes required
+  #- unparam
+  - whitespace
 linters-settings:
   errcheck:
     exclude: .golangci.exclude
@@ -13,3 +30,18 @@ linters-settings:
     exclude:
     - 'SPDX-License-Identifier.*'
     - '\+groupName.*'
+  exhaustive:
+    ignore-enum-types: "syscall.Errno.+"
+    check:
+      - switch
+      - map
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: US
+  # lll:
+  #   line-length: 140
+  # funlen: 
+  #   lines: 100
+  #   statements: 50

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
   - unconvert
   - unparam
   - whitespace
+  - revive
 linters-settings:
   errcheck:
     exclude: .golangci.exclude
@@ -37,6 +38,12 @@ linters-settings:
     disabled-checks:
       - captLocal
       - exitAfterDefer
+  revive:
+    rules:
+    - name: receiver-naming
+      disabled: true
+    - name: dot-imports
+      disabled: true
 issues:
   exclude-rules:
     - path: 'api'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
   #- lll                  #style - fixes required
   #- misspell             #style - fixes required
   #- nakedret             #style - fixes required
-  #- nolintlint
+  - nolintlint
   - stylecheck
   - unconvert
   - unparam              # still 1 fix

--- a/api/v1beta1/bfdprofile_webhook.go
+++ b/api/v1beta1/bfdprofile_webhook.go
@@ -63,7 +63,7 @@ func (bfdProfile *BFDProfile) ValidateDelete() error {
 
 	for _, peer := range existingBGPPeers.Items {
 		if bfdProfile.Name == peer.Spec.BFDProfile {
-			return fmt.Errorf("Failed to delete BFDProfile %s, used by BGPPeer %s", bfdProfile.Name, peer.Name)
+			return fmt.Errorf("failed to delete BFDProfile %s, used by BGPPeer %s", bfdProfile.Name, peer.Name)
 		}
 	}
 	return nil

--- a/api/v1beta1/mock_validator_test.go
+++ b/api/v1beta1/mock_validator_test.go
@@ -39,7 +39,7 @@ func (m *mockValidator) Validate(objects ...client.ObjectList) error {
 	}
 
 	if m.forceError {
-		return errors.New("Error!")
+		return errors.New("error!")
 	}
 	return nil
 }

--- a/api/v1beta2/mock_validator_test.go
+++ b/api/v1beta2/mock_validator_test.go
@@ -23,7 +23,7 @@ func (m *mockValidator) Validate(objects ...client.ObjectList) error {
 	}
 
 	if m.forceError {
-		return errors.New("Error!")
+		return errors.New("error!")
 	}
 	return nil
 }

--- a/configmaptocrs/main.go
+++ b/configmaptocrs/main.go
@@ -112,7 +112,7 @@ func readConfig(origin string) ([]byte, error) {
 	fp := filepath.Join(inputDirPath, origin)
 	fp = filepath.Clean(fp)
 	if !strings.HasPrefix(fp, path.Clean(inputDirPath)) {
-		return nil, fmt.Errorf("Unsafe path %s", origin)
+		return nil, fmt.Errorf("unsafe path %s", origin)
 	}
 	f, err := os.Open(filepath.Clean(fp)) // Clean have to happen here to avoid https://github.com/securego/gosec/issues/893
 	if err != nil {
@@ -163,7 +163,7 @@ func getConfigMapData(raw []byte) ([]byte, error) {
 
 	data := []byte(cm.Data["config"])
 	if len(data) == 0 {
-		return nil, fmt.Errorf("bad ConfigMap. no data.")
+		return nil, fmt.Errorf("bad ConfigMap: no data")
 	}
 
 	return data, nil

--- a/configmaptocrs/main.go
+++ b/configmaptocrs/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	err = generate(f, *source)
 	if err != nil {
-		log.Fatalf("failed to generate resources: %s", err)
+		log.Printf("failed to generate resources: %s", err)
 	}
 }
 
@@ -396,7 +396,7 @@ func bgpAdvertisementsFor(c *configFile) []v1beta1.BGPAdvertisement {
 		for _, bgpAdv := range ap.BGPAdvertisements {
 			var b v1beta1.BGPAdvertisement
 			b.Name = fmt.Sprintf("bgpadvertisement%d", index)
-			index = index + 1
+			index++
 			b.Namespace = resourcesNameSpace
 			b.Spec.Communities = make([]string, len(bgpAdv.Communities))
 			copy(b.Spec.Communities, bgpAdv.Communities)
@@ -408,7 +408,7 @@ func bgpAdvertisementsFor(c *configFile) []v1beta1.BGPAdvertisement {
 		}
 		if len(ap.BGPAdvertisements) == 0 && ap.Protocol == BGP {
 			res = append(res, emptyBGPAdv(ap.Name, index))
-			index = index + 1
+			index++
 		}
 	}
 	return res
@@ -440,7 +440,7 @@ func l2AdvertisementsFor(c *configFile) []v1beta1.L2Advertisement {
 					IPAddressPools: []string{addresspool.Name},
 				},
 			}
-			index = index + 1
+			index++
 			res = append(res, l2Adv)
 		}
 	}

--- a/design/pool-configuration.md
+++ b/design/pool-configuration.md
@@ -177,7 +177,7 @@ All the BGP changes will happen from a "behavioural" point of view. Where needed
 The risk of not covering all possible cases / permutations is still there.
 
 That aside, this proposal covers the majority of the issues that were raised by the users (multiple times), and it won't prevent adding a finer level of configuration
-if the need ever arises. Moreover, providing a straightforward way to separate concerns will make it easier to accomodate new changes, and it will be more clear where
+if the need ever arises. Moreover, providing a straightforward way to separate concerns will make it easier to accommodate new changes, and it will be more clear where
 those new changes must be applied.
 
 ## Design Details

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1054,7 +1054,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				if c.RouterConfig.VRF != "" {
 					ruleName = fmt.Sprintf("%s-%s", ip, c.RouterConfig.VRF)
 				}
-				data = data + fmt.Sprintf("route-map %s-in permit 20\n", ruleName)
+				data += fmt.Sprintf("route-map %s-in permit 20\n", ruleName)
 			}
 			extraData := map[string]string{
 				"extras": data,

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -32,7 +32,6 @@ import (
 	"go.universe.tf/metallb/e2etest/pkg/k8s"
 	"go.universe.tf/metallb/e2etest/pkg/mac"
 	"go.universe.tf/metallb/e2etest/pkg/metallb"
-	"go.universe.tf/metallb/e2etest/pkg/service"
 	metallbconfig "go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/pointer"
 
@@ -227,19 +226,19 @@ var _ = ginkgo.Describe("BGP", func() {
 		framework.ExpectNoError(err)
 
 		svc, _ := testservice.CreateWithBackendPort(cs, f.Namespace.Name, "first-service",
-			service.TestServicePort,
+			testservice.TestServicePort,
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
 				svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
-				svc.Spec.Ports[0].Port = int32(service.TestServicePort)
+				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort)
 			})
 		defer testservice.Delete(cs, svc)
 		svc1, _ := testservice.CreateWithBackendPort(cs, f.Namespace.Name, "second-service",
-			service.TestServicePort+1,
+			testservice.TestServicePort+1,
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
 				svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
-				svc.Spec.Ports[0].Port = int32(service.TestServicePort + 1)
+				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort + 1)
 			})
 		defer testservice.Delete(cs, svc1)
 
@@ -1030,7 +1029,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 					for _, route := range routes {
 						if route.Destination.String() == toInject {
-							return fmt.Errorf("Found %s in %s routes", toInject, pod.Name)
+							return fmt.Errorf("found %s in %s routes", toInject, pod.Name)
 						}
 					}
 				}

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		validateDesiredLB(svc)
 
 		for _, c := range FRRContainers {
-			validateService(cs, svc, allNodes.Items, c)
+			validateService(svc, allNodes.Items, c)
 		}
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		framework.ExpectNoError(err)
 
 		for _, c := range FRRContainers {
-			validateService(cs, svc, epNodes, c)
+			validateService(svc, epNodes, c)
 		}
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
@@ -247,8 +247,8 @@ var _ = ginkgo.Describe("BGP", func() {
 		validateDesiredLB(svc1)
 
 		for _, c := range FRRContainers {
-			validateService(cs, svc, allNodes.Items, c)
-			validateService(cs, svc1, allNodes.Items, c)
+			validateService(svc, allNodes.Items, c)
+			validateService(svc1, allNodes.Items, c)
 		}
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}),
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			framework.ExpectNoError(err)
 
 			for _, c := range FRRContainers {
-				validateService(cs, svc, allNodes.Items, c)
+				validateService(svc, allNodes.Items, c)
 			}
 		},
 			ginkgo.Entry("IPV4 - test AddressPool defined by address range", []metallbv1beta1.IPAddressPool{
@@ -458,7 +458,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			}
 
 			for _, c := range FRRContainers {
-				validateService(cs, svc, allNodes.Items, c)
+				validateService(svc, allNodes.Items, c)
 			}
 
 			Eventually(func() error {
@@ -624,7 +624,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 					ginkgo.By(fmt.Sprintf("checking connectivity of service %d to its external VIP", j+1))
 					for _, c := range FRRContainers {
-						validateService(cs, svc, allNodes.Items, c)
+						validateService(svc, allNodes.Items, c)
 					}
 				}
 			}
@@ -740,9 +740,9 @@ var _ = ginkgo.Describe("BGP", func() {
 				framework.ExpectNoError(err)
 
 				for _, c := range FRRContainers {
-					validateService(cs, svcAdvertisement, allNodes.Items, c)
-					validateService(cs, svcAdvertisement1, allNodes.Items, c)
-					validateService(cs, svcNoAdvertisement, allNodes.Items, c)
+					validateService(svcAdvertisement, allNodes.Items, c)
+					validateService(svcAdvertisement1, allNodes.Items, c)
+					validateService(svcNoAdvertisement, allNodes.Items, c)
 					Eventually(func() error {
 						for _, community := range advertisement.Spec.Communities {
 							// Get community value for test cases with Community CRD.
@@ -1210,7 +1210,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		ginkgo.By("Checking the service is reacheable via BGP")
 		for _, c := range FRRContainers {
-			validateService(cs, svc, allNodes.Items, c)
+			validateService(svc, allNodes.Items, c)
 		}
 
 		checkServiceL2 := func() error {
@@ -1245,7 +1245,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		ginkgo.By("Checking the service is still reacheable via BGP")
 		for _, c := range FRRContainers {
-			validateService(cs, svc, allNodes.Items, c)
+			validateService(svc, allNodes.Items, c)
 		}
 
 		ginkgo.By("Deleting the l2 advertisement")

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 				validateFRRPeeredWithAllNodes(cs, c, pairingFamily)
 			}
 			for _, c := range FRRContainers {
-				validateService(cs, svc, allNodes.Items, c)
+				validateService(svc, allNodes.Items, c)
 			}
 		},
 			ginkgo.Entry("DUALSTACK - via ipv4",
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 				framework.ExpectNoError(err)
 
 				for _, c := range FRRContainers {
-					validateService(cs, svc, allNodes.Items, c)
+					validateService(svc, allNodes.Items, c)
 					for _, ip := range svc.Status.LoadBalancer.Ingress {
 						ingressIP := e2eservice.GetIngressPoint(&ip)
 						Eventually(func() error {

--- a/e2etest/bgptests/bgppeer_selector.go
+++ b/e2etest/bgptests/bgppeer_selector.go
@@ -145,12 +145,12 @@ var _ = ginkgo.Describe("BGP Peer Selector", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By(fmt.Sprintf("checking connectivity of service 1 to external frr container %s", frrContainerForAdv1.Name))
-			validateService(cs, svcAdvertisement1, allNodes.Items, frrContainerForAdv1)
+			validateService(svcAdvertisement1, allNodes.Items, frrContainerForAdv1)
 			ginkgo.By("checking service 1 not advertised to other frr containers")
 			validateServiceNotAdvertised(svcAdvertisement1, FRRContainers, frrContainerForAdv1.Name, ipFamily)
 
 			ginkgo.By(fmt.Sprintf("checking connectivity of service 2 to external frr container %s", frrContainerForAdv2.Name))
-			validateService(cs, svcAdvertisement2, allNodes.Items, frrContainerForAdv2)
+			validateService(svcAdvertisement2, allNodes.Items, frrContainerForAdv2)
 			ginkgo.By("checking service 2 not advertised to other frr containers")
 			validateServiceNotAdvertised(svcAdvertisement2, FRRContainers, frrContainerForAdv2.Name, ipFamily)
 
@@ -162,12 +162,12 @@ var _ = ginkgo.Describe("BGP Peer Selector", func() {
 
 			for _, c := range FRRContainers {
 				ginkgo.By(fmt.Sprintf("checking connectivity of service 1 to external frr container %s", c.Name))
-				validateService(cs, svcAdvertisement1, allNodes.Items, c)
+				validateService(svcAdvertisement1, allNodes.Items, c)
 			}
 
 			for _, c := range FRRContainers {
 				ginkgo.By(fmt.Sprintf("checking connectivity of service 2 to external frr container %s", c.Name))
-				validateService(cs, svcAdvertisement2, allNodes.Items, c)
+				validateService(svcAdvertisement2, allNodes.Items, c)
 			}
 		},
 		ginkgo.Entry("IPV4", []string{"192.168.10.0/24"},

--- a/e2etest/bgptests/dump.go
+++ b/e2etest/bgptests/dump.go
@@ -18,7 +18,7 @@ import (
 )
 
 func dumpBGPInfo(basePath, testName string, cs clientset.Interface, f *framework.Framework) {
-	testPath := path.Join(basePath, strings.Replace(testName, " ", "-", -1))
+	testPath := path.Join(basePath, strings.ReplaceAll(testName, " ", "-"))
 	err := os.Mkdir(testPath, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		fmt.Fprintf(os.Stderr, "failed to create test dir: %v\n", err)

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -53,7 +53,6 @@ var (
 )
 
 func init() {
-
 	if ip := os.Getenv("PROVISIONING_HOST_EXTERNAL_IPV4"); len(ip) != 0 {
 		hostIPv4 = ip
 	}
@@ -505,7 +504,6 @@ func multiHopTearDown(nextHop nextHopSettings, routes map[string]container.Netwo
 		if err != nil {
 			return errors.Wrapf(err, "Failed to delete multihop routes for pod %s", pod.ObjectMeta.Name)
 		}
-
 	}
 
 	return nil

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -144,7 +144,7 @@ func KindnetContainersSetup(cs *clientset.Clientset) ([]*frrcontainer.FRR, error
 }
 
 /*
-	In order to test MetalLB's announcemnet via VRFs, we:
+	In order to test MetalLB's announcement via VRFs, we:
 
 	* create an additional "vrf-net" docker network
 	* for each node, create a vrf named "red" and move the interface in that vrf

--- a/e2etest/bgptests/infra_setup.go
+++ b/e2etest/bgptests/infra_setup.go
@@ -238,7 +238,7 @@ func infraTearDown(cs *clientset.Clientset, containers []*frrcontainer.FRR, next
 func multiHopSetUp(containers []*frrcontainer.FRR, nextHop nextHopSettings, cs *clientset.Clientset) error {
 	err := addContainerToNetwork(nextHop.nextHopContainerName, nextHop.multiHopNetwork)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to connect %s to %s", nextHop.nextHopContainerName, nextHop.multiHopNetwork)
+		return errors.Wrapf(err, "failed to connect %s to %s", nextHop.nextHopContainerName, nextHop.multiHopNetwork)
 	}
 
 	multiHopRoutes, err := container.Networks(nextHop.nextHopContainerName)
@@ -250,13 +250,13 @@ func multiHopSetUp(containers []*frrcontainer.FRR, nextHop nextHopSettings, cs *
 		if c.Network == nextHop.multiHopNetwork {
 			err = container.AddMultiHop(c, c.Network, nextHop.nodeNetwork, defaultRoutingTable, multiHopRoutes)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to set up the multi-hop network for container %s", c.Name)
+				return errors.Wrapf(err, "failed to set up the multi-hop network for container %s", c.Name)
 			}
 		}
 	}
 	err = addMultiHopToNodes(cs, nextHop.nodeNetwork, nextHop.multiHopNetwork, nextHop.nodeRoutingTable, multiHopRoutes)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to set up the multi-hop network")
+		return errors.Wrapf(err, "failed to set up the multi-hop network")
 	}
 
 	return nil
@@ -270,7 +270,7 @@ func vrfSetup(cs *clientset.Clientset) error {
 	for _, pod := range speakerPods {
 		err := addContainerToNetwork(pod.Spec.NodeName, vrfNetwork)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to connect %s to %s", pod.Spec.NodeName, vrfNetwork)
+			return errors.Wrapf(err, "failed to connect %s to %s", pod.Spec.NodeName, vrfNetwork)
 		}
 
 		err = container.SetupVRFForNetwork(pod.Spec.NodeName, vrfNetwork, vrfName, vrfNextHopSettings.nodeRoutingTable)
@@ -491,7 +491,7 @@ func vrfContainersConfig() map[string]frrcontainer.Config {
 func multiHopTearDown(nextHop nextHopSettings, routes map[string]container.NetworkSettings, cs *clientset.Clientset) error {
 	out, err := executor.Host.Exec(executor.ContainerRuntime, "network", "rm", nextHop.multiHopNetwork)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to remove %s: %s", nextHop.multiHopNetwork, out)
+		return errors.Wrapf(err, "failed to remove %s: %s", nextHop.multiHopNetwork, out)
 	}
 
 	speakerPods, err := metallb.SpeakerPods(cs)
@@ -502,7 +502,7 @@ func multiHopTearDown(nextHop nextHopSettings, routes map[string]container.Netwo
 		nodeExec := executor.ForContainer(pod.Spec.NodeName)
 		err = container.DeleteMultiHop(nodeExec, nextHop.nodeNetwork, nextHop.multiHopNetwork, nextHop.nodeRoutingTable, routes)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to delete multihop routes for pod %s", pod.ObjectMeta.Name)
+			return errors.Wrapf(err, "failed to delete multihop routes for pod %s", pod.ObjectMeta.Name)
 		}
 	}
 
@@ -535,7 +535,7 @@ func addMultiHopToNodes(cs *clientset.Clientset, targetNetwork, multiHopNetwork 
 // The valid names are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop.
 func validateContainersNames(containerNames string) error {
 	if len(containerNames) == 0 {
-		return fmt.Errorf("Failed to validate containers names: got empty string")
+		return fmt.Errorf("failed to validate containers names: got empty string")
 	}
 	validNames := map[string]bool{
 		"ibgp-single-hop": true,
@@ -547,10 +547,10 @@ func validateContainersNames(containerNames string) error {
 	for _, n := range names {
 		v, ok := validNames[n]
 		if !ok {
-			return fmt.Errorf("Failed to validate container name: %s invalid name", n)
+			return fmt.Errorf("failed to validate container name: %s invalid name", n)
 		}
 		if !v {
-			return fmt.Errorf("Failed to validate container name: %s duplicate name", n)
+			return fmt.Errorf("failed to validate container name: %s duplicate name", n)
 		}
 		validNames[n] = false
 	}
@@ -585,7 +585,7 @@ func addContainerToNetwork(containerName, network string) error {
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "Failed to connect %s to %s: %s", containerName, network, out)
+		return errors.Wrapf(err, "failed to connect %s to %s: %s", containerName, network, out)
 	}
 	return nil
 }

--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -22,7 +22,6 @@ import (
 	frrconfig "go.universe.tf/metallb/e2etest/pkg/frr/config"
 	frrcontainer "go.universe.tf/metallb/e2etest/pkg/frr/container"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -31,7 +30,7 @@ import (
 var _ = ginkgo.Describe("BGP Node Selector", func() {
 	var cs clientset.Interface
 	var f *framework.Framework
-	var nodeToLabel *v1.Node
+	var nodeToLabel *corev1.Node
 
 	ginkgo.AfterEach(func() {
 		if nodeToLabel != nil {
@@ -253,7 +252,7 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 			k8s.AddLabelToNode(nodeToLabel.Name, "bgp-node-selector-test", "true", cs)
 
 			ginkgo.By(fmt.Sprintf("Validating service IP advertised by %s", nodeToLabel.Name))
-			checkServiceOnlyOnNodes(svc, []v1.Node{*nodeToLabel}, pairingIPFamily)
+			checkServiceOnlyOnNodes(svc, []corev1.Node{*nodeToLabel}, pairingIPFamily)
 
 			ginkgo.By("Validating service IP not advertised by other nodes")
 			nodesNotSelected := nodesNotSelected(allNodes.Items, []int{0})
@@ -295,7 +294,7 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 							p.Spec.NodeSelectors = k8s.SelectorsForNodes(nodes)
 							return
 						}
-						p.Spec.NodeSelectors = k8s.SelectorsForNodes([]v1.Node{})
+						p.Spec.NodeSelectors = k8s.SelectorsForNodes([]corev1.Node{})
 					}),
 			}
 			err = ConfigUpdater.Update(resources)

--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -124,8 +124,8 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 			secondService, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "second-lb", testservice.WithSpecificPool("second-pool"))
 			defer testservice.Delete(cs, secondService)
 
-			checkServiceOnlyOnNodes(cs, firstService, expectedNodesForFirstPool, pairingIPFamily)
-			checkServiceOnlyOnNodes(cs, secondService, expectedNodesForSecondPool, pairingIPFamily)
+			checkServiceOnlyOnNodes(firstService, expectedNodesForFirstPool, pairingIPFamily)
+			checkServiceOnlyOnNodes(secondService, expectedNodesForSecondPool, pairingIPFamily)
 		},
 		ginkgo.Entry("IPV4 - two on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{0, 1}, []int{0, 1}),
 		ginkgo.Entry("IPV4 - one on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{0}, []int{0, 1}),
@@ -187,8 +187,8 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 		svc, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "first-lb", testservice.TrafficPolicyCluster)
 		defer testservice.Delete(cs, svc)
 
-		checkCommunitiesOnlyOnNodes(cs, svc, CommunityNoAdv, expectedNodesForFirstAdv, pairingIPFamily)
-		checkCommunitiesOnlyOnNodes(cs, svc, CommunityGracefulShut, expectedNodesForSecondAdv, pairingIPFamily)
+		checkCommunitiesOnlyOnNodes(svc, CommunityNoAdv, expectedNodesForFirstAdv, pairingIPFamily)
+		checkCommunitiesOnlyOnNodes(svc, CommunityGracefulShut, expectedNodesForSecondAdv, pairingIPFamily)
 	},
 		ginkgo.Entry("IPV4 - two on first, two on second", ipfamily.IPv4, "192.168.10.0/24", []int{0, 1}, []int{0, 1}),
 		ginkgo.Entry("IPV4 - one on first, two on second", ipfamily.IPv4, "192.168.10.0/24", []int{0}, []int{0, 1}),
@@ -246,18 +246,18 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 			defer testservice.Delete(cs, svc)
 
 			ginkgo.By("Validating service IP not advertised")
-			checkServiceNotOnNodes(cs, svc, allNodes.Items, pairingIPFamily)
+			checkServiceNotOnNodes(svc, allNodes.Items, pairingIPFamily)
 
 			nodeToLabel = &allNodes.Items[0]
 			ginkgo.By(fmt.Sprintf("Adding advertisement label to node %s", nodeToLabel.Name))
 			k8s.AddLabelToNode(nodeToLabel.Name, "bgp-node-selector-test", "true", cs)
 
 			ginkgo.By(fmt.Sprintf("Validating service IP advertised by %s", nodeToLabel.Name))
-			checkServiceOnlyOnNodes(cs, svc, []v1.Node{*nodeToLabel}, pairingIPFamily)
+			checkServiceOnlyOnNodes(svc, []v1.Node{*nodeToLabel}, pairingIPFamily)
 
 			ginkgo.By("Validating service IP not advertised by other nodes")
 			nodesNotSelected := nodesNotSelected(allNodes.Items, []int{0})
-			checkServiceNotOnNodes(cs, svc, nodesNotSelected, pairingIPFamily)
+			checkServiceNotOnNodes(svc, nodesNotSelected, pairingIPFamily)
 		},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, "192.168.10.0/24"),
 		ginkgo.Entry("IPV6", ipfamily.IPv6, "fc00:f853:0ccd:e799::/116"),
@@ -309,8 +309,8 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 			for i, c := range FRRContainers {
 				selected := nodesForSelection(allNodes.Items, nodesForPeers[i])
 				nonSelected := nodesNotSelected(allNodes.Items, nodesForPeers[i])
-				validateFRRPeeredWithNodes(cs, selected, c, ipfamily.IPv4)
-				validateFRRNotPeeredWithNodes(cs, nonSelected, c, ipfamily.IPv4)
+				validateFRRPeeredWithNodes(selected, c, ipfamily.IPv4)
+				validateFRRNotPeeredWithNodes(nonSelected, c, ipfamily.IPv4)
 			}
 
 		},

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -154,16 +154,16 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily ipf
 
 func checkBFDConfigPropagated(nodeConfig metallbv1beta1.BFDProfile, peerConfig bgpfrr.BFDPeer) error {
 	if peerConfig.Status != "up" {
-		return fmt.Errorf("Peer status not up")
+		return fmt.Errorf("peer status not up")
 	}
 	if peerConfig.RemoteReceiveInterval != int(*nodeConfig.Spec.ReceiveInterval) {
-		return fmt.Errorf("RemoteReceiveInterval: expecting %d, got %d", *nodeConfig.Spec.ReceiveInterval, peerConfig.RemoteReceiveInterval)
+		return fmt.Errorf("remoteReceiveInterval: expecting %d, got %d", *nodeConfig.Spec.ReceiveInterval, peerConfig.RemoteReceiveInterval)
 	}
 	if peerConfig.RemoteTransmitInterval != int(*nodeConfig.Spec.TransmitInterval) {
-		return fmt.Errorf("RemoteTransmitInterval: expecting %d, got %d", *nodeConfig.Spec.TransmitInterval, peerConfig.RemoteTransmitInterval)
+		return fmt.Errorf("remoteTransmitInterval: expecting %d, got %d", *nodeConfig.Spec.TransmitInterval, peerConfig.RemoteTransmitInterval)
 	}
 	if peerConfig.RemoteEchoReceiveInterval != int(*nodeConfig.Spec.EchoInterval) {
-		return fmt.Errorf("EchoInterval: expecting %d, got %d", *nodeConfig.Spec.EchoInterval, peerConfig.RemoteEchoReceiveInterval)
+		return fmt.Errorf("echoInterval: expecting %d, got %d", *nodeConfig.Spec.EchoInterval, peerConfig.RemoteEchoReceiveInterval)
 	}
 	return nil
 }
@@ -199,7 +199,7 @@ func checkServiceOnlyOnNodes(svc *corev1.Service, expectedNodes []corev1.Node, i
 						continue OUTER
 					}
 				}
-				return fmt.Errorf("UnexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
+				return fmt.Errorf("unexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
 			}
 			return err
 		}, time.Minute, time.Second).Should(Not(HaveOccurred()))
@@ -253,7 +253,7 @@ func checkCommunitiesOnlyOnNodes(svc *corev1.Service, community string, expected
 						continue OUTER
 					}
 				}
-				return fmt.Errorf("UnexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
+				return fmt.Errorf("unexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
 			}
 			return err
 		}, 10*time.Minute, time.Second).Should(Not(HaveOccurred()))
@@ -264,7 +264,7 @@ func nodesForSelection(nodes []corev1.Node, selected []int) []corev1.Node {
 	selectedNodes := []corev1.Node{}
 	for _, i := range selected {
 		if i >= len(nodes) {
-			ginkgo.Skip("Not enough nodes")
+			ginkgo.Skip("not enough nodes")
 		}
 		selectedNodes = append(selectedNodes, nodes[i])
 	}

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -75,7 +75,6 @@ func validateServiceNoWait(cs clientset.Interface, svc *corev1.Service, nodes []
 		framework.ExpectNotEqual(ip1.To4(), ip2.To4())
 	}
 	for _, ip := range svc.Status.LoadBalancer.Ingress {
-
 		ingressIP := e2eservice.GetIngressPoint(&ip)
 
 		// TODO: in case of VRF there's currently no host wiring to the service.

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -15,8 +15,6 @@ import (
 	"go.universe.tf/metallb/e2etest/pkg/service"
 	internalconfig "go.universe.tf/metallb/internal/config"
 
-	testservice "go.universe.tf/metallb/e2etest/pkg/service"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -83,7 +81,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			})
 			framework.ExpectNoError(err)
 			defer func() {
-				testservice.Delete(cs, svc1)
+				service.Delete(cs, svc1)
 			}()
 
 			gomega.Consistently(func() int {
@@ -164,13 +162,13 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
 
-			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
-			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-2")
-			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-3")
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			svc2, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-2")
+			svc3, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-3")
 			defer func() {
-				testservice.Delete(cs, svc1)
-				testservice.Delete(cs, svc2)
-				testservice.Delete(cs, svc3)
+				service.Delete(cs, svc1)
+				service.Delete(cs, svc2)
+				service.Delete(cs, svc3)
 			}()
 
 			// The createWithBackend method always wait for service to acquire an ingress IP, so
@@ -232,13 +230,13 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			err = ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
 
-			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-1")
-			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-2")
-			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-3")
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-1")
+			svc2, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-2")
+			svc3, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-label-pool-3")
 			defer func() {
-				testservice.Delete(cs, svc1)
-				testservice.Delete(cs, svc2)
-				testservice.Delete(cs, svc3)
+				service.Delete(cs, svc1)
+				service.Delete(cs, svc2)
+				service.Delete(cs, svc3)
 			}()
 
 			// The createWithBackend method always wait for service to acquire an ingress IP, so
@@ -295,19 +293,19 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
 
-			svcTweakWithLabel := func(svc *corev1.Service) {
+			svcTweakWithLabel := func(svc *v1.Service) {
 				if svc.Labels == nil {
 					svc.Labels = make(map[string]string)
 				}
 				svc.Labels["test"] = "e2e"
 			}
-			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-1", svcTweakWithLabel)
-			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-2", svcTweakWithLabel)
-			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-3", svcTweakWithLabel)
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-1", svcTweakWithLabel)
+			svc2, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-2", svcTweakWithLabel)
+			svc3, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-svc-label-pool-3", svcTweakWithLabel)
 			defer func() {
-				testservice.Delete(cs, svc1)
-				testservice.Delete(cs, svc2)
-				testservice.Delete(cs, svc3)
+				service.Delete(cs, svc1)
+				service.Delete(cs, svc2)
+				service.Delete(cs, svc3)
 			}()
 
 			// The createWithBackend method always wait for service to acquire an ingress IP, so
@@ -363,19 +361,19 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
 
-			svcTweakWithLabel := func(svc *corev1.Service) {
+			svcTweakWithLabel := func(svc *v1.Service) {
 				if svc.Labels == nil {
 					svc.Labels = make(map[string]string)
 				}
 				svc.Labels["test"] = "e2e"
 			}
-			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-1", svcTweakWithLabel)
-			svc2, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-2", svcTweakWithLabel)
-			svc3, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-3", svcTweakWithLabel)
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-1", svcTweakWithLabel)
+			svc2, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-2", svcTweakWithLabel)
+			svc3, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-ns-svc-label-pool-3", svcTweakWithLabel)
 			defer func() {
-				testservice.Delete(cs, svc1)
-				testservice.Delete(cs, svc2)
-				testservice.Delete(cs, svc3)
+				service.Delete(cs, svc1)
+				service.Delete(cs, svc2)
+				service.Delete(cs, svc3)
 			}()
 
 			// The createWithBackend method always wait for service to acquire an ingress IP, so

--- a/e2etest/l2tests/interface_selector.go
+++ b/e2etest/l2tests/interface_selector.go
@@ -12,7 +12,6 @@ import (
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	internalconfig "go.universe.tf/metallb/internal/config"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -280,7 +279,7 @@ var _ = ginkgo.Describe("L2-interface selector", func() {
 							},
 							Spec: metallbv1beta1.L2AdvertisementSpec{
 								Interfaces:    []string{NodeNics[0]},
-								NodeSelectors: k8s.SelectorsForNodes([]v1.Node{node}),
+								NodeSelectors: k8s.SelectorsForNodes([]corev1.Node{node}),
 							},
 						},
 					},

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("L2", func() {
 				return errors.New("service2 not announced")
 			}
 			if service1Announce != service2Announce {
-				return fmt.Errorf("Service announced from different nodes %s %s", service1Announce, service2Announce)
+				return fmt.Errorf("service announced from different nodes %s %s", service1Announce, service2Announce)
 			}
 			return nil
 		}, 2*time.Minute, 1*time.Second).Should(gomega.BeNil())

--- a/e2etest/l2tests/node_selector.go
+++ b/e2etest/l2tests/node_selector.go
@@ -20,7 +20,6 @@ import (
 
 	internalconfig "go.universe.tf/metallb/internal/config"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -31,7 +30,7 @@ import (
 
 var _ = ginkgo.Describe("L2", func() {
 	var cs clientset.Interface
-	var nodeToLabel *v1.Node
+	var nodeToLabel *corev1.Node
 
 	var f *framework.Framework
 	ginkgo.AfterEach(func() {
@@ -99,7 +98,7 @@ var _ = ginkgo.Describe("L2", func() {
 						Name: "with-selector",
 					},
 					Spec: metallbv1beta1.L2AdvertisementSpec{
-						NodeSelectors: k8s.SelectorsForNodes([]v1.Node{node}),
+						NodeSelectors: k8s.SelectorsForNodes([]corev1.Node{node}),
 					},
 				}
 
@@ -170,7 +169,7 @@ var _ = ginkgo.Describe("L2", func() {
 						Name: "with-selector",
 					},
 					Spec: metallbv1beta1.L2AdvertisementSpec{
-						NodeSelectors: k8s.SelectorsForNodes([]v1.Node{allNodes.Items[1]}),
+						NodeSelectors: k8s.SelectorsForNodes([]corev1.Node{allNodes.Items[1]}),
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{

--- a/e2etest/pkg/config/update.go
+++ b/e2etest/pkg/config/update.go
@@ -67,49 +67,49 @@ func (o beta1Updater) Update(r config.ClusterResources) error {
 	for _, pool := range r.Pools {
 		objects[key] = pool.DeepCopy()
 		oldValues[key] = pool.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, secret := range r.PasswordSecrets {
 		objects[key] = secret.DeepCopy()
 		oldValues[key] = secret.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, peer := range r.Peers {
 		objects[key] = peer.DeepCopy()
 		oldValues[key] = peer.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, bfdProfile := range r.BFDProfiles {
 		objects[key] = bfdProfile.DeepCopy()
 		oldValues[key] = bfdProfile.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, bgpAdv := range r.BGPAdvs {
 		objects[key] = bgpAdv.DeepCopy()
 		oldValues[key] = bgpAdv.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, l2Adv := range r.L2Advs {
 		objects[key] = l2Adv.DeepCopy()
 		oldValues[key] = l2Adv.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, legacyPool := range r.LegacyAddressPools {
 		objects[key] = legacyPool.DeepCopy()
 		oldValues[key] = legacyPool.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	for _, community := range r.Communities {
 		objects[key] = community.DeepCopy()
 		oldValues[key] = community.DeepCopy()
-		key = key + 1
+		key++
 	}
 
 	// Iterating over the map will return the items in a random order.

--- a/e2etest/pkg/config/update.go
+++ b/e2etest/pkg/config/update.go
@@ -27,7 +27,7 @@ type beta1Updater struct {
 	namespace string
 }
 
-func UpdaterForCRs(r *rest.Config, ns string) (*beta1Updater, error) {
+func UpdaterForCRs(r *rest.Config, ns string) (Updater, error) {
 	myScheme := runtime.NewScheme()
 
 	if err := metallbv1beta1.AddToScheme(myScheme); err != nil {

--- a/e2etest/pkg/container/routes.go
+++ b/e2etest/pkg/container/routes.go
@@ -72,7 +72,7 @@ func SetupVRFForNetwork(containerName, vrfNetwork, vrfName, vrfRoutingTable stri
 	}
 	r, ok := containerNetworks[vrfNetwork]
 	if !ok {
-		return fmt.Errorf("Network %s not found in container %s", vrfNetwork, containerName)
+		return fmt.Errorf("network %s not found in container %s", vrfNetwork, containerName)
 	}
 	exec := executor.ForContainer(containerName)
 	// Get the interface beloning to the given network

--- a/e2etest/pkg/executor/executor.go
+++ b/e2etest/pkg/executor/executor.go
@@ -51,7 +51,7 @@ type podExecutor struct {
 	container string
 }
 
-func ForPod(namespace, name, container string) *podExecutor {
+func ForPod(namespace, name, container string) Executor {
 	return &podExecutor{
 		namespace: namespace,
 		name:      name,

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -111,8 +111,8 @@ func RoutesForCommunity(exec executor.Executor, community string, family ipfamil
 
 // NeighborConnected tells if the neighbor in the given
 // json format is connected.
-func NeighborConnected(neighborJson string) (bool, error) {
-	n, err := bgpfrr.ParseNeighbour(neighborJson)
+func NeighborConnected(neighborJSON string) (bool, error) {
+	n, err := bgpfrr.ParseNeighbour(neighborJSON)
 	if err != nil {
 		return false, err
 	}

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -129,43 +129,43 @@ func RawDump(exec executor.Executor, filesToDump ...string) (string, error) {
 	if err != nil {
 		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bgp neighbor: %v", err)
 	}
-	res = res + out
+	res += out
 
 	for _, file := range filesToDump {
-		res = res + fmt.Sprintf("####### Dumping file %s\n", file)
+		res += fmt.Sprintf("####### Dumping file %s\n", file)
 		// limiting the output to 500 lines:
 		out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s | tail -n 500", file))
 		if err != nil {
 			allerrs = errors.Wrapf(allerrs, "\nFailed to cat file %s: %v", file, err)
 		}
-		res = res + out
+		res += out
 	}
 
-	res = res + "####### BGP Neighbors\n"
+	res += "####### BGP Neighbors\n"
 	out, err = exec.Exec("vtysh", "-c", "show bgp neighbor")
 	if err != nil {
 		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bgp neighbor: %v", err)
 	}
-	res = res + out
+	res += out
 
-	res = res + "####### BFD Peers\n"
+	res += "####### BFD Peers\n"
 	out, err = exec.Exec("vtysh", "-c", "show bfd peer")
 	if err != nil {
 		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bfd peer: %v", err)
 	}
-	res = res + out
+	res += out
 
-	res = res + "####### Check for any crashinfo files\n"
+	res += "####### Check for any crashinfo files\n"
 	if crashInfo, err := exec.Exec("bash", "-c", "ls /var/tmp/frr/bgpd.*/crashlog"); err == nil {
 		crashInfo = strings.TrimSuffix(crashInfo, "\n")
 		files := strings.Split(crashInfo, "\n")
 		for _, file := range files {
-			res = res + fmt.Sprintf("####### Dumping crash file %s\n", file)
+			res += fmt.Sprintf("####### Dumping crash file %s\n", file)
 			out, err = exec.Exec("bash", "-c", fmt.Sprintf("cat %s", file))
 			if err != nil {
 				allerrs = errors.Wrapf(allerrs, "\nFailed to cat bgpd crashinfo file %s: %v", file, err)
 			}
-			res = res + out
+			res += out
 		}
 	}
 

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -328,14 +328,14 @@ func reloadFRRConfig(configFile string, exec executor.Executor) error {
 	cmd := fmt.Sprintf("python3 /usr/lib/frr/frr-reload.py --test --stdout %s/%s", frrMountPath, configFile)
 	out, err := exec.Exec("sh", "-c", cmd)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to check configuration file. %s", string(out))
+		return errors.Wrapf(err, "Failed to check configuration file. %s", out)
 	}
 
 	// Applying the configuration file.
 	cmd = fmt.Sprintf("python3 /usr/lib/frr/frr-reload.py --reload --overwrite --stdout %s/%s", frrMountPath, configFile)
 	out, err = exec.Exec("sh", "-c", cmd)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to apply configuration file. %s", string(out))
+		return errors.Wrapf(err, "Failed to apply configuration file. %s", out)
 	}
 
 	return nil

--- a/e2etest/pkg/frr/validation.go
+++ b/e2etest/pkg/frr/validation.go
@@ -27,13 +27,13 @@ func NeighborsMatchNodes(nodes []v1.Node, neighbors []*bgpfrr.Neighbor, ipFamily
 		nodesIPs[ip] = struct{}{}
 	}
 	for _, n := range neighbors {
-		if _, ok := nodesIPs[n.Ip.String()]; !ok { // skipping neighbors that are not nodes
+		if _, ok := nodesIPs[n.IP.String()]; !ok { // skipping neighbors that are not nodes
 			continue
 		}
 		if !n.Connected {
-			return fmt.Errorf("node %s BGP session not established", n.Ip.String())
+			return fmt.Errorf("node %s BGP session not established", n.IP.String())
 		}
-		delete(nodesIPs, n.Ip.String())
+		delete(nodesIPs, n.IP.String())
 	}
 	if len(nodesIPs) != 0 { // some leftover, meaning more nodes than neighbors
 		return fmt.Errorf("IP %v found in nodes but not in neighbors", nodesIPs)

--- a/e2etest/pkg/k8s/pods.go
+++ b/e2etest/pkg/k8s/pods.go
@@ -12,9 +12,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func PodLogsSinceTime(cs clientset.Interface, pod *corev1.Pod, SpeakerContainerName string, sinceTime *metav1.Time) (string, error) {
+func PodLogsSinceTime(cs clientset.Interface, pod *corev1.Pod, speakerContainerName string, sinceTime *metav1.Time) (string, error) {
 	podLogOpt := corev1.PodLogOptions{
-		Container: SpeakerContainerName,
+		Container: speakerContainerName,
 		SinceTime: sinceTime,
 	}
 	return PodLogs(cs, pod, podLogOpt)

--- a/e2etest/pkg/k8s/reporter.go
+++ b/e2etest/pkg/k8s/reporter.go
@@ -62,6 +62,6 @@ func InitReporter(kubeconfig, path, namespace string) *k8sreporter.KubernetesRep
 }
 
 func DumpInfo(reporter *k8sreporter.KubernetesReporter, testName string) {
-	testNameNoSpaces := strings.Replace(ginkgo.CurrentSpecReport().LeafNodeText, " ", "-", -1)
+	testNameNoSpaces := strings.ReplaceAll(ginkgo.CurrentSpecReport().LeafNodeText, " ", "-")
 	reporter.Dump(10*time.Minute, testNameNoSpaces)
 }

--- a/e2etest/pkg/mac/mac.go
+++ b/e2etest/pkg/mac/mac.go
@@ -174,7 +174,7 @@ func GetIfaceMac(iface string, exec executor.Executor) (net.HardwareAddr, error)
 
 	macRe := regexp.MustCompile("([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})")
 
-	res := strings.Split(string(out), "\n")
+	res := strings.Split(out, "\n")
 	for _, line := range res {
 		cur := strings.Split(line, " ")
 		if cur[0] == iface {

--- a/e2etest/pkg/metallb/metallb.go
+++ b/e2etest/pkg/metallb/metallb.go
@@ -34,10 +34,10 @@ func SpeakerPods(cs clientset.Interface) ([]*corev1.Pod, error) {
 		LabelSelector: speakerLabelgSelector,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to fetch speaker pods")
+		return nil, errors.Wrap(err, "failed to fetch speaker pods")
 	}
 	if len(speakers.Items) == 0 {
-		return nil, errors.New("No speaker pods found")
+		return nil, errors.New("no speaker pods found")
 	}
 	speakerPods := make([]*corev1.Pod, 0)
 	for _, item := range speakers.Items {
@@ -53,10 +53,10 @@ func ControllerPod(cs clientset.Interface) (*corev1.Pod, error) {
 		LabelSelector: ControllerLabelSelector,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to fetch controller pods")
+		return nil, errors.Wrap(err, "failed to fetch controller pods")
 	}
 	if len(pods.Items) != 1 {
-		return nil, fmt.Errorf("Expected one controller pod, found %d", len(pods.Items))
+		return nil, fmt.Errorf("expected one controller pod, found %d", len(pods.Items))
 	}
 	return &pods.Items[0], nil
 }

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -73,7 +73,7 @@ func GaugeForLabels(metricName string, labels map[string]string, metrics map[str
 	})
 }
 
-// ValidateGaugeValue checks that the value corresponing to the given metric is the same as expected value.
+// ValidateGaugeValue checks that the value corresponding to the given metric is the same as expected value.
 func ValidateGaugeValue(expectedValue int, metricName string, labels map[string]string, allMetrics []map[string]*dto.MetricFamily) error {
 	return ValidateGaugeValueCompare(func(value int) error {
 		if value != expectedValue {
@@ -83,7 +83,7 @@ func ValidateGaugeValue(expectedValue int, metricName string, labels map[string]
 	}, metricName, labels, allMetrics)
 }
 
-// ValidateGaugeValueCompare checks that the value corresponing to the given metric against the given compare function.
+// ValidateGaugeValueCompare checks that the value corresponding to the given metric against the given compare function.
 func ValidateGaugeValueCompare(check func(int) error, metricName string, labels map[string]string, allMetrics []map[string]*dto.MetricFamily) error {
 	found := false
 	for _, m := range allMetrics {

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -102,7 +102,6 @@ func ValidateGaugeValueCompare(check func(int) error, metricName string, labels 
 		return fmt.Errorf("metric %s not found", metricName)
 	}
 	return nil
-
 }
 
 // ValidateCounterValue checks that the value related to the given metric is at most the expectedMax value.

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -44,8 +44,8 @@ func ForPod(controller, target *corev1.Pod, namespace string) ([]map[string]*dto
 
 	podExecutor := executor.ForPod(namespace, controller.Name, "controller")
 	for _, p := range ports {
-		metricsUrl := path.Join(net.JoinHostPort(target.Status.PodIP, strconv.Itoa(p)), "metrics")
-		metrics, err := podExecutor.Exec("wget", "-qO-", metricsUrl)
+		metricsURL := path.Join(net.JoinHostPort(target.Status.PodIP, strconv.Itoa(p)), "metrics")
+		metrics, err := podExecutor.Exec("wget", "-qO-", metricsURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to scrape metrics for %s", target.Name)
 		}

--- a/e2etest/pkg/metrics/prometheus.go
+++ b/e2etest/pkg/metrics/prometheus.go
@@ -14,7 +14,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-// ValidateOnPrometheus checks the existance of the given metric directly on prometheus pods.
+// ValidateOnPrometheus checks the existence of the given metric directly on prometheus pods.
 func ValidateOnPrometheus(prometheusPod *corev1.Pod, query string, expected CheckType) error {
 	exec := executor.ForPod(prometheusPod.Namespace, prometheusPod.Name, prometheusPod.Spec.Containers[0].Name)
 	url := fmt.Sprintf("localhost:9090/api/v1/query?%s", (url.Values{"query": []string{query}}).Encode())

--- a/e2etest/pkg/routes/patch.go
+++ b/e2etest/pkg/routes/patch.go
@@ -55,7 +55,7 @@ func Delete(exec executor.Executor, target, via, routingTable string) error {
 	args = append(args, dst.String(), "via", gw.String())
 	out, err := exec.Exec(cmd, args...)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to delete route %s", out)
+		return errors.Wrapf(err, "failed to delete route %s", out)
 	}
 
 	return nil

--- a/e2etest/pkg/routes/routes.go
+++ b/e2etest/pkg/routes/routes.go
@@ -29,7 +29,7 @@ func init() {
 // (or in the current host) to reach the service ip.
 func ForIP(target string, exec executor.Executor) []net.IP {
 	dst := net.ParseIP(target)
-	framework.ExpectNotEqual(dst, nil, "Failed to convert", target, "to ip")
+	framework.ExpectNotEqual(dst, nil, "failed to convert", target, "to ip")
 
 	re := Ipv4Re
 	res, err := exec.Exec("ip", []string{"route", "show", target}...)
@@ -61,7 +61,7 @@ func ForIP(target string, exec executor.Executor) []net.IP {
 			continue
 		}
 		netIP := net.ParseIP(ip)
-		framework.ExpectNotEqual(netIP, nil, "Failed to convert", ip, "to ip")
+		framework.ExpectNotEqual(netIP, nil, "failed to convert", ip, "to ip")
 		routes = append(routes, netIP)
 	}
 

--- a/e2etest/pkg/service/create.go
+++ b/e2etest/pkg/service/create.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -49,11 +48,11 @@ func Delete(cs clientset.Interface, svc *corev1.Service) {
 	framework.ExpectNoError(err)
 }
 
-func tweakServicePort(svc *v1.Service, port int) {
+func tweakServicePort(svc *corev1.Service, port int) {
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(port)
 }
 
-func tweakRCPort(rc *v1.ReplicationController, port int) {
+func tweakRCPort(rc *corev1.ReplicationController, port int) {
 	rc.Spec.Template.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", port), fmt.Sprintf("--udp-port=%d", port)}
 	rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(port)
 }

--- a/e2etest/pkg/wget/wget.go
+++ b/e2etest/pkg/wget/wget.go
@@ -16,7 +16,7 @@ const (
 
 func Do(address string, exc executor.Executor) error {
 	retrycnt := 0
-	code := 0
+	var code int
 	var err error
 
 	// Retry loop to handle wget NetworkFailure errors

--- a/e2etest/webhookstests/webhooks.go
+++ b/e2etest/webhookstests/webhooks.go
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 			ginkgo.By("Deleting the profile used by BGPPeer")
 			err = ConfigUpdater.Client().Delete(context.TODO(), &testBFDProfile, &client.DeleteOptions{})
 			framework.ExpectError(err)
-			Expect(err.Error()).To(ContainSubstring("Failed to delete BFDProfile"))
+			Expect(err.Error()).To(ContainSubstring("failed to delete BFDProfile"))
 
 			ginkgo.By("Deleting the BGPPeer")
 			err = ConfigUpdater.Client().Delete(context.TODO(), &testPeer, &client.DeleteOptions{})

--- a/frr-tools/metrics/collector/bfd.go
+++ b/frr-tools/metrics/collector/bfd.go
@@ -91,7 +91,12 @@ type bfd struct {
 	frrCli vtysh.Cli
 }
 
-func NewBFD(l log.Logger) *bfd {
+func NewBFD(l log.Logger) prometheus.Collector {
+	log := log.With(l, "collector", subsystem)
+	return &bfd{Log: log, frrCli: vtysh.Run}
+}
+
+func mockNewBFD(l log.Logger) *bfd {
 	log := log.With(l, "collector", subsystem)
 	return &bfd{Log: log, frrCli: vtysh.Run}
 }

--- a/frr-tools/metrics/collector/bfd.go
+++ b/frr-tools/metrics/collector/bfd.go
@@ -159,11 +159,11 @@ func getBFDPeers(frrCli vtysh.Cli) (map[string][]bgpfrr.BFDPeer, error) {
 	}
 	res := make(map[string][]bgpfrr.BFDPeer)
 	for _, vrf := range vrfs {
-		peersJson, err := frrCli(fmt.Sprintf("show bfd vrf %s peers json", vrf))
+		peersJSON, err := frrCli(fmt.Sprintf("show bfd vrf %s peers json", vrf))
 		if err != nil {
 			return nil, err
 		}
-		peers, err := bgpfrr.ParseBFDPeers(peersJson)
+		peers, err := bgpfrr.ParseBFDPeers(peersJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -180,13 +180,13 @@ func getBFDPeersCounters(frrCli vtysh.Cli) (map[string][]bfdPeerCounters, error)
 
 	res := make(map[string][]bfdPeerCounters)
 	for _, vrf := range vrfs {
-		countersJson, err := frrCli(fmt.Sprintf("show bfd vrf %s peers counters json", vrf))
+		countersJSON, err := frrCli(fmt.Sprintf("show bfd vrf %s peers counters json", vrf))
 		if err != nil {
 			return nil, err
 		}
 
 		parseRes := []bfdPeerCounters{}
-		err = json.Unmarshal([]byte(countersJson), &parseRes)
+		err = json.Unmarshal([]byte(countersJSON), &parseRes)
 		if err != nil {
 			return nil, err
 		}

--- a/frr-tools/metrics/collector/bfd_test.go
+++ b/frr-tools/metrics/collector/bfd_test.go
@@ -221,6 +221,5 @@ func TestBFDCollect(t *testing.T) {
 				t.Errorf("expected no error but got %s", err)
 			}
 		})
-
 	}
 }

--- a/frr-tools/metrics/collector/bfd_test.go
+++ b/frr-tools/metrics/collector/bfd_test.go
@@ -200,7 +200,7 @@ func TestBFDCollect(t *testing.T) {
 			}
 
 			l := log.NewNopLogger()
-			collector := NewBFD(l)
+			collector := mockNewBFD(l)
 			cmdOutput := map[string]string{
 				"show bgp vrf all json":                    vrfVtysh,
 				"show bfd vrf default peers json":          test.vtyshPeersOutput,

--- a/frr-tools/metrics/collector/bgp.go
+++ b/frr-tools/metrics/collector/bgp.go
@@ -179,7 +179,6 @@ func getBGPNeighbors(frrCli vtysh.Cli) (map[string][]*bgpfrr.Neighbor, error) {
 			return nil, err
 		}
 		neighbors[vrf] = neighborsPerVRF
-
 	}
 	return neighbors, nil
 }

--- a/frr-tools/metrics/collector/bgp.go
+++ b/frr-tools/metrics/collector/bgp.go
@@ -144,7 +144,7 @@ func updateNeighborsMetrics(ch chan<- prometheus.Metric, neighbors map[string][]
 			if !n.Connected {
 				sessionUp = 0
 			}
-			peerLabel := fmt.Sprintf("%s:%d", n.Ip.String(), n.Port)
+			peerLabel := fmt.Sprintf("%s:%d", n.IP.String(), n.Port)
 
 			ch <- prometheus.MustNewConstMetric(sessionUpDesc, prometheus.GaugeValue, float64(sessionUp), peerLabel, vrf)
 			ch <- prometheus.MustNewConstMetric(prefixesDesc, prometheus.GaugeValue, float64(n.PrefixSent), peerLabel, vrf)

--- a/frr-tools/metrics/collector/bgp.go
+++ b/frr-tools/metrics/collector/bgp.go
@@ -107,7 +107,12 @@ type bgp struct {
 	frrCli vtysh.Cli
 }
 
-func NewBGP(l log.Logger) *bgp {
+func NewBGP(l log.Logger) prometheus.Collector {
+	log := log.With(l, "collector", bgpmetrics.Subsystem)
+	return &bgp{Log: log, frrCli: vtysh.Run}
+}
+
+func mocknewBGP(l log.Logger) *bgp {
 	log := log.With(l, "collector", bgpmetrics.Subsystem)
 	return &bgp{Log: log, frrCli: vtysh.Run}
 }

--- a/frr-tools/metrics/collector/bgp_test.go
+++ b/frr-tools/metrics/collector/bgp_test.go
@@ -484,6 +484,5 @@ func TestCollect(t *testing.T) {
 				t.Errorf("expected no error but got %s", err)
 			}
 		})
-
 	}
 }

--- a/frr-tools/metrics/collector/bgp_test.go
+++ b/frr-tools/metrics/collector/bgp_test.go
@@ -466,7 +466,7 @@ func TestCollect(t *testing.T) {
 			}
 
 			l := log.NewNopLogger()
-			collector := NewBGP(l)
+			collector := mocknewBGP(l)
 			cmdOutput := map[string]string{
 				"show bgp vrf all json":               vrfVtysh,
 				"show bgp vrf default neighbors json": tc.vtyshOutput,

--- a/frr-tools/metrics/liveness/liveness_test.go
+++ b/frr-tools/metrics/liveness/liveness_test.go
@@ -53,8 +53,6 @@ func TestLiveness(t *testing.T) {
 			if res.StatusCode != test.expectedStatusCode {
 				t.Errorf("status code %d different from expected %d", res.StatusCode, test.expectedStatusCode)
 			}
-
 		})
 	}
-
 }

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1374,7 +1374,7 @@ func TestAllocation(t *testing.T) {
 			unassign: true,
 			ipFamily: ipfamily.IPv6,
 		},
-		//Dual-stack test cases
+		// Dual-stack test cases
 		{
 			desc:     "s1 gets dual-stack IPs",
 			svcKey:   "s1",

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1076,7 +1076,6 @@ func TestPoolAllocation(t *testing.T) {
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("%s: should have caused an error, but did not", test.desc)
-
 			}
 			continue
 		}
@@ -1536,7 +1535,6 @@ func TestBuggyIPs(t *testing.T) {
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("#%d should have caused an error, but did not", i+1)
-
 			}
 			continue
 		}
@@ -1549,7 +1547,6 @@ func TestBuggyIPs(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestConfigReload(t *testing.T) {

--- a/internal/bgp/frr/debounce_test.go
+++ b/internal/bgp/frr/debounce_test.go
@@ -14,7 +14,7 @@ const timer = 10 * time.Millisecond
 const failureTimer = 10 * time.Millisecond
 
 func TestDebounce(t *testing.T) {
-	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	result := make(chan *frrConfig, 10) // buffered to accommodate spurious rewrites
 	dummyUpdate := func(config *frrConfig) error {
 		result <- config
 		return nil
@@ -52,7 +52,7 @@ func TestDebounce(t *testing.T) {
 }
 
 func TestDebounceRetry(t *testing.T) {
-	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	result := make(chan *frrConfig, 10) // buffered to accommodate spurious rewrites
 	count := 0
 	dummyUpdate := func(config *frrConfig) error {
 		count++
@@ -83,7 +83,7 @@ func TestDebounceRetry(t *testing.T) {
 }
 
 func TestDebounceReuseOld(t *testing.T) {
-	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	result := make(chan *frrConfig, 10) // buffered to accommodate spurious rewrites
 	dummyUpdate := func(config *frrConfig) error {
 		result <- config
 		return nil
@@ -118,7 +118,7 @@ func TestDebounceReuseOld(t *testing.T) {
 }
 
 func TestDebounceSameConfig(t *testing.T) {
-	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	result := make(chan *frrConfig, 10) // buffered to accommodate spurious rewrites
 	dummyUpdate := func(config *frrConfig) error {
 		result <- config
 		return nil

--- a/internal/bgp/frr/frr_bfd_test.go
+++ b/internal/bgp/frr/frr_bfd_test.go
@@ -40,7 +40,7 @@ func TestBFDProfileNoSessions(t *testing.T) {
 		},
 	}
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	err := sessionManager.SyncBFDProfiles(pp)
@@ -72,7 +72,7 @@ func TestBFDProfileCornerCases(t *testing.T) {
 	}
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	err := sessionManager.SyncBFDProfiles(pp)
@@ -114,7 +114,7 @@ func TestBFDWithSession(t *testing.T) {
 	}
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	err := sessionManager.SyncBFDProfiles(pp)
@@ -168,7 +168,7 @@ func TestBFDProfileAllDefault(t *testing.T) {
 	}
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	err := sessionManager.SyncBFDProfiles(pp)

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -101,7 +101,7 @@ func TestSingleEBGPSessionMultiHop(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -128,7 +128,7 @@ func TestSingleEBGPSessionOneHop(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -156,7 +156,7 @@ func TestSingleIPv6EBGPSessionOneHop(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -184,7 +184,7 @@ func TestSingleIBGPSession(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -212,7 +212,7 @@ func TestSingleIPv6IBGPSession(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -239,7 +239,7 @@ func TestSingleSessionClose(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	session, err := sessionManager.NewSession(l,
@@ -267,7 +267,7 @@ func TestTwoSessions(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session1, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -313,7 +313,7 @@ func TestTwoIPv6Sessions(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	session1, err := sessionManager.NewSession(l,
@@ -358,7 +358,7 @@ func TestTwoSessionsDuplicate(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session1, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -403,7 +403,7 @@ func TestTwoSessionsDuplicateRouter(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	session1, err := sessionManager.NewSession(l,
@@ -449,7 +449,7 @@ func TestSingleAdvertisement(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -496,7 +496,7 @@ func TestSingleAdvertisementNoRouterID(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -538,7 +538,7 @@ func TestSingleAdvertisementInvalidNoPort(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -566,7 +566,7 @@ func TestSingleAdvertisementStop(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -613,7 +613,7 @@ func TestSingleAdvertisementChange(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -668,7 +668,7 @@ func TestSingleAdvertisementWithPeerSelector(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	session, err := sessionManager.NewSession(l,
@@ -717,7 +717,7 @@ func TestSingleAdvertisementNonExistingPeer(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -765,7 +765,7 @@ func TestTwoAdvertisements(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -818,7 +818,7 @@ func TestTwoAdvertisementsTwoSessions(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -895,7 +895,7 @@ func TestTwoAdvertisementsTwoSessionsOneWithPeerSelector(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -973,7 +973,7 @@ func TestSingleSessionExtras(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	err := sessionManager.SyncExtraInfo("# hello")
 	if err != nil {
@@ -1005,7 +1005,7 @@ func TestLoggingConfiguration(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelWarn)
+	sessionManager := mockNewSessionManager(l, logging.LevelWarn)
 	defer close(sessionManager.reloadConfig)
 
 	config, err := sessionManager.createConfig()
@@ -1021,7 +1021,7 @@ func TestLoggingConfigurationDebug(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelDebug)
+	sessionManager := mockNewSessionManager(l, logging.LevelDebug)
 	defer close(sessionManager.reloadConfig)
 
 	config, err := sessionManager.createConfig()
@@ -1041,7 +1041,7 @@ func TestLoggingConfigurationOverrideByEnvironmentVar(t *testing.T) {
 	t.Cleanup(func() { os.Setenv("FRR_LOGGING_LEVEL", orig) })
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelDebug)
+	sessionManager := mockNewSessionManager(l, logging.LevelDebug)
 	defer close(sessionManager.reloadConfig)
 
 	config, err := sessionManager.createConfig()

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -31,7 +31,6 @@ func testOsHostname() (string, error) {
 }
 
 func testCompareFiles(t *testing.T, configFile, goldenFile string) {
-
 	var lastError error
 
 	// Try comparing files multiple times because tests can generate more than one configuration

--- a/internal/bgp/frr/frr_vrf_test.go
+++ b/internal/bgp/frr/frr_vrf_test.go
@@ -17,7 +17,7 @@ func TestVRFSingleEBGPSessionMultiHop(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -45,7 +45,7 @@ func TestSingleVRFIBGPSession(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -74,7 +74,7 @@ func TestTwoSessionsOneVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session1, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -121,7 +121,7 @@ func TestTwoSessionsSameIPVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session1, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -168,7 +168,7 @@ func TestTwoSessionsSameIPRouterIDASNVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session1, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -211,7 +211,7 @@ func TestSingleAdvertisementVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -259,7 +259,7 @@ func TestSingleAdvertisementChangeVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -315,7 +315,7 @@ func TestSingleAdvertisementWithPeerSelectorVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 
 	session, err := sessionManager.NewSession(l,
@@ -365,7 +365,7 @@ func TestTwoAdvertisementsVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -419,7 +419,7 @@ func TestTwoAdvertisementsTwoSessionsOneVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -497,7 +497,7 @@ func TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{
@@ -577,7 +577,7 @@ func TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector(t *testing.T) {
 	testSetup(t)
 
 	l := log.NewNopLogger()
-	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
 	defer close(sessionManager.reloadConfig)
 	session, err := sessionManager.NewSession(l,
 		bgp.SessionParameters{

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Neighbor struct {
-	Ip             net.IP
+	IP             net.IP
 	VRF            string
 	Connected      bool
 	LocalAS        string
@@ -128,7 +128,7 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		return &Neighbor{
-			Ip:             ip,
+			IP:             ip,
 			Connected:      connected,
 			LocalAS:        strconv.Itoa(n.LocalAs),
 			RemoteAS:       strconv.Itoa(n.RemoteAs),
@@ -165,7 +165,7 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		res = append(res, &Neighbor{
-			Ip:             ip,
+			IP:             ip,
 			Connected:      connected,
 			LocalAS:        strconv.Itoa(n.LocalAs),
 			RemoteAS:       strconv.Itoa(n.RemoteAs),

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -101,7 +101,7 @@ type BFDPeer struct {
 }
 
 // parseNeighbour takes the result of a show bgp neighbor x.y.w.z
-// and parses the informations related to the neighbor.
+// and parses the informations related to the neighbour.
 func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 	res := map[string]FRRNeighbor{}
 	err := json.Unmarshal([]byte(vtyshRes), &res)

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -101,7 +101,7 @@ type BFDPeer struct {
 }
 
 // parseNeighbour takes the result of a show bgp neighbor x.y.w.z
-// and parses the informations related to the neighbour.
+// and parses the informations related to the neighbor.
 func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 	res := map[string]FRRNeighbor{}
 	err := json.Unmarshal([]byte(vtyshRes), &res)

--- a/internal/bgp/frr/parse_test.go
+++ b/internal/bgp/frr/parse_test.go
@@ -151,8 +151,8 @@ func TestNeighbour(t *testing.T) {
 			if err != nil {
 				t.Fatal("Failed to parse ", err)
 			}
-			if !n.Ip.Equal(net.ParseIP(tt.neighborIP)) {
-				t.Fatal("Expected neighbour ip", tt.neighborIP, "got", n.Ip.String())
+			if !n.IP.Equal(net.ParseIP(tt.neighborIP)) {
+				t.Fatal("Expected neighbour ip", tt.neighborIP, "got", n.IP.String())
 			}
 			if n.RemoteAS != tt.remoteAS {
 				t.Fatal("Expected remote as", tt.remoteAS, "got", n.RemoteAS)
@@ -499,16 +499,16 @@ func TestNeighbours(t *testing.T) {
 		t.Fatalf("Expected 4 neighbours, got %d", len(nn))
 	}
 	sort.Slice(nn, func(i, j int) bool {
-		return (bytes.Compare(nn[i].Ip, nn[j].Ip) < 0)
+		return (bytes.Compare(nn[i].IP, nn[j].IP) < 0)
 	})
 
-	if !nn[0].Ip.Equal(net.ParseIP("172.18.0.2")) {
+	if !nn[0].IP.Equal(net.ParseIP("172.18.0.2")) {
 		t.Fatal("neighbour ip not matching")
 	}
-	if !nn[1].Ip.Equal(net.ParseIP("172.18.0.3")) {
+	if !nn[1].IP.Equal(net.ParseIP("172.18.0.3")) {
 		t.Fatal("neighbour ip not matching")
 	}
-	if !nn[2].Ip.Equal(net.ParseIP("172.18.0.4")) {
+	if !nn[2].IP.Equal(net.ParseIP("172.18.0.4")) {
 		t.Fatal("neighbour ip not matching")
 	}
 

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -281,7 +281,7 @@ func (s *session) connect() error {
 	return nil
 }
 
-func hashRouterId(hostname string) (net.IP, error) {
+func hashRouterID(hostname string) (net.IP, error) {
 	buf := new(bytes.Buffer)
 	err := binary.Write(buf, binary.LittleEndian, crc32.ChecksumIEEE([]byte(hostname)))
 	if err != nil {
@@ -299,7 +299,7 @@ func getRouterID(addr net.IP, myNode string) (net.IP, error) {
 
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return hashRouterId(myNode)
+		return hashRouterID(myNode)
 	}
 	for _, i := range ifaces {
 		addrs, err := i.Addrs()
@@ -330,11 +330,11 @@ func getRouterID(addr net.IP, myNode string) (net.IP, error) {
 						return ip, nil
 					}
 				}
-				return hashRouterId(myNode)
+				return hashRouterID(myNode)
 			}
 		}
 	}
-	return hashRouterId(myNode)
+	return hashRouterID(myNode)
 }
 
 // sendKeepalives sends BGP KEEPALIVE packets at the negotiated rate
@@ -508,11 +508,11 @@ func dialMD5(ctx context.Context, addr string, srcAddr net.IP, password string) 
 	if srcAddr != nil {
 		ifs, err := net.Interfaces()
 		if err != nil {
-			return nil, fmt.Errorf("Querying local interfaces: %w", err)
+			return nil, fmt.Errorf("querying local interfaces: %w", err)
 		}
 
 		if !localAddressExists(ifs, srcAddr) {
-			return nil, fmt.Errorf("Address %q doesn't exist on this host", srcAddr)
+			return nil, fmt.Errorf("address %q doesn't exist on this host", srcAddr)
 		}
 
 		a = fmt.Sprintf("[%s]", srcAddr.String())
@@ -520,7 +520,7 @@ func dialMD5(ctx context.Context, addr string, srcAddr net.IP, password string) 
 
 	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", a))
 	if err != nil {
-		return nil, fmt.Errorf("Error resolving local address: %s ", err)
+		return nil, fmt.Errorf("error resolving local address: %s ", err)
 	}
 
 	raddr, err := net.ResolveTCPAddr("tcp", addr)

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -496,9 +496,9 @@ func (s *session) Close() error {
 }
 
 // DialTCP does the part of creating a connection manually,  including setting the
-// proper TCP MD5 options when the password is not empty. Works by manupulating
+// proper TCP MD5 options when the password is not empty. Works by manipulating
 // the low level FD's, skipping the net.Conn API as it has not hooks to set
-// the neccessary sockopts for TCP MD5.
+// the necessary sockopts for TCP MD5.
 func dialMD5(ctx context.Context, addr string, srcAddr net.IP, password string) (net.Conn, error) {
 	// If srcAddr exists on any of the local network interfaces, use it as the
 	// source address of the TCP socket. Otherwise, use the IPv6 unspecified

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -49,7 +49,7 @@ type session struct {
 type sessionManager struct {
 }
 
-func NewSessionManager(l log.Logger) *sessionManager {
+func NewSessionManager(l log.Logger) bgp.SessionManager {
 	return &sessionManager{}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -935,13 +935,13 @@ func getCommunityValue(community string, communities map[string]uint32) (uint32,
 	}
 
 	v, err := ParseCommunity(community)
-	if errors.Is(err, invalidCommunityValue) {
+	if errors.Is(err, errInvalidaCommunityValue) {
 		return 0, err
 	}
 
 	// Return TransientError on invalidCommunityFormat, in case it refers
 	// a Community resource that doesn't exist yet.
-	if errors.Is(err, invalidCommunityFormat) {
+	if errors.Is(err, errInvalidCommunityFormat) {
 		return 0, TransientError{err.Error()}
 	}
 
@@ -1018,21 +1018,21 @@ func advertisementsAreCompatible(newAdv, adv *BGPAdvertisement) bool {
 	return true
 }
 
-var invalidCommunityValue = errors.New("invalid community value")
-var invalidCommunityFormat = errors.New("invalid community format")
+var errInvalidaCommunityValue = errors.New("invalid community value")
+var errInvalidCommunityFormat = errors.New("invalid community format")
 
 func ParseCommunity(c string) (uint32, error) {
 	fs := strings.Split(c, ":")
 	if len(fs) != 2 {
-		return 0, fmt.Errorf("%w: %s", invalidCommunityFormat, c)
+		return 0, fmt.Errorf("%w: %s", errInvalidCommunityFormat, c)
 	}
 	a, err := strconv.ParseUint(fs[0], 10, 16)
 	if err != nil {
-		return 0, fmt.Errorf("%w: invalid first section of community %q: %s", invalidCommunityValue, fs[0], err)
+		return 0, fmt.Errorf("%w: invalid first section of community %q: %s", errInvalidaCommunityValue, fs[0], err)
 	}
 	b, err := strconv.ParseUint(fs[1], 10, 16)
 	if err != nil {
-		return 0, fmt.Errorf("%w: invalid second section of community %q: %s", invalidCommunityValue, fs[1], err)
+		return 0, fmt.Errorf("%w: invalid second section of community %q: %s", errInvalidaCommunityValue, fs[1], err)
 	}
 
 	return (uint32(a) << 16) + uint32(b), nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,7 +260,7 @@ func bfdProfilesFor(resources ClusterResources) (map[string]*BFDProfile, error) 
 }
 
 func peersFor(resources ClusterResources, BFDProfiles map[string]*BFDProfile) (map[string]*Peer, error) {
-	var res map[string]*Peer = make(map[string]*Peer)
+	var res = make(map[string]*Peer)
 	for _, p := range resources.Peers {
 		peer, err := peerFromCR(p, resources.PasswordSecrets)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1172,10 +1172,8 @@ OUTER:
 				continue OUTER
 			}
 		}
-
 	}
 	return res, nil
-
 }
 
 func selectedPools(pools []metallbv1beta1.IPAddressPool, selectors []metav1.LabelSelector) ([]string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1962,7 +1962,7 @@ func TestParse(t *testing.T) {
 				},
 				PasswordSecrets: map[string]corev1.Secret{
 					"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: v1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"},
-						Data: map[string][]byte{"password": []byte([]byte("nopass"))}},
+						Data: map[string][]byte{"password": []byte("nopass")}},
 				},
 			},
 			want: &Config{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,9 +12,7 @@ import (
 	"go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/metallb/internal/pointer"
 	corev1 "k8s.io/api/core/v1"
-	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -39,7 +37,7 @@ func TestParse(t *testing.T) {
 	testAdvName := "testAdv"
 	testPoolName := "testPool"
 	testPool := v1beta1.IPAddressPool{
-		ObjectMeta: v1.ObjectMeta{Name: testPoolName},
+		ObjectMeta: metav1.ObjectMeta{Name: testPoolName},
 		Spec: v1beta1.IPAddressPoolSpec{
 			Addresses: []string{
 				"10.20.0.0/16",
@@ -66,7 +64,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -74,7 +72,7 @@ func TestParse(t *testing.T) {
 							ASN:          142,
 							Address:      "1.2.3.4",
 							Port:         1179,
-							HoldTime:     v1.Duration{Duration: 180 * time.Second},
+							HoldTime:     metav1.Duration{Duration: 180 * time.Second},
 							RouterID:     "10.20.30.40",
 							SrcAddress:   "10.20.30.40",
 							EBGPMultiHop: true,
@@ -82,7 +80,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer2",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -90,12 +88,12 @@ func TestParse(t *testing.T) {
 							ASN:          200,
 							Address:      "2.3.4.5",
 							EBGPMultiHop: false,
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{
 										"foo": "bar",
 									},
-									MatchExpressions: []v1.LabelSelectorRequirement{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Key:      "bar",
 											Operator: "In",
@@ -109,7 +107,7 @@ func TestParse(t *testing.T) {
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -122,7 +120,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool2",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -132,7 +130,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool3",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -145,7 +143,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool4",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -157,7 +155,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -169,7 +167,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv2",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -179,7 +177,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -189,7 +187,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -197,14 +195,14 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv2",
 						},
 					},
 				},
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -335,7 +333,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -350,7 +348,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool2",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -358,11 +356,11 @@ func TestParse(t *testing.T) {
 								"30.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 2,
-								NamespaceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}}},
+								NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}}},
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool3",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -370,18 +368,18 @@ func TestParse(t *testing.T) {
 								"40.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 3,
-								NamespaceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"team": "red"}}}},
+								NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"team": "red"}}}},
 						},
 					},
 				},
 				Namespaces: []corev1.Namespace{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-ns1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "test-ns2",
 							Labels: map[string]string{"team": "metallb"},
 						},
@@ -422,7 +420,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -439,7 +437,7 @@ func TestParse(t *testing.T) {
 				},
 				Namespaces: []corev1.Namespace{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-ns1",
 						},
 					},
@@ -452,7 +450,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -464,7 +462,7 @@ func TestParse(t *testing.T) {
 							AutoAssign:    pointer.BoolPtr(false),
 							AllocateTo: &v1beta1.ServiceAllocation{
 								Priority: 1,
-								NamespaceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}},
+								NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}},
 									{MatchLabels: map[string]string{"foo": "bar"}}},
 							},
 						},
@@ -472,7 +470,7 @@ func TestParse(t *testing.T) {
 				},
 				Namespaces: []corev1.Namespace{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "test-ns1",
 							Labels: map[string]string{"foo": "bar"},
 						},
@@ -486,7 +484,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -494,11 +492,11 @@ func TestParse(t *testing.T) {
 								"30.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 2,
-								ServiceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}}},
+								ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}}},
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool2",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -506,7 +504,7 @@ func TestParse(t *testing.T) {
 								"40.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 3,
-								ServiceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"team": "red"}}}},
+								ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"team": "red"}}}},
 						},
 					},
 				},
@@ -537,7 +535,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -545,7 +543,7 @@ func TestParse(t *testing.T) {
 								"30.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 2,
-								ServiceSelectors: []v1.LabelSelector{{MatchExpressions: []metav1.LabelSelectorRequirement{
+								ServiceSelectors: []metav1.LabelSelector{{MatchExpressions: []metav1.LabelSelectorRequirement{
 									{
 										Key:      "foo",
 										Operator: metav1.LabelSelectorOpIn,
@@ -563,7 +561,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -572,11 +570,11 @@ func TestParse(t *testing.T) {
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 2,
 								Namespaces:       []string{"test-ns1"},
-								ServiceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"testsvc-1": "1"}}}},
+								ServiceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"testsvc-1": "1"}}}},
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool2",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -584,19 +582,19 @@ func TestParse(t *testing.T) {
 								"40.0.0.0/8",
 							},
 							AllocateTo: &v1beta1.ServiceAllocation{Priority: 3,
-								NamespaceSelectors: []v1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}},
-								ServiceSelectors:   []v1.LabelSelector{{MatchLabels: map[string]string{"testsvc-2": "2"}}}},
+								NamespaceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"team": "metallb"}}},
+								ServiceSelectors:   []metav1.LabelSelector{{MatchLabels: map[string]string{"testsvc-2": "2"}}}},
 						},
 					},
 				},
 				Namespaces: []corev1.Namespace{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-ns1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "test-ns2",
 							Labels: map[string]string{"team": "metallb"},
 						},
@@ -727,7 +725,7 @@ func TestParse(t *testing.T) {
 							MyASN:    42,
 							ASN:      42,
 							Address:  "1.2.3.4",
-							HoldTime: v1.Duration{Duration: time.Second},
+							HoldTime: metav1.Duration{Duration: time.Second},
 						},
 					},
 				},
@@ -753,7 +751,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -789,12 +787,12 @@ func TestParse(t *testing.T) {
 							MyASN:   42,
 							ASN:     42,
 							Address: "1.2.3.4",
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{
 										"foo": "bar",
 									},
-									MatchExpressions: []v1.LabelSelectorRequirement{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Operator: "In",
 											Values:   []string{"quux"},
@@ -816,12 +814,12 @@ func TestParse(t *testing.T) {
 							MyASN:   42,
 							ASN:     42,
 							Address: "1.2.3.4",
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{
 										"foo": "bar",
 									},
-									MatchExpressions: []v1.LabelSelectorRequirement{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Key:    "bar",
 											Values: []string{"quux"},
@@ -843,12 +841,12 @@ func TestParse(t *testing.T) {
 							MyASN:   42,
 							ASN:     42,
 							Address: "1.2.3.4",
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{
 										"foo": "bar",
 									},
-									MatchExpressions: []v1.LabelSelectorRequirement{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Key:      "bar",
 											Operator: "surrounds",
@@ -867,7 +865,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -875,12 +873,12 @@ func TestParse(t *testing.T) {
 							ASN:          200,
 							Address:      "2.3.4.5",
 							EBGPMultiHop: false,
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{
 										"foo": "bar",
 									},
-									MatchExpressions: []v1.LabelSelectorRequirement{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Key:      "bar",
 											Operator: metav1.LabelSelectorOpIn,
@@ -928,7 +926,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec:       v1beta1.IPAddressPoolSpec{},
 					},
 				},
@@ -939,7 +937,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 					},
 				},
 			},
@@ -949,7 +947,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"100.200.300.400/24",
@@ -964,7 +962,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"1.2.3.0/33",
@@ -979,7 +977,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"1.2.3.10-1.2.3.1",
@@ -994,7 +992,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"1.2.3.0/24",
@@ -1004,7 +1002,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
@@ -1036,7 +1034,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"1.2.3.0/24",
@@ -1046,7 +1044,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
@@ -1078,7 +1076,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"1.2.3.10-1.2.3.1",
@@ -1100,7 +1098,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1121,21 +1119,21 @@ func TestParse(t *testing.T) {
 		{
 			desc: "different local pref - same peers and nodes",
 			crs: ClusterResources{
-				Nodes: []v1core.Node{
+				Nodes: []corev1.Node{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 						},
 					},
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1160,21 +1158,21 @@ func TestParse(t *testing.T) {
 		{
 			desc: "different local pref - different ipv4 aggregation length",
 			crs: ClusterResources{
-				Nodes: []v1core.Node{
+				Nodes: []corev1.Node{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 						},
 					},
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1200,21 +1198,21 @@ func TestParse(t *testing.T) {
 		{
 			desc: "different local pref - different aggregation lengths",
 			crs: ClusterResources{
-				Nodes: []v1core.Node{
+				Nodes: []corev1.Node{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 						},
 					},
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1270,15 +1268,15 @@ func TestParse(t *testing.T) {
 		{
 			desc: "different local pref - same peers & different nodes",
 			crs: ClusterResources{
-				Nodes: []v1core.Node{
+				Nodes: []corev1.Node{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "node1",
 							Labels: map[string]string{"node": "node1"},
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "node2",
 							Labels: map[string]string{"node": "node2"},
 						},
@@ -1286,7 +1284,7 @@ func TestParse(t *testing.T) {
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1298,7 +1296,7 @@ func TestParse(t *testing.T) {
 					{
 						Spec: v1beta1.BGPAdvertisementSpec{
 							LocalPref: 100,
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{"node": "node1"},
 								},
@@ -1308,7 +1306,7 @@ func TestParse(t *testing.T) {
 					{
 						Spec: v1beta1.BGPAdvertisementSpec{
 							LocalPref: 200,
-							NodeSelectors: []v1.LabelSelector{
+							NodeSelectors: []metav1.LabelSelector{
 								{
 									MatchLabels: map[string]string{"node": "node2"},
 								},
@@ -1350,21 +1348,21 @@ func TestParse(t *testing.T) {
 		{
 			desc: "different local pref - different peers & same nodes",
 			crs: ClusterResources{
-				Nodes: []v1core.Node{
+				Nodes: []corev1.Node{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 						},
 					},
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.20.30.40/24",
@@ -1424,7 +1422,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"3.3.3.2-3.3.3.254",
@@ -1479,7 +1477,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"3.3.3.2-3.3.3.254",
@@ -1502,7 +1500,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.L2AdvertisementSpec{
 							IPAddressPools: []string{testPoolName, testPoolName},
 						},
@@ -1516,7 +1514,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							IPAddressPools: []string{testPoolName, testPoolName},
 						},
@@ -1530,7 +1528,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -1542,7 +1540,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							IPAddressPools: []string{testPoolName},
 							Peers:          []string{"peer1", "peer1"},
@@ -1557,7 +1555,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							Communities:    []string{"1234"},
 							IPAddressPools: []string{testPoolName},
@@ -1572,7 +1570,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							Communities:    []string{"99999999:1"},
 							IPAddressPools: []string{testPoolName},
@@ -1587,7 +1585,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							Communities:    []string{"1:99999999"},
 							IPAddressPools: []string{testPoolName},
@@ -1602,7 +1600,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							Communities:    []string{"community"},
 							IPAddressPools: []string{testPoolName},
@@ -1617,7 +1615,7 @@ func TestParse(t *testing.T) {
 				Pools: []v1beta1.IPAddressPool{testPool},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: testAdvName},
+						ObjectMeta: metav1.ObjectMeta{Name: testAdvName},
 						Spec: v1beta1.BGPAdvertisementSpec{
 							Communities:    []string{"1234:5678", "1234:5678"},
 							IPAddressPools: []string{testPoolName},
@@ -1631,7 +1629,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1651,7 +1649,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1671,7 +1669,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1691,7 +1689,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community1",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1704,7 +1702,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community2",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1724,7 +1722,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -1748,15 +1746,15 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec:       v1beta1.IPAddressPoolSpec{},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool2"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool2"},
 						Spec:       v1beta1.IPAddressPoolSpec{},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec:       v1beta1.IPAddressPoolSpec{},
 					},
 				},
@@ -1767,7 +1765,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								" 10.0.0.0/8",
@@ -1775,7 +1773,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool2"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool2"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								" 10.0.0.0/8",
@@ -1790,7 +1788,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								" 10.0.0.0/8",
@@ -1798,7 +1796,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "pool2"},
+						ObjectMeta: metav1.ObjectMeta{Name: "pool2"},
 						Spec: v1beta1.IPAddressPoolSpec{
 							Addresses: []string{
 								"10.0.0.0/16",
@@ -1813,7 +1811,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -1826,7 +1824,7 @@ func TestParse(t *testing.T) {
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -1838,14 +1836,14 @@ func TestParse(t *testing.T) {
 				},
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
 						},
 					},
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
@@ -1919,7 +1917,7 @@ func TestParse(t *testing.T) {
 					},
 				},
 				PasswordSecrets: map[string]corev1.Secret{
-					"bgpsecret": {Type: corev1.SecretTypeOpaque, ObjectMeta: v1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"}},
+					"bgpsecret": {Type: corev1.SecretTypeOpaque, ObjectMeta: metav1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"}},
 				},
 			},
 		},
@@ -1938,7 +1936,7 @@ func TestParse(t *testing.T) {
 					},
 				},
 				PasswordSecrets: map[string]corev1.Secret{
-					"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: v1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"}},
+					"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: metav1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"}},
 				},
 			},
 		},
@@ -1947,7 +1945,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -1961,7 +1959,7 @@ func TestParse(t *testing.T) {
 					},
 				},
 				PasswordSecrets: map[string]corev1.Secret{
-					"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: v1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"},
+					"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: metav1.ObjectMeta{Name: "bgpsecret", Namespace: "metallb-system"},
 						Data: map[string][]byte{"password": []byte("nopass")}},
 				},
 			},
@@ -2015,7 +2013,7 @@ func TestParse(t *testing.T) {
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2027,7 +2025,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
@@ -2039,7 +2037,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2051,17 +2049,17 @@ func TestParse(t *testing.T) {
 				},
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "foo",
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "foo",
 						},
 					},
@@ -2073,7 +2071,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2085,7 +2083,7 @@ func TestParse(t *testing.T) {
 				},
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "nondefault",
 						},
 						Spec: v1beta1.BFDProfileSpec{
@@ -2101,7 +2099,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
@@ -2145,7 +2143,7 @@ func TestParse(t *testing.T) {
 
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
 						},
 						Spec: v1beta1.BFDProfileSpec{
@@ -2161,7 +2159,7 @@ func TestParse(t *testing.T) {
 
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
 						},
 						Spec: v1beta1.BFDProfileSpec{
@@ -2176,7 +2174,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2188,7 +2186,7 @@ func TestParse(t *testing.T) {
 				},
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "nondefault",
 						},
 						Spec: v1beta1.BFDProfileSpec{
@@ -2204,14 +2202,14 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv3",
 						},
 					},
 				},
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -2219,7 +2217,7 @@ func TestParse(t *testing.T) {
 							ASN:          142,
 							Address:      "1.2.3.4",
 							Port:         1179,
-							HoldTime:     v1.Duration{Duration: 180 * time.Second},
+							HoldTime:     metav1.Duration{Duration: 180 * time.Second},
 							RouterID:     "10.20.30.40",
 							SrcAddress:   "10.20.30.40",
 							EBGPMultiHop: true,
@@ -2234,7 +2232,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2246,7 +2244,7 @@ func TestParse(t *testing.T) {
 				},
 				BFDProfiles: []v1beta1.BFDProfile{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "with-echo",
 						},
 						Spec: v1beta1.BFDProfileSpec{
@@ -2256,14 +2254,14 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv",
 						},
 					},
 				},
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -2318,7 +2316,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -2326,7 +2324,7 @@ func TestParse(t *testing.T) {
 							ASN:          142,
 							Address:      "1.2.3.4",
 							Port:         1179,
-							HoldTime:     v1.Duration{Duration: 180 * time.Second},
+							HoldTime:     metav1.Duration{Duration: 180 * time.Second},
 							RouterID:     "10.20.30.40",
 							SrcAddress:   "10.20.30.40",
 							EBGPMultiHop: true,
@@ -2335,7 +2333,7 @@ func TestParse(t *testing.T) {
 				},
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2350,7 +2348,7 @@ func TestParse(t *testing.T) {
 				},
 				LegacyAddressPools: []v1beta1.AddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacyl2pool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -2363,7 +2361,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacybgppool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -2385,7 +2383,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2465,7 +2463,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				LegacyAddressPools: []v1beta1.AddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacybgppool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -2487,7 +2485,7 @@ func TestParse(t *testing.T) {
 				},
 				Communities: []v1beta1.Community{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "community",
 						},
 						Spec: v1beta1.CommunitySpec{
@@ -2528,7 +2526,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2543,7 +2541,7 @@ func TestParse(t *testing.T) {
 				},
 				LegacyAddressPools: []v1beta1.AddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacyl2pool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -2556,7 +2554,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacybgppool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -2575,7 +2573,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2586,7 +2584,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool2",
 							Labels: map[string]string{"test": "pool2"},
 						},
@@ -2599,7 +2597,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -2615,7 +2613,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2631,7 +2629,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv2",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2695,7 +2693,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2708,7 +2706,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -2746,7 +2744,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2759,7 +2757,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2787,7 +2785,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2800,7 +2798,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2827,7 +2825,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2840,7 +2838,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -2866,7 +2864,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool1",
 							Labels: map[string]string{"test": "pool1"},
 						},
@@ -2877,7 +2875,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   "pool2",
 							Labels: map[string]string{"test": "pool2"},
 						},
@@ -2890,7 +2888,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -2906,7 +2904,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2922,7 +2920,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv2",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -2965,7 +2963,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2975,7 +2973,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool2",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -2987,7 +2985,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -3002,7 +3000,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv2",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -3019,7 +3017,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -3036,7 +3034,7 @@ func TestParse(t *testing.T) {
 				},
 				LegacyAddressPools: []v1beta1.AddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacyl2pool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -3049,7 +3047,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacybgppool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{
@@ -3155,7 +3153,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -3167,7 +3165,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -3189,7 +3187,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -3233,7 +3231,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -3245,7 +3243,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -3271,7 +3269,7 @@ func TestParse(t *testing.T) {
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 						Spec: v1beta1.L2AdvertisementSpec{
@@ -3314,7 +3312,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -3326,14 +3324,14 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 					},
 				},
 				L2Advs: []v1beta1.L2Advertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "l2adv1",
 						},
 					},
@@ -3392,7 +3390,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				Pools: []v1beta1.IPAddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "pool1",
 						},
 						Spec: v1beta1.IPAddressPoolSpec{
@@ -3404,7 +3402,7 @@ func TestParse(t *testing.T) {
 				},
 				Peers: []v1beta2.BGPPeer{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "peer1",
 						},
 						Spec: v1beta2.BGPPeerSpec{
@@ -3416,7 +3414,7 @@ func TestParse(t *testing.T) {
 				},
 				BGPAdvs: []v1beta1.BGPAdvertisement{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "adv1",
 						},
 						Spec: v1beta1.BGPAdvertisementSpec{
@@ -3467,7 +3465,7 @@ func TestParse(t *testing.T) {
 			crs: ClusterResources{
 				LegacyAddressPools: []v1beta1.AddressPool{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name: "legacybgppool1",
 						},
 						Spec: v1beta1.AddressPoolSpec{

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -91,7 +91,6 @@ func DiscardNativeOnly(c ClusterResources) error {
 				p.Spec.VRFName == p1.Spec.VRFName {
 				return fmt.Errorf("peer %s has myAsn different from %s, in FRR mode all myAsn must be equal for the same VRF", p.Spec.Address, p1.Spec.Address)
 			}
-
 		}
 	}
 	return nil

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -30,9 +30,8 @@ func ForAddresses(ips []string) (Family, error) {
 		ip := net.ParseIP(ips[0])
 		if ip.To4() != nil {
 			return IPv4, nil
-		} else {
-			return IPv6, nil
 		}
+		return IPv6, nil
 	case 2:
 		ip1 := net.ParseIP(ips[0])
 		ip2 := net.ParseIP(ips[1])

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -170,7 +170,7 @@ var requestHandler = func(r *ConfigReconciler, ctx context.Context, req ctrl.Req
 		// which is not what we want here.
 		r.currentConfig = nil
 		level.Error(r.Logger).Log("controller", "ConfigReconciler", "metallb CRs and Secrets", dumpClusterResources(&resources), "event", "reload failed, retry")
-		return ctrl.Result{}, retryError
+		return ctrl.Result{}, errRetry
 	case SyncStateReprocessAll:
 		level.Info(r.Logger).Log("controller", "ConfigReconciler", "event", "force service reload")
 		r.ForceReload()

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -334,7 +334,6 @@ func TestNodeEvent(t *testing.T) {
 		defer mutex.Unlock()
 		return configUpdate
 	}, 5*time.Second, 200*time.Millisecond).Should(Equal(initialConfigUpdateCount + 2))
-
 }
 
 var (

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -227,17 +227,17 @@ func TestNodeEvent(t *testing.T) {
 		Scheme:                scheme,
 	}
 	cfg, err := testEnv.Start()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	defer func() {
 		err = testEnv.Stop()
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}()
 	err = v1beta1.AddToScheme(k8sscheme.Scheme)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	err = v1beta2.AddToScheme(k8sscheme.Scheme)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	m, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	var configUpdate int
 	var mutex sync.Mutex
@@ -259,11 +259,11 @@ func TestNodeEvent(t *testing.T) {
 		ValidateConfig: config.DontValidate,
 	}
 	err = r.SetupWithManager(m)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	ctx := context.Background()
 	go func() {
 		err = m.Start(ctx)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}()
 
 	// count for update on namespace events
@@ -286,7 +286,7 @@ func TestNodeEvent(t *testing.T) {
 	node.Labels = make(map[string]string)
 	node.Labels["test"] = "e2e"
 	err = m.GetClient().Create(ctx, node)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -30,7 +30,6 @@ import (
 	v1beta1 "go.universe.tf/metallb/api/v1beta1"
 	v1beta2 "go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/metallb/internal/config"
-	metallbcfg "go.universe.tf/metallb/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,7 +86,7 @@ func TestConfigController(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		var resources metallbcfg.ClusterResources
+		var resources config.ClusterResources
 		if test.validResources {
 			resources = configControllerValidResources
 		} else {
@@ -105,7 +104,7 @@ func TestConfigController(t *testing.T) {
 			t.Fatalf("test %s failed to create config, got unexpected error: %v", test.desc, err)
 		}
 
-		cmpOpt := cmpopts.IgnoreUnexported(metallbcfg.Pool{})
+		cmpOpt := cmpopts.IgnoreUnexported(config.Pool{})
 
 		mockHandler := func(l log.Logger, cfg *config.Config) SyncState {
 			if !cmp.Equal(expectedCfg, cfg, cmpOpt) {
@@ -339,7 +338,7 @@ func TestNodeEvent(t *testing.T) {
 var (
 	testNamespace                  = "test-controller"
 	scheme                         = runtime.NewScheme()
-	configControllerValidResources = metallbcfg.ClusterResources{
+	configControllerValidResources = config.ClusterResources{
 		Peers: []v1beta2.BGPPeer{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -429,7 +428,7 @@ var (
 			},
 		},
 	}
-	configControllerInvalidResources = metallbcfg.ClusterResources{
+	configControllerInvalidResources = config.ClusterResources{
 		Peers: []v1beta2.BGPPeer{
 			{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -206,7 +206,7 @@ func TestSecretShouldntTrigger(t *testing.T) {
 
 	handlerCalled = false
 	err = fakeClient.Create(context.TODO(), &corev1.Secret{Type: corev1.SecretTypeBasicAuth, ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: testNamespace},
-		Data: map[string][]byte{"password": []byte([]byte("nopass"))}})
+		Data: map[string][]byte{"password": []byte("nopass")}})
 	if err != nil {
 		t.Fatalf("create failed on secret foo: %v", err)
 	}
@@ -396,7 +396,7 @@ var (
 		},
 		PasswordSecrets: map[string]corev1.Secret{
 			"bgpsecret": {Type: corev1.SecretTypeBasicAuth, ObjectMeta: metav1.ObjectMeta{Name: "bgpsecret", Namespace: testNamespace},
-				Data: map[string][]byte{"password": []byte([]byte("nopass"))}},
+				Data: map[string][]byte{"password": []byte("nopass")}},
 		},
 		LegacyAddressPools: []v1beta1.AddressPool{
 			{

--- a/internal/k8s/controllers/fakeclient_test.go
+++ b/internal/k8s/controllers/fakeclient_test.go
@@ -79,7 +79,6 @@ func objectsFromResources(r config.ClusterResources) []client.Object {
 
 	for _, bgpAdv := range r.BGPAdvs {
 		objects = append(objects, bgpAdv.DeepCopy())
-
 	}
 
 	for _, l2Adv := range r.L2Advs {

--- a/internal/k8s/controllers/node_controller_test.go
+++ b/internal/k8s/controllers/node_controller_test.go
@@ -125,17 +125,17 @@ func TestNodeReconciler_SetupWithManager(t *testing.T) {
 		Scheme:                scheme,
 	}
 	cfg, err := testEnv.Start()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	defer func() {
 		err = testEnv.Stop()
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}()
 	err = v1beta1.AddToScheme(k8sscheme.Scheme)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	err = v1beta2.AddToScheme(k8sscheme.Scheme)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	m, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	var configUpdate int
 	var mutex sync.Mutex
@@ -154,11 +154,11 @@ func TestNodeReconciler_SetupWithManager(t *testing.T) {
 		NodeName:  "test-node",
 	}
 	err = r.SetupWithManager(m)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	ctx := context.Background()
 	go func() {
 		err = m.Start(ctx)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}()
 
 	// test new node event.
@@ -169,7 +169,7 @@ func TestNodeReconciler_SetupWithManager(t *testing.T) {
 	node.Labels = make(map[string]string)
 	node.Labels["test"] = "e2e"
 	err = m.GetClient().Create(ctx, node)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()

--- a/internal/k8s/controllers/pool_controller.go
+++ b/internal/k8s/controllers/pool_controller.go
@@ -96,7 +96,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		updateErrors.Inc()
 		configStale.Set(1)
 		level.Error(r.Logger).Log("controller", "PoolReconciler", "metallb CRs and Secrets", dumpClusterResources(&resources), "event", "reload failed, retry")
-		return ctrl.Result{}, retryError
+		return ctrl.Result{}, errRetry
 	case SyncStateReprocessAll:
 		level.Info(r.Logger).Log("controller", "PoolReconciler", "event", "force service reload")
 		r.ForceReload()

--- a/internal/k8s/controllers/pool_controller_test.go
+++ b/internal/k8s/controllers/pool_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1beta1 "go.universe.tf/metallb/api/v1beta1"
-	"go.universe.tf/metallb/internal/config"
 	metallbcfg "go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/pointer"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,14 +89,14 @@ func TestPoolController(t *testing.T) {
 			t.Fatalf("test %s failed to create fake client: %v", test.desc, err)
 		}
 
-		expectedCfg, err := config.For(resources, config.DontValidate)
+		expectedCfg, err := metallbcfg.For(resources, metallbcfg.DontValidate)
 		if err != nil && test.validResources {
 			t.Fatalf("test %s failed to create config, got unexpected error: %v", test.desc, err)
 		}
 
 		cmpOpt := cmpopts.IgnoreUnexported(metallbcfg.Pool{})
 
-		mockHandler := func(l log.Logger, pools *config.Pools) SyncState {
+		mockHandler := func(l log.Logger, pools *metallbcfg.Pools) SyncState {
 			if !cmp.Equal(expectedCfg.Pools, pools, cmpOpt) {
 				t.Errorf("test %s failed, handler called with unexpected config: %s", test.desc, cmp.Diff(expectedCfg.Pools, pools, cmpOpt))
 			}
@@ -112,7 +111,7 @@ func TestPoolController(t *testing.T) {
 			Logger:         log.NewNopLogger(),
 			Scheme:         scheme,
 			Namespace:      testNamespace,
-			ValidateConfig: config.DontValidate,
+			ValidateConfig: metallbcfg.DontValidate,
 			Handler:        mockHandler,
 			ForceReload:    mockForceReload,
 		}

--- a/internal/k8s/controllers/service_controller.go
+++ b/internal/k8s/controllers/service_controller.go
@@ -90,7 +90,7 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
 	case SyncStateError:
 		updateErrors.Inc()
 		level.Info(r.Logger).Log("controller", "ServiceReconciler", "name", req.NamespacedName.String(), "service", dumpResource(service), "endpoints", dumpResource(epSlices), "event", "failed to handle service")
-		return ctrl.Result{}, retryError
+		return ctrl.Result{}, errRetry
 	case SyncStateReprocessAll:
 		level.Info(r.Logger).Log("controller", "ServiceReconciler", "event", "force service reload")
 		r.forceReload()

--- a/internal/k8s/controllers/service_controller_reload.go
+++ b/internal/k8s/controllers/service_controller_reload.go
@@ -99,7 +99,7 @@ func (r *ServiceReconciler) reprocessAll(ctx context.Context, req ctrl.Request) 
 		// in case we want to retry, we return an error to trigger the exponential backoff mechanism so that
 		// this controller won't loop at full speed
 		level.Info(r.Logger).Log("controller", "ServiceReconciler - reprocessAll", "event", "force service reload")
-		return ctrl.Result{}, retryError
+		return ctrl.Result{}, errRetry
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/k8s/controllers/service_controller_test.go
+++ b/internal/k8s/controllers/service_controller_test.go
@@ -258,7 +258,6 @@ func TestServiceController(t *testing.T) {
 }
 
 func TestLBClass(t *testing.T) {
-
 	tests := []struct {
 		desc           string
 		serviceLBClass *string

--- a/internal/k8s/controllers/values.go
+++ b/internal/k8s/controllers/values.go
@@ -29,4 +29,4 @@ const (
 	EndpointSlices
 )
 
-var retryError = errors.New("event handling failed, retrying")
+var errRetry = errors.New("event handling failed, retrying")

--- a/internal/k8s/epslices/endpoint_slices.go
+++ b/internal/k8s/epslices/endpoint_slices.go
@@ -50,7 +50,7 @@ func ServiceKeyForSlice(endpointSlice *discovery.EndpointSlice) (types.Namespace
 func SlicesServiceIndex(obj interface{}) ([]string, error) {
 	endpointSlice, ok := obj.(*discovery.EndpointSlice)
 	if !ok {
-		return nil, fmt.Errorf("Passed object is not a slice")
+		return nil, fmt.Errorf("passed object is not a slice")
 	}
 	serviceKey, err := ServiceKeyForSlice(endpointSlice)
 	if err != nil {

--- a/internal/k8s/epslices/endpoint_slices.go
+++ b/internal/k8s/epslices/endpoint_slices.go
@@ -56,7 +56,7 @@ func SlicesServiceIndex(obj interface{}) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []string{string(serviceKey.String())}, nil
+	return []string{serviceKey.String()}, nil
 }
 
 func serviceNameForSlice(endpointSlice *discovery.EndpointSlice) (string, error) {

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -119,7 +119,6 @@ type Config struct {
 // The client uses processName to identify itself to the cluster
 // (e.g. when logging events).
 //
-//nolint:godot
 func New(cfg *Config) (*Client, error) {
 	namespaceSelector := cache.ObjectSelector{
 		Field: fields.ParseSelectorOrDie(fmt.Sprintf("metadata.namespace=%s", cfg.Namespace)),

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -31,7 +31,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -348,7 +347,7 @@ func (c *Client) CreateMlSecret(namespace, controllerDeploymentName, secretName 
 	// Create the K8S Secret object.
 	_, err = c.client.CoreV1().Secrets(namespace).Create(
 		context.TODO(),
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretName,
 				OwnerReferences: []metav1.OwnerReference{{
@@ -397,19 +396,19 @@ func (c *Client) Run(stopCh <-chan struct{}) error {
 
 // UpdateStatus writes the protected "status" field of svc back into
 // the Kubernetes cluster.
-func (c *Client) UpdateStatus(svc *v1.Service) error {
+func (c *Client) UpdateStatus(svc *corev1.Service) error {
 	_, err := c.client.CoreV1().Services(svc.Namespace).UpdateStatus(context.TODO(), svc, metav1.UpdateOptions{})
 	return err
 }
 
 // Infof logs an informational event about svc to the Kubernetes cluster.
-func (c *Client) Infof(svc *v1.Service, kind, msg string, args ...interface{}) {
-	c.events.Eventf(svc, v1.EventTypeNormal, kind, msg, args...)
+func (c *Client) Infof(svc *corev1.Service, kind, msg string, args ...interface{}) {
+	c.events.Eventf(svc, corev1.EventTypeNormal, kind, msg, args...)
 }
 
 // Errorf logs an error event about svc to the Kubernetes cluster.
-func (c *Client) Errorf(svc *v1.Service, kind, msg string, args ...interface{}) {
-	c.events.Eventf(svc, v1.EventTypeWarning, kind, msg, args...)
+func (c *Client) Errorf(svc *corev1.Service, kind, msg string, args ...interface{}) {
+	c.events.Eventf(svc, corev1.EventTypeWarning, kind, msg, args...)
 }
 
 // UseEndpointSlices detect if Endpoints Slices are enabled in the cluster.

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -118,7 +118,6 @@ type Config struct {
 //
 // The client uses processName to identify itself to the cluster
 // (e.g. when logging events).
-//
 func New(cfg *Config) (*Client, error) {
 	namespaceSelector := cache.ObjectSelector{
 		Field: fields.ParseSelectorOrDie(fmt.Sprintf("metadata.namespace=%s", cfg.Namespace)),

--- a/internal/layer2/ip_advertisement.go
+++ b/internal/layer2/ip_advertisement.go
@@ -23,23 +23,23 @@ func NewIPAdvertisement(ip net.IP, allInterfaces bool, interfaces sets.Set[strin
 	}
 }
 
-func (i1 *IPAdvertisement) Equal(i2 *IPAdvertisement) bool {
-	if i1 == nil && i2 == nil {
+func (i *IPAdvertisement) Equal(other *IPAdvertisement) bool {
+	if i == nil && other == nil {
 		return true
 	}
-	if i1 == nil || i2 == nil {
+	if i == nil || other == nil {
 		return false
 	}
-	if !i1.ip.Equal(i2.ip) {
+	if !i.ip.Equal(other.ip) {
 		return false
 	}
-	if i1.allInterfaces != i2.allInterfaces {
+	if i.allInterfaces != other.allInterfaces {
 		return false
 	}
-	if i1.allInterfaces {
+	if i.allInterfaces {
 		return true
 	}
-	return i1.interfaces.Equal(i2.interfaces)
+	return i.interfaces.Equal(other.interfaces)
 }
 
 func (i *IPAdvertisement) MatchInterfaces(intfs ...string) bool {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -87,7 +87,7 @@ func Init(lvl string) (log.Logger, error) {
 func collectGlogs(f *os.File, logger log.Logger) {
 	defer func() {
 		if err := f.Close(); err != nil {
-			//cant log here, as this is the logger
+			// cant log here, as this is the logger
 			errorString := fmt.Sprintf("Error closing file: %s", err)
 			panic(errorString)
 		}

--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -255,7 +255,7 @@ func (sl *SpeakerList) mlJoin() {
 	if err != nil || nr != len(joinIPs) {
 		level.Error(sl.l).Log("op", "memberDiscovery", "msg", "partial join", "joined", nr, "expected", len(joinIPs), "error", err)
 	} else {
-		level.Info(sl.l).Log("op", "Member detection", "msg", "memberlist join succesfully", "number of other nodes", nr)
+		level.Info(sl.l).Log("op", "Member detection", "msg", "memberlist join successfully", "number of other nodes", nr)
 	}
 }
 

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -1160,14 +1160,14 @@ func TestShouldAnnounce(t *testing.T) {
 
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
-			lbIP_s := lbIP.String()
-			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
-			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
-			if response1 != test.c1ExpectedResult[lbIP_s] {
-				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
+			lbIPStr := lbIP.String()
+			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIPStr])
+			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "balancer", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIPStr])
+			if response1 != test.c1ExpectedResult[lbIPStr] {
+				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c1ExpectedResult[lbIPStr], response1)
 			}
-			if response2 != test.c2ExpectedResult[lbIP_s] {
-				t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c2ExpectedResult[lbIP_s], response2)
+			if response2 != test.c2ExpectedResult[lbIPStr] {
+				t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c2ExpectedResult[lbIPStr], response2)
 			}
 		}
 	}
@@ -2095,14 +2095,14 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 
 		for _, svc := range test.svcs {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
-			lbIP_s := lbIP.String()
-			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
-			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIP_s])
-			if response1 != test.c1ExpectedResult[lbIP_s] {
-				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
+			lbIPStr := lbIP.String()
+			response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIPStr])
+			response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, test.config.Pools.ByName["default"], svc, test.eps[lbIPStr])
+			if response1 != test.c1ExpectedResult[lbIPStr] {
+				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c1ExpectedResult[lbIPStr], response1)
 			}
-			if response2 != test.c2ExpectedResult[lbIP_s] {
-				t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c2ExpectedResult[lbIP_s], response2)
+			if response2 != test.c2ExpectedResult[lbIPStr] {
+				t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c2ExpectedResult[lbIPStr], response2)
 			}
 		}
 	}
@@ -2332,14 +2332,14 @@ func TestShouldAnnounceNodeSelector(t *testing.T) {
 		}
 
 		lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
-		lbIP_s := lbIP.String()
-		response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIP_s])
-		response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIP_s])
-		if response1 != test.c1ExpectedResult[lbIP_s] {
-			t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
+		lbIPStr := lbIP.String()
+		response1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIPStr])
+		response2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], &svc, test.eps[lbIPStr])
+		if response1 != test.c1ExpectedResult[lbIPStr] {
+			t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c1ExpectedResult[lbIPStr], response1)
 		}
-		if response2 != test.c2ExpectedResult[lbIP_s] {
-			t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c2ExpectedResult[lbIP_s], response2)
+		if response2 != test.c2ExpectedResult[lbIPStr] {
+			t.Errorf("%q: shouldAnnounce for controller 2 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIPStr, test.c2ExpectedResult[lbIPStr], response2)
 		}
 	}
 }

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -339,7 +339,6 @@ func (c *controller) handleService(l log.Logger,
 	svc *v1.Service, pool *config.Pool,
 	eps epslices.EpsOrSlices,
 	protocol config.Proto) controllers.SyncState {
-
 	l = log.With(l, "protocol", protocol)
 	handler := c.protocolHandlers[protocol]
 	if handler == nil {
@@ -482,7 +481,6 @@ func parseAnnouncedInterfacesToExclude() (*regexp.Regexp, error) {
 }
 
 func (c *controller) SetConfig(l log.Logger, cfg *config.Config) controllers.SyncState {
-
 	level.Debug(l).Log("event", "startUpdate", "msg", "start of config update")
 	defer level.Debug(l).Log("event", "endUpdate", "msg", "end of config update")
 

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
-	metallbcfg "go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/k8s"
 	"go.universe.tf/metallb/internal/k8s/controllers"
 	"go.universe.tf/metallb/internal/k8s/epslices"
@@ -161,11 +160,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	var validateConfig metallbcfg.Validate
+	var validateConfig config.Validate
 	if bgpType == "native" {
-		validateConfig = metallbcfg.DiscardFRROnly
+		validateConfig = config.DiscardFRROnly
 	} else {
-		validateConfig = metallbcfg.DiscardNativeOnly
+		validateConfig = config.DiscardNativeOnly
 	}
 
 	client, err := k8s.New(&k8s.Config{

--- a/speaker/speaker_test.go
+++ b/speaker/speaker_test.go
@@ -16,7 +16,7 @@ import (
 
 var logger = log.NewNopLogger()
 
-func NewController(l2Handler *MockProtocol, bgpHandler *MockProtocol, t *testing.T) *controller {
+func mockNewController(l2Handler *MockProtocol, bgpHandler *MockProtocol, t *testing.T) *controller {
 	ret := &controller{
 		myNode:  "nodeName",
 		bgpType: "frr",
@@ -44,7 +44,7 @@ func TestLoadBalancerCreation(t *testing.T) {
 		protocol:       config.BGP,
 		shouldAnnounce: true,
 	}
-	c := NewController(l2MockHandler, bgpMockHandler, t)
+	c := mockNewController(l2MockHandler, bgpMockHandler, t)
 
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tasks.py
+++ b/tasks.py
@@ -691,7 +691,7 @@ def lint(ctx, env="container"):
     convenient to install the golangci-lint binaries on the host. This can be
     achieved by running `inv lint --env host`.
     """
-    version = "1.50.1"
+    version = "1.52.2"
     golangci_cmd = "golangci-lint run --timeout 10m0s ./..."
 
     if env == "container":


### PR DESCRIPTION
This PR adds a couple of linters from golangci-lint:

  - ginkgolinter
  - dogsled
  - exportloopref
  - gocritic
  - misspell
  - nolintlint
  - stylecheck
  - unconvert
  - unparam
  - whitespace
  - revive
  - unused
  - wastedassign
Each commit shows what each linter fixes.
The commits are split for sake of reviewing, will squash them if required.
More details about each linter and their configurations can be found here: https://golangci-lint.run/usage/linters/ 

fixes #1860 
fixes #1867 