### PR TITLE
Remove IP verifications in SetPools

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1040,12 +1040,23 @@ func TestControllerConfig(t *testing.T) {
 		t.Errorf("SetBalancer produced unexpected mutation (-want +got)\n%s", diff)
 	}
 
-	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetPools(l, &config.Pools{ByName: map[string]*config.Pool{}}) != controllers.SyncStateError {
-		t.Fatalf("SetPools that deletes allocated IPs was accepted")
+	// Removing the IP pool should be accepted even if the IP is allocated
+	// This triggers a reprocess all event to force the service to get a new IP
+	if c.SetPools(l, &config.Pools{ByName: map[string]*config.Pool{}}) != controllers.SyncStateReprocessAll {
+		t.Fatalf("SetPools that deletes allocated IPs was not accepted")
 	}
 
-	// Deleting the config also makes MetalLB sad.
+	// Balancer should clear the service. Not reprocess all because previous ip is not longer assignable.
+	if c.SetBalancer(l, "test", gotSvc, epslices.EpsOrSlices{}) != controllers.SyncStateErrorNoRetry {
+		t.Fatalf("SetBalancer failed")
+	}
+
+	gotSvc = k.gotService(gotSvc)
+	if diff := diffService(svc, gotSvc); diff != "" {
+		t.Errorf("SetBalancer produced unexpected mutation (-want +got)\n%s", diff)
+	}
+
+	// Deleting the config makes MetalLB sad.
 	if c.SetPools(l, nil) != controllers.SyncStateErrorNoRetry {
 		t.Fatalf("SetPools that deletes the config was accepted")
 	}
@@ -1097,7 +1108,7 @@ func TestDeleteRecyclesIP(t *testing.T) {
 		},
 	}
 	if c.SetBalancer(l, "test2", svc2, epslices.EpsOrSlices{}) == controllers.SyncStateError {
-		t.Fatal("SetBalancer svc2 failed")
+		t.Fatal("SetBalancer svc2 was supposed to fail with no retry")
 	}
 	if k.gotService(svc2) != nil {
 		t.Fatal("SetBalancer svc2 mutated svc2 even though it should not have allocated")
@@ -1121,7 +1132,7 @@ func TestDeleteRecyclesIP(t *testing.T) {
 		t.Fatal("svc2 didn't get an IP")
 	}
 }
-func TestControllerDualStackConfig(t *testing.T) {
+func TestControllerReassing(t *testing.T) {
 	k := &testK8S{t: t}
 	c := &controller{
 		ips:    allocator.New(),
@@ -1129,40 +1140,15 @@ func TestControllerDualStackConfig(t *testing.T) {
 	}
 
 	l := log.NewNopLogger()
+
 	svc := &v1.Service{
 		Spec: v1.ServiceSpec{
 			Type:       "LoadBalancer",
-			ClusterIPs: []string{"1.2.3.4", "1000::"},
+			ClusterIPs: []string{"1.2.3.4"},
 		},
 	}
-	if c.SetBalancer(l, "test", svc, epslices.EpsOrSlices{}) == controllers.SyncStateError {
-		t.Fatalf("SetBalancer failed")
-	}
 
-	gotSvc := k.gotService(svc)
-	if gotSvc != nil {
-		t.Errorf("SetBalancer with no configuration mutated service (-in +out)\n%s", diffService(svc, gotSvc))
-	}
-	if k.loggedWarning {
-		t.Error("SetBalancer with no configuration logged an error")
-	}
-
-	// Set an empty config. Balancer should still not do anything to
-	// our unallocated service, and return an error to force a
-	// retry after sync is complete.
-	if c.SetPools(l, &config.Pools{ByName: map[string]*config.Pool{}}) == controllers.SyncStateError {
-		t.Fatalf("SetPools with empty config failed")
-	}
-
-	gotSvc = k.gotService(svc)
-	if gotSvc != nil {
-		t.Errorf("unsynced SetBalancer mutated service (-in +out)\n%s", diffService(svc, gotSvc))
-	}
-	if k.loggedWarning {
-		t.Error("unsynced SetBalancer logged an error")
-	}
-
-	// Set a config with some IPs. Still no allocation, not synced.
+	// Set a config with some IPs.
 	pools := &config.Pools{ByName: map[string]*config.Pool{
 		"default": {
 			Name:       "default",
@@ -1171,37 +1157,73 @@ func TestControllerDualStackConfig(t *testing.T) {
 		},
 	}}
 
-	if c.SetPools(l, pools) == controllers.SyncStateError {
+	if c.SetPools(l, pools) != controllers.SyncStateReprocessAll {
 		t.Fatalf("SetPools failed")
 	}
 
-	gotSvc = k.gotService(svc)
-	if gotSvc != nil {
-		t.Errorf("unsynced SetBalancer mutated service (-in +out)\n%s", diffService(svc, gotSvc))
-	}
-	if k.loggedWarning {
-		t.Error("unsynced SetBalancer logged an error")
-	}
-
-	if c.SetBalancer(l, "test", svc, epslices.EpsOrSlices{}) == controllers.SyncStateError {
+	if c.SetBalancer(l, "test", svc, epslices.EpsOrSlices{}) != controllers.SyncStateSuccess {
 		t.Fatalf("SetBalancer failed")
 	}
 
-	gotSvc = k.gotService(svc)
+	gotSvc := k.gotService(svc)
 	wantSvc := new(v1.Service)
 	*wantSvc = *svc
-	wantSvc.Status = statusAssigned([]string{"1.2.3.0", "1000::"})
+	wantSvc.Status = statusAssigned([]string{"1.2.3.0"})
 	if diff := diffService(wantSvc, gotSvc); diff != "" {
 		t.Errorf("SetBalancer produced unexpected mutation (-want +got)\n%s", diff)
 	}
 
-	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetPools(l, &config.Pools{ByName: map[string]*config.Pool{}}) != controllers.SyncStateError {
-		t.Fatalf("SetPools that deletes allocated IPs was accepted")
+	// Set a config with some 2 pools.
+	pools = &config.Pools{ByName: map[string]*config.Pool{
+		"default": {
+			Name:       "default",
+			AutoAssign: true,
+			CIDR:       []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("1000::1/127")},
+		},
+		"second": {
+			Name:       "second",
+			AutoAssign: true,
+			CIDR:       []*net.IPNet{ipnet("4.5.6.0/24")},
+		},
+	}}
+
+	if c.SetPools(l, pools) == controllers.SyncStateError {
+		t.Fatalf("SetPools failed")
 	}
 
-	// Deleting the config also makes MetalLB sad.
-	if c.SetPools(l, nil) != controllers.SyncStateErrorNoRetry {
-		t.Fatalf("SetPools that deletes the config was accepted")
+	// Allocation shouldn't change.
+	if c.SetBalancer(l, "test", gotSvc, epslices.EpsOrSlices{}) != controllers.SyncStateSuccess {
+		t.Fatalf("SetBalancer failed")
+	}
+
+	k.reset()
+
+	if k.gotService(gotSvc) != nil {
+		t.Errorf("unsynced SetBalancer mutated service%s", gotSvc)
+	}
+
+	// Delete default pool.
+	pools = &config.Pools{ByName: map[string]*config.Pool{
+		"second": {
+			Name:       "second",
+			AutoAssign: true,
+			CIDR:       []*net.IPNet{ipnet("4.5.6.0/24")},
+		},
+	}}
+
+	if c.SetPools(l, pools) != controllers.SyncStateReprocessAll {
+		t.Fatalf("SetPools failed")
+	}
+
+	// It should get an IP from the second pool
+	if c.SetBalancer(l, "test", gotSvc, epslices.EpsOrSlices{}) != controllers.SyncStateSuccess {
+		t.Fatalf("SetBalancer failed")
+	}
+
+	gotSvc = k.gotService(svc)
+	*wantSvc = *svc
+	wantSvc.Status = statusAssigned([]string{"4.5.6.0"})
+	if diff := diffService(wantSvc, gotSvc); diff != "" {
+		t.Errorf("SetBalancer produced unexpected mutation (-want +got)\n%s", diff)
 	}
 }

--- a/controller/main.go
+++ b/controller/main.go
@@ -81,6 +81,11 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		syncStateRes = controllers.SyncStateErrorNoRetry
 	}
 
+	if reflect.DeepEqual(svcRo, svc) {
+		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
+		return syncStateRes
+	}
+
 	if len(prevIPs) != 0 && !c.isServiceAllocated(name) {
 		// Only reprocess all if the previous IP(s) are still contained within a pool.
 		if c.ips.PoolForIP(prevIPs) != nil {
@@ -90,10 +95,6 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 			level.Info(l).Log("event", "serviceUpdated", "msg", "removed loadbalancer from service, services will be reprocessed")
 			syncStateRes = controllers.SyncStateReprocessAll
 		}
-	}
-	if reflect.DeepEqual(svcRo, svc) {
-		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
-		return syncStateRes
 	}
 
 	toWrite := svcRo.DeepCopy()

--- a/controller/service.go
+++ b/controller/service.go
@@ -50,6 +50,13 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		return nil
 	}
 
+	// Return if pools are empty.
+	if len(c.pools.ByName) == 0 {
+		level.Debug(l).Log("event", "clearAssignment", "reason", "noConfig", "msg", "pools are empty")
+		c.clearServiceState(key, svc)
+		return ErrConverge
+	}
+
 	// If the ClusterIPs is malformed or not set we can't determine the
 	// ipFamily to use.
 	if len(svc.Spec.ClusterIPs) == 0 && svc.Spec.ClusterIP == "" {

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	"go.universe.tf/e2etest/pkg/config"
 	"go.universe.tf/e2etest/pkg/k8s"
 	"go.universe.tf/e2etest/pkg/service"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +20,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const secondNamespace = "test-namespace"
@@ -145,6 +146,95 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 					err := cs.CoreV1().Services(svc.Namespace).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
 					return err
 				}))
+	})
+
+	ginkgo.Context("IPV4 removing pools", func() {
+		var pool1 metallbv1beta1.IPAddressPool
+		var pool2 metallbv1beta1.IPAddressPool
+
+		ginkgo.AfterEach(func() {
+			// Clean previous configuration.
+			err := ConfigUpdater.Clean()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.BeforeEach(func() {
+			pool1 = metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			pool2 = metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+				},
+			}
+
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{pool1, pool2},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("removes all pools", func() {
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			defer func() {
+				service.Delete(cs, svc1)
+			}()
+
+			ginkgo.By("validate LoadBalancer IP is allocated from pool1")
+			err := config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool1}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting all pools")
+			err = ConfigUpdater.Client().DeleteAllOf(context.Background(), &metallbv1beta1.IPAddressPool{}, client.InNamespace(ConfigUpdater.Namespace()))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("validate LoadBalancer IP is removed from the svc")
+			gomega.Eventually(func() int {
+				s, err := cs.CoreV1().Services(svc1.Namespace).Get(context.Background(), svc1.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				return len(s.Status.LoadBalancer.Ingress)
+			}, time.Minute, 1*time.Second).Should(gomega.Equal(0))
+		})
+
+		ginkgo.It("reallocates svc after deleting a pool", func() {
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			defer func() {
+				service.Delete(cs, svc1)
+			}()
+
+			ginkgo.By("validate LoadBalancer IP is allocated from pool1")
+			err := config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool1}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting pool 1")
+			p := &metallbv1beta1.IPAddressPool{}
+			err = ConfigUpdater.Client().Get(context.Background(), client.ObjectKey{Namespace: ConfigUpdater.Namespace(), Name: pool1.Name}, p)
+			framework.ExpectNoError(err)
+			err = ConfigUpdater.Client().Delete(context.Background(), p)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("validate LoadBalancer IP is re-allocated from pool2")
+			gomega.Eventually(func() error {
+				svc1, err := cs.CoreV1().Services(svc1.Namespace).Get(context.Background(), svc1.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool2}, e2eservice.GetIngressPoint(
+					&svc1.Status.LoadBalancer.Ingress[0]))
+				return err
+			}, time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("IPV4 - Validate service allocation in address pools", func() {

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -45,7 +45,7 @@ func selector(s string) labels.Selector {
 
 func TestAssignment(t *testing.T) {
 	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"test": {
 			Name:       "test",
 			AutoAssign: true,
@@ -105,9 +105,7 @@ func TestAssignment(t *testing.T) {
 				ipnet("1000::9:0/120"),
 			},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	tests := []struct {
 		desc       string
@@ -651,7 +649,7 @@ func TestPoolAllocation(t *testing.T) {
 	// This test only allocates from the "test" pool, so it will run
 	// out of IPs quickly even though there are tons available in
 	// other pools.
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"not_this_one": {
 			Name:       "not_this_one",
 			AutoAssign: true,
@@ -672,9 +670,7 @@ func TestPoolAllocation(t *testing.T) {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("10.20.30.0/24"), ipnet("fc00::2:0/120")},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	validIP4s := map[string]bool{
 		"1.2.3.4":  true,
@@ -1103,7 +1099,7 @@ func TestPoolAllocation(t *testing.T) {
 
 func TestAllocation(t *testing.T) {
 	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"test1": {
 			Name:       "test1",
 			AutoAssign: true,
@@ -1114,9 +1110,7 @@ func TestAllocation(t *testing.T) {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.10/31"), ipnet("1000::10/127")},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	validIP4s := map[string]bool{
 		"1.2.3.4":  true,
@@ -1476,7 +1470,7 @@ func TestAllocation(t *testing.T) {
 
 func TestBuggyIPs(t *testing.T) {
 	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"test": {
 			Name:       "test",
 			AutoAssign: true,
@@ -1499,9 +1493,7 @@ func TestBuggyIPs(t *testing.T) {
 			AutoAssign:    true,
 			CIDR:          []*net.IPNet{ipnet("1.2.4.254/31")},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	validIPs := map[string]bool{
 		"1.2.3.0":   true,
@@ -1549,198 +1541,9 @@ func TestBuggyIPs(t *testing.T) {
 	}
 }
 
-func TestConfigReload(t *testing.T) {
-	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
-		"test": {
-			Name:       "test",
-			AutoAssign: true,
-			CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::/126")},
-		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
-	if err := alloc.Assign("s1", svc, []net.IP{net.ParseIP("1.2.3.0")}, nil, "", ""); err != nil {
-		t.Fatalf("Assign(s1, 1.2.3.0): %s", err)
-	}
-	if err := alloc.Assign("s2", svc, []net.IP{net.ParseIP("1000::")}, nil, "", ""); err != nil {
-		t.Fatalf("Assign(s2, 1000::): %s", err)
-	}
-	tests := []struct {
-		desc    string
-		pools   map[string]*config.Pool
-		wantErr bool
-		pool    string // Pool that 1.2.3.0 and 1000:: should be in
-	}{
-		{
-			desc: "set same config is no-op",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::/126")},
-				},
-			},
-			pool: "test",
-		},
-		{
-			desc: "expand pool",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("1000::/120")},
-				},
-			},
-			pool: "test",
-		},
-		{
-			desc: "shrink pool",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::/126")},
-				},
-			},
-			pool: "test",
-		},
-		{
-			desc: "can't shrink further",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31"), ipnet("1000::0/126")},
-				},
-			},
-			pool:    "test",
-			wantErr: true,
-		},
-		{
-			desc: "can't shrink further ipv6",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::2/127")},
-				},
-			},
-			pool:    "test",
-			wantErr: true,
-		},
-		{
-			desc: "rename the pool",
-			pools: map[string]*config.Pool{
-				"test2": {
-					Name:       "test2",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::0/126")},
-				},
-			},
-			pool: "test2",
-		},
-		{
-			desc: "split pool",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
-				},
-				"test2": {
-					Name:       "test2",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31"), ipnet("1000::2/127")},
-				},
-			},
-			pool: "test",
-		},
-		{
-			desc: "swap pool names",
-			pools: map[string]*config.Pool{
-				"test2": {
-					Name:       "test2",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
-				},
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31"), ipnet("1000::2/127")},
-				},
-			},
-			pool: "test2",
-		},
-		{
-			desc: "delete used pool",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31"), ipnet("1000::/126")},
-				},
-			},
-			pool:    "test2",
-			wantErr: true,
-		},
-		{
-			desc: "delete used pool ipv6",
-			pools: map[string]*config.Pool{
-				"test": {
-					Name:       "test",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30"), ipnet("1000::2/127")},
-				},
-			},
-			pool:    "test2",
-			wantErr: true,
-		},
-		{
-			desc: "delete unused pool",
-			pools: map[string]*config.Pool{
-				"test2": {
-					Name:       "test2",
-					AutoAssign: true,
-					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
-				},
-			},
-			pool: "test2",
-		},
-		{
-			desc: "enable buggy IPs not allowed",
-			pools: map[string]*config.Pool{
-				"test2": {
-					Name:          "test2",
-					AutoAssign:    true,
-					AvoidBuggyIPs: true,
-					CIDR:          []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
-				},
-			},
-			pool:    "test2",
-			wantErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		err := alloc.SetPools(&config.Pools{ByName: test.pools})
-		if test.wantErr {
-			if err == nil {
-				t.Errorf("%q should have failed to SetPools, but succeeded", test.desc)
-			}
-		} else if err != nil {
-			t.Errorf("%q failed to SetPools: %s", test.desc, err)
-		}
-		gotPool := alloc.Pool("s1")
-		if gotPool != test.pool {
-			t.Errorf("%q: s1 is in wrong pool, want %q, got %q", test.desc, test.pool, gotPool)
-		}
-	}
-}
-
 func TestAutoAssign(t *testing.T) {
 	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"test1": {
 			Name:       "test1",
 			AutoAssign: false,
@@ -1751,9 +1554,7 @@ func TestAutoAssign(t *testing.T) {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.10/31"), ipnet("1000::10/127")},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	validIP4s := map[string]bool{
 		"1.2.3.4":  false,
@@ -1988,7 +1789,7 @@ func TestPoolCount(t *testing.T) {
 
 func TestPoolMetrics(t *testing.T) {
 	alloc := New()
-	if err := alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
+	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
 		"test": {
 			Name:       "test",
 			AutoAssign: true,
@@ -1997,9 +1798,7 @@ func TestPoolMetrics(t *testing.T) {
 				ipnet("1000::4/126"),
 			},
 		},
-	}}); err != nil {
-		t.Fatalf("SetPools: %s", err)
-	}
+	}})
 
 	tests := []struct {
 		desc       string


### PR DESCRIPTION
Pool changes might invalidate the LB IPs of services. When this happens, the pool controller ignores the new configuration and continues operating with the current one. This PR modifies this behavior by always accepting the new configuration and letting the service controller to clear the IPs of the affected services.

Fixes #462