### PR TITLE
Revert "E2E tests: Test networkUnavailable case"

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -147,45 +147,6 @@ var _ = ginkgo.Describe("BGP", func() {
 			}),
 	)
 
-	ginkgo.Describe("Service with ETP=cluster", func() {
-		ginkgo.It("IPV4 - should not be announced from a node with a NetworkUnavailable condition", func() {
-			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			framework.ExpectNoError(err)
-			nodeToSet := allNodes.Items[0].Name
-
-			_, svc := setupBGPService(f, ipfamily.IPv4, []string{v4PoolAddresses}, FRRContainers, func(svc *corev1.Service) {
-				testservice.TrafficPolicyCluster(svc)
-			})
-			defer testservice.Delete(cs, svc)
-			validateDesiredLB(svc)
-
-			for _, c := range FRRContainers {
-				validateService(svc, allNodes.Items, c)
-			}
-
-			err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionTrue)
-			framework.ExpectNoError(err)
-			defer func() {
-				err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionFalse)
-				framework.ExpectNoError(err)
-			}()
-
-			ginkgo.By("validating service is not announced from the unavailable node")
-			for _, c := range FRRContainers {
-				Eventually(func() error {
-					return validateServiceNoWait(svc, []corev1.Node{allNodes.Items[0]}, c)
-				}, time.Minute, time.Second).Should(HaveOccurred())
-			}
-
-			ginkgo.By("validating service is announced from the other available nodes")
-			for _, c := range FRRContainers {
-				Eventually(func() error {
-					return validateServiceNoWait(svc, allNodes.Items[1:], c)
-				}, time.Minute, time.Second).ShouldNot(HaveOccurred())
-			}
-		})
-	})
-
 	ginkgo.DescribeTable("A service of protocol load balancer should work with ETP=local", func(pairingIPFamily ipfamily.Family, poolAddresses []string, tweak testservice.Tweak) {
 
 		jig, svc := setupBGPService(f, pairingIPFamily, poolAddresses, FRRContainers, func(svc *corev1.Service) {

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -232,54 +232,6 @@ var _ = ginkgo.Describe("L2", func() {
 			err = wget.Do(address, executor.Host)
 			framework.ExpectNoError(err)
 		})
-
-		ginkgo.It("should not be announced from a node with a NetworkUnavailable condition", func() {
-			svc, _ := service.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", service.TrafficPolicyCluster)
-			defer func() {
-				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err)
-			}()
-
-			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			framework.ExpectNoError(err)
-
-			ginkgo.By("getting the advertising node")
-			ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
-			n, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
-			framework.ExpectNoError(err)
-			nodeToSet := n.Name
-
-			err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionTrue)
-			framework.ExpectNoError(err)
-			defer func() {
-				err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionFalse)
-				framework.ExpectNoError(err)
-			}()
-
-			ginkgo.By("validating the service is announced from a different node")
-			gomega.Eventually(func() string {
-				advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
-				if err != nil {
-					return err.Error()
-				}
-
-				return advNode.Name
-			}, time.Minute, time.Second).ShouldNot(gomega.Equal(nodeToSet))
-
-			ginkgo.By("setting the NetworkUnavailable condition back to false")
-			err = k8s.SetNodeCondition(cs, nodeToSet, corev1.NodeNetworkUnavailable, corev1.ConditionFalse)
-			framework.ExpectNoError(err)
-
-			ginkgo.By("validating the service is announced back again from the previous node")
-			gomega.Eventually(func() string {
-				advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
-				if err != nil {
-					return err.Error()
-				}
-
-				return advNode.Name
-			}, time.Minute, time.Second).Should(gomega.Equal(nodeToSet))
-		})
 	})
 
 	ginkgo.Context("validate different AddressPools for type=Loadbalancer", func() {

--- a/e2etest/pkg/k8s/nodes.go
+++ b/e2etest/pkg/k8s/nodes.go
@@ -4,17 +4,11 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net"
-	"time"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"go.universe.tf/metallb/e2etest/pkg/executor"
 	"go.universe.tf/metallb/e2etest/pkg/netdev"
 	"go.universe.tf/metallb/internal/ipfamily"
-	"go.universe.tf/metallb/internal/k8s/nodes"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -96,45 +90,4 @@ func RemoveLabelFromNode(nodeName, key string, cs clientset.Interface) {
 	delete(nodeObject.Labels, key)
 	_, err = cs.CoreV1().Nodes().Update(context.Background(), nodeObject, metav1.UpdateOptions{})
 	framework.ExpectNoError(err)
-}
-
-// SetNodeCondition sets the node's condition to the desired status and validates that the change is applied.
-func SetNodeCondition(cs clientset.Interface, nodeName string, conditionType v1.NodeConditionType, status v1.ConditionStatus) error {
-	ginkgo.By(fmt.Sprintf("setting the %s condition to %s on node %s", conditionType, status, nodeName))
-
-	condition := v1.NodeCondition{
-		Type:               conditionType,
-		Status:             status,
-		Reason:             "Testing",
-		Message:            fmt.Sprintf("This condition is %s for testing", status),
-		LastTransitionTime: metav1.Now(),
-		LastHeartbeatTime:  metav1.Now(),
-	}
-
-	raw, err := json.Marshal(&[]v1.NodeCondition{condition})
-	if err != nil {
-		return fmt.Errorf("failed to set condition %s on node %s: %s", conditionType, nodeName, err)
-	}
-
-	gomega.Eventually(func() error {
-		patch := []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw))
-		_, err = cs.CoreV1().Nodes().PatchStatus(context.Background(), nodeName, patch)
-		if err != nil {
-			return fmt.Errorf("failed to set condition %s on node %s: %s", conditionType, nodeName, err)
-		}
-
-		n, err := cs.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get node %s: %s", nodeName, err)
-		}
-
-		gotStatus := nodes.ConditionStatus(n, conditionType)
-		if status != gotStatus {
-			return fmt.Errorf("failed: got unexpected %s status on node %s", conditionType, nodeName)
-		}
-
-		return nil
-	}, time.Minute, 3*time.Second).ShouldNot(gomega.HaveOccurred())
-
-	return nil
 }


### PR DESCRIPTION
This reverts commit 1d8858ca30cea8eaba4c3bd09e2726e7ef23b933.

E2E tests are flakying and being worked on, but they currently prevent
merges. We are not reverting the implementation as the other e2es are
passing and the changes are not preventing MetalLB's functionality.