### PR TITLE
Fix syncState response for unconverged services

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -73,19 +73,21 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	// copy makes the code much easier to follow, and we have a GC for
 	// a reason.
 	svc := svcRo.DeepCopy()
-	successRes := controllers.SyncStateSuccess
+	syncStateRes := controllers.SyncStateSuccess
 	wasAllocated := c.isServiceAllocated(name)
-	c.convergeBalancer(l, name, svc)
+	if c.convergeBalancer(l, name, svc) != nil {
+		syncStateRes = controllers.SyncStateErrorNoRetry
+	}
 
 	if wasAllocated && !c.isServiceAllocated(name) { // convergeBalancer may deallocate our service and this means it did it.
 		// if the service was deallocated, it may have have left room
 		// for another one, so we reprocess
 		level.Info(l).Log("event", "serviceUpdated", "msg", "removed loadbalancer from service, services will be reprocessed")
-		successRes = controllers.SyncStateReprocessAll
+		syncStateRes = controllers.SyncStateReprocessAll
 	}
 	if reflect.DeepEqual(svcRo, svc) {
 		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
-		return successRes
+		return syncStateRes
 	}
 
 	toWrite := svcRo.DeepCopy()
@@ -103,11 +105,11 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 			return controllers.SyncStateError
 		}
 		level.Info(l).Log("event", "serviceUpdated", "msg", "updated service object")
-		return successRes
+		return syncStateRes
 	}
 
 	level.Info(l).Log("event", "serviceUpdated", "msg", "service is not updated")
-	return successRes
+	return syncStateRes
 }
 
 func (c *controller) SetPools(l log.Logger, pools *config.Pools) controllers.SyncState {

--- a/controller/service.go
+++ b/controller/service.go
@@ -35,7 +35,9 @@ const (
 	annotationIPAllocateFromPool = "metallb.universe.tf/ip-allocated-from-pool"
 )
 
-func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service) {
+var ErrConverge = fmt.Errorf("failed to converge")
+
+func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service) error {
 	lbIPs := []net.IP{}
 	var err error
 	// Not a LoadBalancer, early exit. It might have been a balancer
@@ -45,7 +47,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		c.clearServiceState(key, svc)
 		// Early return, we explicitly do *not* want to reallocate
 		// an IP.
-		return
+		return nil
 	}
 
 	// If the ClusterIPs is malformed or not set we can't determine the
@@ -53,7 +55,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	if len(svc.Spec.ClusterIPs) == 0 && svc.Spec.ClusterIP == "" {
 		level.Info(l).Log("event", "clearAssignment", "reason", "noClusterIPs", "msg", "No ClusterIPs")
 		c.clearServiceState(key, svc)
-		return
+		return ErrConverge
 	}
 
 	// The assigned LB IP(s) is the end state of convergence. If there's
@@ -77,7 +79,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		if err != nil {
 			level.Error(l).Log("event", "clearAssignment", "reason", "noclusterIPsIPFamily", "msg", "Failed to retrieve clusterIPs family")
 			c.client.Errorf(svc, "noclusterIPsIPFamily", "Failed to retrieve ClusterIPs IPFamily for %q %s: %s", svc.Spec.ClusterIPs, svc.Spec.ClusterIP, err)
-			return
+			return ErrConverge
 		}
 		// Clear the lbIP if it has a different ipFamily compared to the clusterIP.
 		// (this should not happen since the "ipFamily" of a service is immutable)
@@ -117,7 +119,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		if err != nil {
 			level.Error(l).Log("event", "loadbalancerIP", "error", err, "msg", "invalid requested loadbalancer IPs")
 			c.client.Errorf(svc, "LoadBalancerFailed", "invalid requested loadbalancer IPs: %s", err)
-			return
+			return ErrConverge
 		}
 		if len(desiredLbIPs) > 0 && !isEqualIPs(lbIPs, desiredLbIPs) {
 			level.Info(l).Log("event", "clearAssignment", "reason", "differentIPRequested", "msg", "user requested a different IP than the one currently assigned")
@@ -135,7 +137,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 			// The outer controller loop will retry converging this
 			// service when another service gets deleted, so there's
 			// nothing to do here but wait to get called again later.
-			return
+			return ErrConverge
 		}
 		level.Info(l).Log("event", "ipAllocated", "ip", lbIPs, "msg", "IP address assigned by controller")
 		c.client.Infof(svc, "IPAllocated", "Assigned IP %q", lbIPs)
@@ -145,7 +147,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		level.Error(l).Log("bug", "true", "msg", "internal error: failed to allocate an IP, but did not exit convergeService early!")
 		c.client.Errorf(svc, "InternalError", "didn't allocate an IP but also did not fail")
 		c.clearServiceState(key, svc)
-		return
+		return ErrConverge
 	}
 
 	pool := c.ips.Pool(key)
@@ -153,7 +155,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		level.Error(l).Log("bug", "true", "ip", lbIPs, "msg", "internal error: allocated IP has no matching address pool")
 		c.client.Errorf(svc, "InternalError", "allocated an IP that has no pool")
 		c.clearServiceState(key, svc)
-		return
+		return ErrConverge
 	}
 
 	// At this point, we have an IP selected somehow, all that remains
@@ -167,6 +169,8 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		svc.Annotations = make(map[string]string)
 	}
 	svc.Annotations[annotationIPAllocateFromPool] = pool
+
+	return nil
 }
 
 // clearServiceState clears all fields that are actively managed by


### PR DESCRIPTION
When convergeBalancer fails to assign an LB IP to a unallocated service, the response of the service handler was SyncStateSuccess which errounously indicates that the service converged. This PR sets the response to SyncStateErrorNoRetry.

No functional changes, just an extra error log message from the switch of the service controller.
