### PR TITLE
E2E assignement tests: retry to apply the labels

### DIFF
--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -61,8 +61,10 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Updating the first namespace labels")
-		err = k8s.ApplyLabelsToNamespace(cs, f.Namespace.Name, firstNsLabels)
-		framework.ExpectNoError(err)
+		gomega.Eventually(func() error {
+			err := k8s.ApplyLabelsToNamespace(cs, f.Namespace.Name, firstNsLabels)
+			return err
+		}, 30*time.Second, 1*time.Second).Should(gomega.Succeed())
 
 		ginkgo.By("Creating a second namespace")
 


### PR DESCRIPTION
We apply the labels to the ns right after its creation. Because of this, if the namespace is changed by the cluster we might get a "the object has been modified" error.
