### PR TITLE
Change 'interface to exclude' log level

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -73,7 +73,7 @@ func (a *Announce) updateInterfaces() {
 		ifi := intf
 
 		if (a.excludeRegexp != nil) && a.excludeRegexp.MatchString(ifi.Name) {
-			level.Info(a.logger).Log("event", "announced interface to exclude", "interface", ifi.Name)
+			level.Debug(a.logger).Log("event", "announced interface to exclude", "interface", ifi.Name)
 			continue
 		}
 


### PR DESCRIPTION
This commit changes the log level from Info to Debug as this log is called every 10 seconds and spams/bloats the speaker's logs.

See example:
```
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:49:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:49:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:49:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:49:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:10Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:10Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:10Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:10Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:20Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:20Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:20Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:20Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:30Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:30Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:30Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:30Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:40Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:40Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:40Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:40Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:50:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:50:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:50:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:50:50Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"lo","level":"info","ts":"2023-07-01T12:51:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth9d893234","level":"info","ts":"2023-07-01T12:51:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth1d7c0ce9","level":"info","ts":"2023-07-01T12:51:00Z"}
{"caller":"announcer.go:76","event":"announced interface to exclude","interface":"veth940dd62c","level":"info","ts":"2023-07-01T12:51:00Z"}

```
