### PR TITLE
e2etests: logs and error output modifications

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -519,7 +519,7 @@ var _ = ginkgo.Describe("BGP", func() {
 					}
 				}
 				return nil
-			}, 4*time.Minute, 1*time.Second).Should(BeNil())
+			}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
 		},
 			ginkgo.Entry("IPV4 - default",
@@ -828,7 +828,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 						}
 						return nil
-					}, 1*time.Minute, 1*time.Second).Should(BeNil())
+					}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 				}
 
 			},
@@ -1195,7 +1195,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				err = k8s.CreateConfigmap(cs, "bgpextras", metallb.Namespace, extraData)
 				framework.ExpectNoError(err)
 			}
-			Eventually(checkRoutesAreInjected, time.Minute, 1*time.Second).Should(Not(HaveOccurred()))
+			Eventually(checkRoutesAreInjected, time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 		},
 			ginkgo.Entry("IPV4 - before config", "192.168.10.0/24", "172.16.1.%d/32", ipfamily.IPv4, before),
 			ginkgo.Entry("IPV6 - before config", "fc00:f853:0ccd:e799::/116", "fc00:f853:ccd:e800::%d/128", ipfamily.IPv6, before),
@@ -1359,7 +1359,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		}
 
 		ginkgo.By("Checking the service is not reacheable via L2")
-		Consistently(checkServiceL2, 3*time.Second, 1*time.Second).Should(Not(BeNil()))
+		Consistently(checkServiceL2, 3*time.Second, 1*time.Second).Should(HaveOccurred())
 
 		ginkgo.By("Creating the l2 advertisement")
 		l2Advertisement := metallbv1beta1.L2Advertisement{
@@ -1375,7 +1375,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		ginkgo.By("Checking the service is reacheable via L2")
 		Eventually(func() error {
 			return testservice.ValidateL2(svc)
-		}, 2*time.Minute, 1*time.Second).Should(BeNil())
+		}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
 		ginkgo.By("Checking the service is still reacheable via BGP")
 		for _, c := range FRRContainers {
@@ -1389,7 +1389,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		ginkgo.By("Checking the service is not reacheable via L2 anymore")
 		// We use arping here, because the client's cache may still be filled with the mac and the ip of the
 		// destination
-		Eventually(checkServiceL2, 5*time.Second, 1*time.Second).Should(Not(BeNil()))
+		Eventually(checkServiceL2, 5*time.Second, 1*time.Second).Should(HaveOccurred())
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{l2tests.IPV4ServiceRange}),
 		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{l2tests.IPV6ServiceRange}),

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -214,7 +214,7 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 								}
 							}
 							return nil
-						}, 1*time.Minute, 1*time.Second).Should(BeNil())
+						}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 					}
 				}
 			},

--- a/e2etest/bgptests/metrics.go
+++ b/e2etest/bgptests/metrics.go
@@ -218,7 +218,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						}
 					}
 					return nil
-				}, 2*time.Minute, 1*time.Second).Should(BeNil())
+				}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 			}
 		},
 			ginkgo.Entry("IPV4 - Checking service", ipfamily.IPv4, v4PoolAddresses, 256),
@@ -288,7 +288,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					return err
 				}
 				return nil
-			}, 2*time.Minute, 1*time.Second).Should(BeNil())
+			}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
 			selectors := labelsForPeers(FRRContainers, ipFamily)
 
@@ -319,7 +319,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						}
 					}
 					return nil
-				}, 2*time.Minute, 1*time.Second).Should(BeNil())
+				}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 			}
 
 			ginkgo.By("creating a service")
@@ -341,7 +341,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					return err
 				}
 				return nil
-			}, 2*time.Minute, 1*time.Second).Should(BeNil())
+			}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
 			for _, speaker := range speakerPods {
 				ginkgo.By(fmt.Sprintf("checking speaker %s", speaker.Name))
@@ -385,7 +385,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						return err
 					}
 					return nil
-				}, 2*time.Minute, 1*time.Second).Should(BeNil())
+				}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 			}
 		},
 			ginkgo.Entry("IPV4 - Checking service", ipfamily.IPv4, v4PoolAddresses, 256),
@@ -522,7 +522,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					}
 				}
 				return nil
-			}, time.Minute, 5*time.Second).Should(BeNil())
+			}, time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		ginkgo.By("disabling BFD in external FRR containers")
@@ -563,7 +563,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					}
 				}
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(BeNil())
+			}, 2*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 		}
 	},
 		ginkgo.Entry("IPV4 - default",

--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -123,7 +123,10 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 			secondService, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "second-lb", testservice.WithSpecificPool("second-pool"))
 			defer testservice.Delete(cs, secondService)
 
+			ginkgo.By(fmt.Sprintf("Checking service %s is announced only from expected nodes", firstService.Name))
 			checkServiceOnlyOnNodes(firstService, expectedNodesForFirstPool, pairingIPFamily)
+
+			ginkgo.By(fmt.Sprintf("Checking service %s is announced only from expected nodes", secondService.Name))
 			checkServiceOnlyOnNodes(secondService, expectedNodesForSecondPool, pairingIPFamily)
 		},
 		ginkgo.Entry("IPV4 - two on first, two on second", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}, []int{0, 1}, []int{0, 1}),

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -57,7 +57,7 @@ func validateFRRPeeredWithNodes(nodes []corev1.Node, c *frrcontainer.FRR, ipFami
 			return fmt.Errorf("failed to match neighbors for %s, %w", c.Name, err)
 		}
 		return nil
-	}, 4*time.Minute, 1*time.Second).Should(BeNil(), "timed out waiting to validate nodes peered with the frr instance")
+	}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred(), "timed out waiting to validate nodes peered with the frr instance")
 }
 
 func validateService(svc *corev1.Service, nodes []corev1.Node, c *frrcontainer.FRR) {
@@ -150,7 +150,7 @@ func frrIsPairedOnPods(cs clientset.Interface, n *frrcontainer.FRR, ipFamily ipf
 			}
 		}
 		return nil
-	}, 4*time.Minute, 1*time.Second).Should(BeNil())
+	}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 func checkBFDConfigPropagated(nodeConfig metallbv1beta1.BFDProfile, peerConfig bgpfrr.BFDPeer) error {
@@ -203,7 +203,7 @@ func checkServiceOnlyOnNodes(svc *corev1.Service, expectedNodes []corev1.Node, i
 				return fmt.Errorf("unexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
 			}
 			return err
-		}, time.Minute, time.Second).Should(Not(HaveOccurred()))
+		}, time.Minute, time.Second).ShouldNot(HaveOccurred())
 	}
 }
 
@@ -257,7 +257,7 @@ func checkCommunitiesOnlyOnNodes(svc *corev1.Service, community string, expected
 				return fmt.Errorf("unexpectedIP found %s, nodes %s in container %s for service %s", n.String(), nodeIps, c.Name, ip)
 			}
 			return err
-		}, 10*time.Minute, time.Second).Should(Not(HaveOccurred()))
+		}, 10*time.Minute, time.Second).ShouldNot(HaveOccurred())
 	}
 }
 
@@ -332,7 +332,7 @@ func validateServiceInRoutesForCommunity(c *frrcontainer.FRR, community string, 
 			}
 		}
 		return nil
-	}, 4*time.Minute, 1*time.Second).Should(Not(HaveOccurred()))
+	}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 func validateServiceNotInRoutesForCommunity(c *frrcontainer.FRR, community string, family ipfamily.Family, svc *corev1.Service) {

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -57,13 +57,14 @@ func validateFRRPeeredWithNodes(nodes []corev1.Node, c *frrcontainer.FRR, ipFami
 			return fmt.Errorf("failed to match neighbors for %s, %w", c.Name, err)
 		}
 		return nil
-	}, 4*time.Minute, 1*time.Second).Should(BeNil())
+	}, 4*time.Minute, 1*time.Second).Should(BeNil(), "timed out waiting to validate nodes peered with the frr instance")
 }
 
 func validateService(svc *corev1.Service, nodes []corev1.Node, c *frrcontainer.FRR) {
+	ginkgo.By(fmt.Sprintf("Validating service %s is announced to container: %s", svc.Name, c.Name))
 	Eventually(func() error {
 		return validateServiceNoWait(svc, nodes, c)
-	}, 4*time.Minute, 1*time.Second).Should(BeNil())
+	}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred(), "timed out waiting to validate service")
 }
 
 func validateServiceNoWait(svc *corev1.Service, nodes []corev1.Node, c *frrcontainer.FRR) error {
@@ -85,7 +86,7 @@ func validateServiceNoWait(svc *corev1.Service, nodes []corev1.Node, c *frrconta
 			address := fmt.Sprintf("http://%s/", hostport)
 			err := wget.Do(address, c)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to wget from %s to %s: %w", c.Name, address, err)
 			}
 		}
 

--- a/e2etest/l2tests/interface_selector.go
+++ b/e2etest/l2tests/interface_selector.go
@@ -222,7 +222,7 @@ var _ = ginkgo.Describe("L2-interface selector", func() {
 					}
 				}
 				return fmt.Errorf("service hasn't receive the \"announceFailed\" event")
-			}, 1*time.Minute, 1*time.Second).Should(gomega.BeNil())
+			}, 1*time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("Address pool connected with two L2 advertisements", func() {

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -127,7 +127,7 @@ var _ = ginkgo.Describe("L2", func() {
 
 			gomega.Eventually(func() error {
 				return service.ValidateL2(svc)
-			}, 2*time.Minute, 1*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("should work for ExternalTrafficPolicy=Local", func() {
@@ -178,7 +178,7 @@ var _ = ginkgo.Describe("L2", func() {
 				}
 
 				return nil
-			}, 5*time.Second, 1*time.Second).Should(gomega.BeNil())
+			}, 5*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("IPV4 Should work with mixed protocol services", func() {
@@ -315,7 +315,7 @@ var _ = ginkgo.Describe("L2", func() {
 
 			gomega.Eventually(func() error {
 				return service.ValidateL2(svc)
-			}, 2*time.Minute, 1*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 		},
 			ginkgo.Entry("AddressPool defined by address range", func() []metallbv1beta1.IPAddressPool {
 				return []metallbv1beta1.IPAddressPool{
@@ -453,7 +453,7 @@ var _ = ginkgo.Describe("L2", func() {
 				return fmt.Errorf("service announced from different nodes %s %s", service1Announce, service2Announce)
 			}
 			return nil
-		}, 2*time.Minute, 1*time.Second).Should(gomega.BeNil())
+		}, 2*time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 
 	},
 		ginkgo.Entry("IPV4", &IPV4ServiceRange),
@@ -529,7 +529,7 @@ var _ = ginkgo.Describe("L2", func() {
 					return err
 				}
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 5*time.Second).ShouldNot(gomega.HaveOccurred())
 
 			ginkgo.By("creating a service")
 			svc, _ := service.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", service.TrafficPolicyCluster)
@@ -555,7 +555,7 @@ var _ = ginkgo.Describe("L2", func() {
 					return err
 				}
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 5*time.Second).ShouldNot(gomega.HaveOccurred())
 
 			ingressIP := e2eservice.GetIngressPoint(
 				&svc.Status.LoadBalancer.Ingress[0])
@@ -636,7 +636,7 @@ var _ = ginkgo.Describe("L2", func() {
 				}
 
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 5*time.Second).ShouldNot(gomega.HaveOccurred())
 
 			// Negative - validate that the other speakers don't publish layer2 metrics
 			delete(speakerPods, advSpeaker.Spec.NodeName)
@@ -674,7 +674,7 @@ var _ = ginkgo.Describe("L2", func() {
 				}
 
 				return nil
-			}, time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, time.Minute, 5*time.Second).ShouldNot(gomega.HaveOccurred())
 		},
 			ginkgo.Entry("IPV4 - Checking service", "ipv4"),
 			ginkgo.Entry("IPV6 - Checking service", "ipv6"))

--- a/e2etest/pkg/wget/wget.go
+++ b/e2etest/pkg/wget/wget.go
@@ -3,6 +3,7 @@
 package wget
 
 import (
+	"fmt"
 	"os/exec"
 
 	"go.universe.tf/metallb/e2etest/pkg/executor"
@@ -15,13 +16,16 @@ const (
 )
 
 func Do(address string, exc executor.Executor) error {
-	retrycnt := 0
-	var code int
-	var err error
+	var (
+		code     int
+		err      error
+		out      string
+		retrycnt = 0
+	)
 
 	// Retry loop to handle wget NetworkFailure errors
 	for {
-		_, err = exc.Exec("wget", "-O-", "-q", address, "-T", "60")
+		out, err = exc.Exec("wget", "-O-", "-q", address, "-T", "60")
 		if exitErr, ok := err.(*exec.ExitError); err != nil && ok {
 			code = exitErr.ExitCode()
 		} else {
@@ -34,5 +38,8 @@ func Do(address string, exc executor.Executor) error {
 			break
 		}
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, out)
+	}
+	return nil
 }

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -306,7 +306,7 @@ func TestNodeEvent(t *testing.T) {
 			return err
 		}
 		return nil
-	}, 5*time.Second, 200*time.Millisecond).Should(BeNil())
+	}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()
@@ -327,7 +327,7 @@ func TestNodeEvent(t *testing.T) {
 			return err
 		}
 		return nil
-	}, 5*time.Second, 200*time.Millisecond).Should(BeNil())
+	}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()

--- a/internal/k8s/controllers/node_controller_test.go
+++ b/internal/k8s/controllers/node_controller_test.go
@@ -203,7 +203,7 @@ func TestNodeReconciler_SetupWithManager(t *testing.T) {
 			return err
 		}
 		return nil
-	}, 5*time.Second, 200*time.Millisecond).Should(BeNil())
+	}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()
@@ -224,7 +224,7 @@ func TestNodeReconciler_SetupWithManager(t *testing.T) {
 			return err
 		}
 		return nil
-	}, 5*time.Second, 200*time.Millisecond).Should(BeNil())
+	}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
 	g.Eventually(func() int {
 		mutex.Lock()
 		defer mutex.Unlock()


### PR DESCRIPTION
This PR includes 2 commits that modify the e2etest:
1. Add more verbose logs to tests and modify the `wget` error output to include the std message.
2. Modify Gomega error assertions to be aligned with best practices.