### PR TITLE
Make the configuration conversion stable

### DIFF
--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -298,8 +298,8 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			advConfig := advertisementConfig{
 				IPFamily:         family,
 				Prefix:           prefix,
-				Communities:      communities,
-				LargeCommunities: largeCommunities,
+				Communities:      sort.StringSlice(communities),
+				LargeCommunities: sort.StringSlice(largeCommunities),
 				LocalPref:        adv.LocalPref,
 			}
 
@@ -313,6 +313,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				neighbor.HasV6Advertisements = true
 			}
 		}
+		sortAdvertiesements(neighbor.Advertisements)
 	}
 
 	for _, r := range sortMap(routers) {
@@ -457,4 +458,36 @@ func sortMap[T any](toSort map[string]T) []T {
 		res = append(res, toSort[k])
 	}
 	return res
+}
+
+func sortAdvertiesements(toSort []*advertisementConfig) {
+	sort.Slice(toSort, func(i, j int) bool {
+		if toSort[i].IPFamily != toSort[j].IPFamily {
+			return toSort[i].IPFamily < toSort[j].IPFamily
+		}
+		if toSort[i].Prefix != toSort[j].Prefix {
+			return toSort[i].Prefix < toSort[j].Prefix
+		}
+		if toSort[i].LocalPref != toSort[j].LocalPref {
+			return toSort[i].LocalPref < toSort[j].LocalPref
+		}
+		if len(toSort[i].Communities) != len(toSort[j].Communities) {
+			return len(toSort[i].Communities) < len(toSort[j].Communities)
+		}
+		for k := range toSort[i].Communities {
+			if toSort[i].Communities[k] != toSort[j].Communities[k] {
+				return toSort[i].Communities[k] < toSort[j].Communities[k]
+			}
+		}
+		if len(toSort[i].LargeCommunities) != len(toSort[j].LargeCommunities) {
+			return len(toSort[i].LargeCommunities) < len(toSort[j].LargeCommunities)
+		}
+
+		for k := range toSort[i].LargeCommunities {
+			if toSort[i].LargeCommunities[k] != toSort[j].LargeCommunities[k] {
+				return toSort[i].LargeCommunities[k] < toSort[j].LargeCommunities[k]
+			}
+		}
+		return false
+	})
 }

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -142,7 +142,7 @@ var requestHandler = func(r *ConfigReconciler, ctx context.Context, req ctrl.Req
 
 	level.Debug(r.Logger).Log("controller", "ConfigReconciler", "metallb CRs and Secrets", dumpClusterResources(&resources))
 
-	cfg, err := config.For(resources, r.ValidateConfig)
+	cfg, err := toConfig(resources, r.ValidateConfig)
 	if err != nil {
 		configStale.Set(1)
 		level.Error(r.Logger).Log("controller", "ConfigReconciler", "error", "failed to parse the configuration", "error", err)

--- a/internal/k8s/controllers/config_conversion.go
+++ b/internal/k8s/controllers/config_conversion.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package controllers
+
+import (
+	"sort"
+
+	"go.universe.tf/metallb/internal/config"
+)
+
+func toConfig(fromK8s config.ClusterResources, validate config.Validate) (*config.Config, error) {
+	resources := config.ClusterResources{
+		Pools:              sortedCopy(fromK8s.Pools),
+		Peers:              sortedCopy(fromK8s.Peers),
+		BFDProfiles:        sortedCopy(fromK8s.BFDProfiles),
+		L2Advs:             sortedCopy(fromK8s.L2Advs),
+		BGPAdvs:            sortedCopy(fromK8s.BGPAdvs),
+		LegacyAddressPools: sortedCopy(fromK8s.LegacyAddressPools),
+		Communities:        sortedCopy(fromK8s.Communities),
+		PasswordSecrets:    fromK8s.PasswordSecrets,
+		Nodes:              sortedCopy(fromK8s.Nodes),
+		Namespaces:         sortedCopy(fromK8s.Namespaces),
+		BGPExtras:          fromK8s.BGPExtras,
+	}
+
+	cfg, err := config.For(resources, validate)
+	return cfg, err
+}
+
+// We need to do this ballet because we need to leverage the GetName() function
+// of the objects, but the interface is implemented by the pointer, not the object,
+// whereas what we are given with .Items is the slice of objects.
+func sortedCopy[T any, PT interface {
+	GetName() string
+	*T
+}](toSort []T) []T {
+	res := make([]T, len(toSort))
+	copy(res, toSort)
+	sort.Slice(res, func(i, j int) bool {
+		first := PT(&toSort[i])
+		second := PT(&toSort[j])
+		return first.GetName() < second.GetName()
+	})
+	return res
+}

--- a/internal/k8s/controllers/config_conversion_test.go
+++ b/internal/k8s/controllers/config_conversion_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package controllers
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	v1beta1 "go.universe.tf/metallb/api/v1beta1"
+	v1beta2 "go.universe.tf/metallb/api/v1beta2"
+	"go.universe.tf/metallb/internal/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConversionIsStable(t *testing.T) {
+	peers := []v1beta2.BGPPeer{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "peer1",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta2.BGPPeerSpec{
+				MyASN:      42,
+				ASN:        142,
+				Address:    "1.2.3.4",
+				BFDProfile: "default",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "peer2",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta2.BGPPeerSpec{
+				MyASN:      42,
+				ASN:        142,
+				Address:    "1.2.3.5",
+				BFDProfile: "default",
+			},
+		},
+	}
+	bfdProfiles := []v1beta1.BFDProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: "metallb-system",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "metallb-system",
+			},
+		},
+	}
+	pools := []v1beta1.IPAddressPool{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool1",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.IPAddressPoolSpec{
+				Addresses: []string{
+					"10.20.0.0/16",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool2",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.IPAddressPoolSpec{
+				Addresses: []string{
+					"10.10.0.0/16",
+				},
+				AllocateTo: &v1beta1.ServiceAllocation{
+					Namespaces: []string{"foo", "bar"},
+				},
+			},
+		},
+	}
+	legacyAddressPools := []v1beta1.AddressPool{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacypool1",
+				Namespace: testNamespace,
+			},
+			Spec: v1beta1.AddressPoolSpec{
+				Addresses: []string{
+					"10.21.0.0/16",
+				},
+				Protocol: "bgp",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacypool2",
+				Namespace: testNamespace,
+			},
+			Spec: v1beta1.AddressPoolSpec{
+				Addresses: []string{
+					"10.22.0.0/16",
+				},
+				Protocol: "layer2",
+			},
+		},
+	}
+	bgpAdvs := []v1beta1.BGPAdvertisement{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "adv1",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.BGPAdvertisementSpec{
+				Communities: []string{"bar"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "adv2",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.BGPAdvertisementSpec{
+				Communities: []string{"bar2"},
+			},
+		},
+	}
+	l2Advs := []v1beta1.L2Advertisement{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "l2adv1",
+				Namespace: "metallb-system",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "l2adv2",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.L2AdvertisementSpec{
+				Interfaces: []string{"foo"},
+			},
+		},
+	}
+
+	communities := []v1beta1.Community{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "community",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.CommunitySpec{
+				Communities: []v1beta1.CommunityAlias{
+					{
+						Name:  "bar",
+						Value: "64512:1234",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "community1",
+				Namespace: "metallb-system",
+			},
+			Spec: v1beta1.CommunitySpec{
+				Communities: []v1beta1.CommunityAlias{
+					{
+						Name:  "bar2",
+						Value: "64512:1235",
+					},
+				},
+			},
+		},
+	}
+	namespaces := []v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+	}
+	nodes := []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+			},
+		},
+	}
+
+	resources := config.ClusterResources{
+		Pools:              pools,
+		Peers:              peers,
+		BFDProfiles:        bfdProfiles,
+		L2Advs:             l2Advs,
+		BGPAdvs:            bgpAdvs,
+		LegacyAddressPools: legacyAddressPools,
+		Communities:        communities,
+		PasswordSecrets:    map[string]v1.Secret{},
+		Nodes:              nodes,
+		Namespaces:         namespaces,
+	}
+
+	firstConfig, err := toConfig(resources, config.DontValidate)
+
+	if err != nil {
+		t.Fatalf("conversion failed, err %v", err)
+	}
+	seed := time.Now().UnixNano()
+	rand.Seed(seed)
+
+	// Here we check the stability of the conversion, by shuffling the
+	// order of the resources and checking that the output is the same.
+	for i := 0; i < 100; i++ {
+		shuffleObjects(resources.Peers)
+		shuffleObjects(resources.BFDProfiles)
+		shuffleObjects(resources.Pools)
+		shuffleObjects(resources.BGPAdvs)
+		shuffleObjects(resources.L2Advs)
+		shuffleObjects(resources.Communities)
+		shuffleObjects(resources.LegacyAddressPools)
+		shuffleObjects(resources.Nodes)
+		shuffleObjects(resources.Namespaces)
+
+		config, err := toConfig(resources, config.DontValidate)
+
+		if err != nil {
+			t.Fatalf("conversion failed, seed %d, %v", seed, err)
+		}
+
+		if !reflect.DeepEqual(config, firstConfig) {
+			t.Fatalf("conversion is not stable, seed %d, current %v\n previous %v\n", seed, spew.Sdump(config), spew.Sdump(firstConfig))
+		}
+	}
+}
+
+func shuffleObjects[T any](toShuffle []T) {
+	rand.Shuffle(len(toShuffle), func(i, j int) { toShuffle[i], toShuffle[j] = toShuffle[j], toShuffle[i] })
+}

--- a/internal/k8s/controllers/pool_controller.go
+++ b/internal/k8s/controllers/pool_controller.go
@@ -83,7 +83,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	level.Debug(r.Logger).Log("controller", "PoolReconciler", "metallb CRs", dumpClusterResources(&resources))
 
-	cfg, err := config.For(resources, r.ValidateConfig)
+	cfg, err := toConfig(resources, r.ValidateConfig)
 	if err != nil {
 		configStale.Set(1)
 		level.Error(r.Logger).Log("controller", "PoolReconciler", "error", "failed to parse the configuration", "error", err)


### PR DESCRIPTION
When translating the configuration coming from the k8s api to the internal one, the outcome depends on the order in which the cache returns us the various items. This may cause unnecessary reloads.

In order to avoid this, we pre-order the list of items to feed the conversion with.
The sorting is done in a conversion function in the controller (rather than the config package) in order to make it harder to forget to add the sorting action.

