### PR TITLE
BGP: invoke SyncBFDProfiles on empty lists too

### DIFF
--- a/internal/bgp/frr/frr_bfd_test.go
+++ b/internal/bgp/frr/frr_bfd_test.go
@@ -182,3 +182,34 @@ func TestBFDProfileAllDefault(t *testing.T) {
 		t.Fatalf("Failed to sync bfd profiles %s", err)
 	}
 }
+
+func TestBFDProfileThenDelete(t *testing.T) {
+	testSetup(t)
+
+	pp := map[string]*config.BFDProfile{
+		"foo": {
+			Name:             "foo",
+			ReceiveInterval:  pointer.Uint32Ptr(60),
+			TransmitInterval: pointer.Uint32Ptr(70),
+			DetectMultiplier: pointer.Uint32Ptr(5),
+			EchoInterval:     pointer.Uint32Ptr(90),
+			EchoMode:         false,
+			PassiveMode:      false,
+			MinimumTTL:       pointer.Uint32Ptr(60),
+		},
+	}
+	l := log.NewNopLogger()
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+
+	err := sessionManager.SyncBFDProfiles(pp)
+	if err != nil {
+		t.Fatalf("Failed to sync bfd profiles: %s", err)
+	}
+
+	err = sessionManager.SyncBFDProfiles(map[string]*config.BFDProfile{})
+	if err != nil {
+		t.Fatalf("Failed to sync bfd profiles: %s", err)
+	}
+	testCheckConfigFile(t)
+}

--- a/internal/bgp/frr/testdata/TestBFDProfileThenDelete.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileThenDelete.golden
@@ -1,0 +1,7 @@
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -75,7 +75,10 @@ func (sm *sessionManager) NewSession(l log.Logger, args bgp.SessionParameters) (
 }
 
 func (sm *sessionManager) SyncBFDProfiles(profiles map[string]*config.BFDProfile) error {
-	return errors.New("bfd profiles not supported in native mode")
+	if len(profiles) > 0 {
+		return errors.New("bfd profiles not supported in native mode")
+	}
+	return nil
 }
 
 func (sm *sessionManager) SyncExtraInfo(extras string) error {

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -268,10 +268,6 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 }
 
 func (c *bgpController) syncBFDProfiles(profiles map[string]*config.BFDProfile) error {
-	if len(profiles) == 0 {
-		return nil
-	}
-
 	return c.sessionManager.SyncBFDProfiles(profiles)
 }
 


### PR DESCRIPTION
When a bfd profile is deleted, the sync is not called and we leave the bfd profile filled even if it was deleted on the CR side.

Additionally, we add a unit test to validate the deletion works properly.
