### PR TITLE
Trigger reprocessall event only when an ip has been unassigned

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -188,9 +188,9 @@ func (a *Allocator) Assign(svcKey string, svc *v1.Service, ips []net.IP, ports [
 }
 
 // Unassign frees the IP associated with service, if any.
-func (a *Allocator) Unassign(svc string) bool {
+func (a *Allocator) Unassign(svc string) {
 	if a.allocated[svc] == nil {
-		return false
+		return
 	}
 
 	al := a.allocated[svc]
@@ -216,7 +216,6 @@ func (a *Allocator) Unassign(svc string) bool {
 		}
 	}
 	stats.poolActive.WithLabelValues(al.pool).Set(float64(len(a.poolIPsInUse[al.pool])))
-	return true
 }
 
 // AllocateFromPool assigns an available IP from pool to service.


### PR DESCRIPTION
This prevents the unnecessary reprocess of all services when a service with no LB IP assigned is deleted.
