### PR TITLE
Add "ginkgo_params" flag to the e2etests task

### DIFF
--- a/e2etest/README.md
+++ b/e2etest/README.md
@@ -24,6 +24,11 @@ Run only L2 test suite:
 inv e2etest --focus L2
 ```
 
+Run with additional ginkgo parameters for example:
+```
+inv e2etest --ginkgo-params="--until-it-fails -v"
+```
+
 The test suite will run the appropriate tests against the cluster.
 Be sure to cleanup any previously created development clusters using `inv dev-env-cleanup`.
 

--- a/tasks.py
+++ b/tasks.py
@@ -781,8 +781,9 @@ def helmdocs(ctx, env="container"):
     "external_containers": "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)",
     "native_bgp": "tells if the given cluster is deployed using native bgp mode ",
     "external_frr_image": "overrides the image used for the external frr containers used in tests",
+    "ginkgo_params": "additional ginkgo params to run the e2e tests with"
 })
-def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="kube-system,metallb-system", service_pod_port=80, skip_docker=False, focus="", skip="", ipv4_service_range=None, ipv6_service_range=None, prometheus_namespace="", node_nics="kind", local_nics="kind", external_containers="", native_bgp=False,external_frr_image=""):
+def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="kube-system,metallb-system", service_pod_port=80, skip_docker=False, focus="", skip="", ipv4_service_range=None, ipv6_service_range=None, prometheus_namespace="", node_nics="kind", local_nics="kind", external_containers="", native_bgp=False,external_frr_image="", ginkgo_params=""):
     """Run E2E tests against development cluster."""
     _fetch_kubectl()
 
@@ -845,7 +846,7 @@ def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="k
     if external_frr_image != "":
         external_frr_image = "--frr-image="+(external_frr_image)
     testrun = run("cd `git rev-parse --show-toplevel`/e2etest &&"
-            "KUBECONFIG={} ginkgo --timeout=3h {} {} -- --provider=local --kubeconfig={} --service-pod-port={} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {} {}  -bgp-native-mode={} {}".format(kubeconfig, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ipv4_service_range, ipv6_service_range, opt_skip_docker, report_path, prometheus_namespace, node_nics, local_nics, external_containers, native_bgp, external_frr_image), warn="True")
+            "KUBECONFIG={} ginkgo {} --timeout=3h {} {} -- --provider=local --kubeconfig={} --service-pod-port={} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {} {}  -bgp-native-mode={} {}".format(kubeconfig, ginkgo_params, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ipv4_service_range, ipv6_service_range, opt_skip_docker, report_path, prometheus_namespace, node_nics, local_nics, external_containers, native_bgp, external_frr_image), warn="True")
 
     if export != None:
         run("kind export logs {}".format(export))


### PR DESCRIPTION
This commit adds a "ginkgo_params" flag to the e2etests task. This addition is to enable developers to insert ginkgo params that are not already covered by existing parameters (focus and skip)

A simple example of this feature is running the e2etests with the --until-it-fails flag, which is handy for catching flaky tests.

The implementation injects the value of this new parameter in the ginkgo test run command. and It's possible to add numerous ginkgo params for example:
`invoke e2etest --ginkgo-params="--until-it-fails -v --focus=L2"`

Also, added a mention of this new flag in the e2etests/README.md.

Fixed #1955 