### PR TITLE
Upgrade the cancel-workflow-action

### DIFF
--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 


### PR DESCRIPTION
This commit upgrades the cancel-workflow-action to the latest v0.11.0,
due to the following deprecation notice (seen as warning messages in the actions tab):
```
Node.js 12 actions are deprecated. Please update the following actions
to use Node.js 16: styfle/cancel-workflow-action@0.9.1.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

As mentioned in the cancel-workflow-action README, we should consider
using the native concurrency property to cancel workflows:
https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/