### PR TITLE
Fix the NetworkUnavailable condition L2 flakes

### DIFF
--- a/e2etest/l2tests/interface_selector.go
+++ b/e2etest/l2tests/interface_selector.go
@@ -293,21 +293,11 @@ var _ = ginkgo.Describe("L2-interface selector", func() {
 				framework.ExpectNoError(err)
 
 				gomega.Eventually(func() string {
-					err := mac.RequestAddressResolutionFromIface(ingressIP, LocalNics[0], executor.Host)
+					node, err := nodeForService(svc, allNodes.Items)
 					if err != nil {
-						return err.Error()
+						return ""
 					}
-					err = service.ValidateL2(svc)
-					if err != nil {
-						return err.Error()
-					}
-
-					advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
-					if err != nil {
-						return err.Error()
-					}
-
-					return advNode.Name
+					return node
 				}, 1*time.Minute, 1*time.Second).Should(gomega.Equal(node.Name))
 			}
 		})

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -244,10 +244,16 @@ var _ = ginkgo.Describe("L2", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("getting the advertising node")
+			var nodeToSet string
 			ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
-			n, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
-			framework.ExpectNoError(err)
-			nodeToSet := n.Name
+			gomega.Eventually(func() error {
+				n, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
+				if err != nil {
+					return err
+				}
+				nodeToSet = n.Name
+				return nil
+			}, time.Minute, time.Second).ShouldNot(gomega.HaveOccurred())
 
 			err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionTrue)
 			framework.ExpectNoError(err)

--- a/e2etest/l2tests/node_service.go
+++ b/e2etest/l2tests/node_service.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package l2tests
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+	"go.universe.tf/metallb/e2etest/pkg/mac"
+	"go.universe.tf/metallb/e2etest/pkg/wget"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+)
+
+func nodeForService(svc *corev1.Service, nodes []corev1.Node) (string, error) {
+	ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
+
+	port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+	hostport := net.JoinHostPort(ingressIP, port)
+	address := fmt.Sprintf("http://%s/", hostport)
+	err := mac.RequestAddressResolution(ingressIP, executor.Host)
+	if err != nil {
+		return "", err
+	}
+	err = wget.Do(address, executor.Host)
+	framework.ExpectNoError(err)
+	advNode, err := advertisingNodeFromMAC(nodes, ingressIP, executor.Host)
+	if err != nil {
+		return "", err
+	}
+
+	return advNode.Name, nil
+}

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -512,7 +512,7 @@ func (c *controller) SetConfig(l log.Logger, cfg *config.Config) controllers.Syn
 }
 
 func (c *controller) SetNode(l log.Logger, node *v1.Node) controllers.SyncState {
-	conditionChanged := isNetworkConditionChanged(c.myNode, c.nodes, node)
+	conditionChanged := isNetworkConditionChanged(node.Name, c.nodes, node)
 	c.nodes[node.Name] = node
 
 	for proto, handler := range c.protocolHandlers {


### PR DESCRIPTION
After discovering flakes in the L2 tests around the networkUnavailable condition feature, this commit fixes:

1. Wrap "advertisingNodeFromMAC" with Eventually to give the speakers enough time to settle.

2. In the speaker's "SetNode" function: fixed the name of the node we're passing to the isNetworkConditionChanged function.

fixes #1904 
