### PR TITLE
Have the FRR one the default implementation when deploying with charts

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -111,7 +111,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.affinity | object | `{}` |  |
 | speaker.enabled | bool | `true` |  |
 | speaker.excludeInterfaces.enabled | bool | `true` |  |
-| speaker.frr.enabled | bool | `false` |  |
+| speaker.frr.enabled | bool | `true` |  |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `"8.4.2"` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -319,7 +319,7 @@ speaker:
   # frr contains configuration specific to the MetalLB FRR container,
   # for speaker running alongside FRR.
   frr:
-    enabled: false
+    enabled: true
     image:
       repository: quay.io/frrouting/frr
       tag: 8.4.2


### PR DESCRIPTION
The FRR implementation is now mature, and it is where all our efforts are going, so it makes sense to have it as the default implementation.
