### PR TITLE
E2E ns label test: use only the extra label for selection

### DIFF
--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -30,8 +30,7 @@ var (
 		"first-ns": "true",
 	}
 	secondNsLabels = map[string]string{
-		"second-ns":                    "true",
-		admissionapi.EnforceLevelLabel: string(admissionapi.LevelPrivileged),
+		"second-ns": "true",
 	}
 )
 
@@ -66,7 +65,11 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a second namespace")
-		err = k8s.CreateNamespace(cs, secondNamespace, secondNsLabels)
+
+		err = k8s.CreateNamespace(cs, secondNamespace, secondNsLabels, func(ns *v1.Namespace) {
+			// we also need to set the pod security policy for the namespace
+			ns.Labels[admissionapi.EnforceLevelLabel] = string(admissionapi.LevelPrivileged)
+		})
 		framework.ExpectNoError(err)
 
 	})

--- a/e2etest/pkg/k8s/namespace.go
+++ b/e2etest/pkg/k8s/namespace.go
@@ -13,13 +13,21 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func CreateNamespace(cs clientset.Interface, name string, labels map[string]string) error {
-	_, err := cs.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+func CreateNamespace(cs clientset.Interface, name string, labels map[string]string, options ...func(*corev1.Namespace)) error {
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Labels: labels,
+			Labels: make(map[string]string),
 		},
-	}, metav1.CreateOptions{})
+	}
+	for k, v := range labels {
+		ns.Labels[k] = v
+	}
+	for _, option := range options {
+		option(ns)
+	}
+
+	_, err := cs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 	return err
 }
 


### PR DESCRIPTION
Depending on the platform we run the test, the level privileged label can be added or removed. Because of this, we rely only on the extra label we add so the test has more control on the execution.