### PR TITLE
Allow enabling the audit logs on kind

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -247,3 +247,14 @@ Commercial support is available at
 </body>
 </html>
 ```
+
+## Enabling the apiserver audit logs
+
+To enable the apiserver audit logs, to understand what are the impacts of the controller and the speakers over
+the apiserver, the `-t, --with-api-audit` flag must be passed to `inv dev-env`.
+
+When the audit logs are enabled, they can be inspected by running:
+
+```bash
+docker exec kind-control-plane cat /var/log/kubernetes/kube-apiserver-audit.log
+```

--- a/dev-env/audit-policy.yaml
+++ b/dev-env/audit-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - "ResponseComplete"
+  - "ResponseStarted"
+rules:
+- level: Metadata
+  users:
+  - "system:serviceaccount:metallb-system:speaker"
+  - "system:serviceaccount:metallb-system:controller"

--- a/tasks.py
+++ b/tasks.py
@@ -314,10 +314,12 @@ def generate_manifest(ctx, crd_options="crd:crdVersions=v1", bgp_type="native", 
                 "Default: True.",
     "with_prometheus": "Deploys the prometheus kubernetes stack"
                 "Default: False.",
+    "with_api_audit": "Enables audit on the apiserver"
+                "Default: False.",
 })
 def dev_env(ctx, architecture="amd64", name="kind", protocol=None, frr_volume_dir="",
         node_img=None, ip_family="ipv4", bgp_type="native", log_level="info",
-        helm_install=False, build_images=True, with_prometheus=False):
+        helm_install=False, build_images=True, with_prometheus=False, with_api_audit=False):
     """Build and run MetalLB in a local Kind cluster.
 
     If the cluster specified by --name (default "kind") doesn't exist,
@@ -342,6 +344,29 @@ def dev_env(ctx, architecture="amd64", name="kind", protocol=None, frr_volume_di
             ],
         }
 
+        if with_api_audit:
+            config["nodes"][0]["kubeadmConfigPatches"] = [r"""kind: ClusterConfiguration
+apiServer:
+  # enable auditing flags on the API server
+  extraArgs:
+    audit-log-path: /var/log/kubernetes/kube-apiserver-audit.log
+    audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+    # mount new files / directories on the control plane
+  extraVolumes:
+    - name: audit-policies
+      hostPath: /etc/kubernetes/policies
+      mountPath: /etc/kubernetes/policies
+      readOnly: true
+      pathType: "DirectoryOrCreate"
+    - name: "audit-logs"
+      hostPath: "/var/log/kubernetes"
+      mountPath: "/var/log/kubernetes"
+      readOnly: false
+      pathType: DirectoryOrCreate"""]
+            config["nodes"][0]["extraMounts"] = [{"hostPath": "./dev-env/audit-policy.yaml",
+                                        "containerPath": "/etc/kubernetes/policies/audit-policy.yaml",
+                                        "readOnly": True}]
+
         networking_config = {}
         if ip_family != "ipv4":
             networking_config["ipFamily"] = ip_family
@@ -353,6 +378,7 @@ def dev_env(ctx, architecture="amd64", name="kind", protocol=None, frr_volume_di
         if node_img != None:
             extra_options = "--image={}".format(node_img)
         config = yaml.dump(config).encode("utf-8")
+        
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(config)
             tmp.flush()


### PR DESCRIPTION
Audit logs are useful to understand the interaction between metallb and the api server, to see if metallb is behaving correctly. Here we add a parameter to enable them.