### PR TITLE
tasks.py - delete old metallb dev images

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -190,6 +190,20 @@ def build(ctx, binaries, architectures, registry="quay.io", repo="metallb", tag=
     for arch in architectures:
 
         for bin in binaries:
+            try:
+                if _is_podman():
+                    command = "podman"
+                else:
+                    command = "docker"
+                run ("{command} image rm {registry}/{repo}/{bin}:{tag}-{arch}".format(
+                            command=command,
+                            registry=registry,
+                            repo=repo,
+                            bin=bin,
+                            tag=tag,
+                            arch=arch))
+            except:
+                pass
             run("{docker_build_cmd} "
                 "--platform linux/{arch} "
                 "-t {registry}/{repo}/{bin}:{tag}-{arch} "


### PR DESCRIPTION
Currently, the `dev-env` task from tasks.py builds new docker images from the source code, and the old images stay untouched, accumulating over and time taking up space.

This commit adds the logic for deleting the old metallb dev images when invoking dev-env.

We wrap it up with `try` and `except` to ignore the failure: Docker Image doesn't exist.

fixes #1325