### PR TITLE
Remove deprecated kustomization vars

### DIFF
--- a/config/native/kustomization.yaml
+++ b/config/native/kustomization.yaml
@@ -8,19 +8,3 @@ resources:
 - ../controllers
 - ../webhook
 namespace: metallb-system
-
-# the following config is for teaching kustomize how to do var substitution.
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: SERVICE_NAMESPACE
-  objref:
-    kind: Service
-    name: webhook-service
-    version: v1
-- fieldref: {}
-  name: SERVICE_NAME
-  objref:
-    kind: Service
-    name: webhook-service
-    version: v1


### PR DESCRIPTION
This removes the deprecated kustomization vars discussed in #1911 . I used `kustomize build` and compared the output before and after this change and it seems to output the same code.