### PR TITLE
E2E: read the namespace before changing the labels

### DIFF
--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -61,8 +61,7 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Updating the first namespace labels")
-		f.Namespace.Labels = firstNsLabels
-		_, err = cs.CoreV1().Namespaces().Update(context.Background(), f.Namespace, metav1.UpdateOptions{})
+		err = k8s.ApplyLabelsToNamespace(cs, f.Namespace.Name, firstNsLabels)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a second namespace")

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -30,7 +30,8 @@ var (
 		"first-ns": "true",
 	}
 	secondNsLabels = map[string]string{
-		"second-ns": "true",
+		"second-ns":                    "true",
+		admissionapi.EnforceLevelLabel: string(admissionapi.LevelPrivileged),
 	}
 )
 

--- a/e2etest/pkg/k8s/namespace.go
+++ b/e2etest/pkg/k8s/namespace.go
@@ -45,3 +45,18 @@ func DeleteNamespace(cs clientset.Interface, name string) error {
 	})
 	return err
 }
+
+func ApplyLabelsToNamespace(cs clientset.Interface, name string, labels map[string]string) error {
+	ns, err := cs.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		ns.Labels[k] = v
+	}
+	_, err = cs.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+	return err
+}


### PR DESCRIPTION
This prevents version skews in case the ns is modified after the creation.
