### PR TITLE
Multiip mode, metallb.universe.tf/enforced-single-node annotation

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -22,11 +24,11 @@ import (
 type Allocator struct {
 	pools *config.Pools
 
-	allocated       map[string]*alloc          // svc -> alloc
-	sharingKeyForIP map[string]*key            // ip.String() -> assigned sharing key
-	portsInUse      map[string]map[Port]string // ip.String() -> Port -> svc
-	servicesOnIP    map[string]map[string]bool // ip.String() -> svc -> allocated?
-	poolIPsInUse    map[string]map[string]int  // poolName -> ip.String() -> number of users
+	allocated       map[string]*alloc              // svc -> alloc
+	sharingKeyForIP map[netip.Addr]*key            // ip -> assigned sharing key
+	portsInUse      map[netip.Addr]map[Port]string // ip -> Port -> svc
+	servicesOnIP    map[netip.Addr]map[string]bool // ip -> svc -> allocated?
+	poolIPsInUse    map[string]map[netip.Addr]int  // poolName -> ip -> number of users
 }
 
 // Port represents one port in use by a service.
@@ -46,10 +48,41 @@ type key struct {
 }
 
 type alloc struct {
-	pool  string
-	ips   []net.IP
-	ports []Port
+	ipPools map[netip.Addr]string
+	ports   []Port
 	key
+}
+
+func (a *alloc) ips() []netip.Addr {
+	var out []netip.Addr
+	for ip := range a.ipPools {
+		out = append(out, ip)
+	}
+	return out
+}
+
+func (a *alloc) poolsUnique() []string {
+	keys := make(map[string]bool)
+	var pools []string
+	for _, pool := range a.ipPools {
+		if _, value := keys[pool]; !value {
+			keys[pool] = true
+			pools = append(pools, pool)
+		}
+	}
+	return pools
+}
+
+func uniqifyPools(pools map[netip.Addr]*config.Pool) []string {
+	keys := make(map[string]bool)
+	var out []string
+	for _, pool := range pools {
+		if _, value := keys[pool.Name]; !value {
+			keys[pool.Name] = true
+			out = append(out, pool.Name)
+		}
+	}
+	return out
 }
 
 // New returns an Allocator managing no pools.
@@ -58,10 +91,10 @@ func New() *Allocator {
 		pools: &config.Pools{ByName: map[string]*config.Pool{}},
 
 		allocated:       map[string]*alloc{},
-		sharingKeyForIP: map[string]*key{},
-		portsInUse:      map[string]map[Port]string{},
-		servicesOnIP:    map[string]map[string]bool{},
-		poolIPsInUse:    map[string]map[string]int{},
+		sharingKeyForIP: map[netip.Addr]*key{},
+		portsInUse:      map[netip.Addr]map[Port]string{},
+		servicesOnIP:    map[netip.Addr]map[string]bool{},
+		poolIPsInUse:    map[string]map[netip.Addr]int{},
 	}
 }
 
@@ -72,9 +105,9 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 	// only question we have to answer is: can we fit all allocated
 	// IPs into address pools under the new configuration?
 	for svc, alloc := range a.allocated {
-		pool := poolFor(pools.ByName, alloc.ips)
-		if pool == nil {
-			return fmt.Errorf("new config not compatible with assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
+		pools := poolsFor(pools.ByName, alloc.ips())
+		if len(pools) == 0 {
+			return fmt.Errorf("new config not compatible with assigned IPs: service %q cannot own %q under new config", svc, alloc.ips())
 		}
 	}
 
@@ -90,13 +123,19 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 
 	// Need to rearrange existing pool mappings and counts
 	for svc, alloc := range a.allocated {
-		pool := poolFor(a.pools.ByName, alloc.ips)
-		if pool == nil {
-			return fmt.Errorf("can't retrieve new pool for assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
+		pools := poolsFor(a.pools.ByName, alloc.ips())
+		if len(pools) == 0 {
+			return fmt.Errorf("can't retrieve new pool for assigned IPs: service %q cannot own %q under new config", svc, alloc.ips())
 		}
-		if pool.Name != alloc.pool {
-			a.Unassign(svc)
-			alloc.pool = pool.Name
+		allocPools := alloc.poolsUnique()
+		sort.Strings(allocPools)
+		newPools := uniqifyPools(pools)
+		sort.Strings(newPools)
+		if !reflect.DeepEqual(allocPools, newPools) {
+			alloc.ipPools = make(map[netip.Addr]string, 0)
+			for ip, pool := range pools {
+				alloc.ipPools[ip] = pool.Name
+			}
 			// Use the internal assign, we know for a fact the IP is
 			// still usable.
 			a.assign(svc, alloc)
@@ -117,58 +156,75 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 func (a *Allocator) assign(svc string, alloc *alloc) {
 	a.Unassign(svc)
 	a.allocated[svc] = alloc
-	for _, ip := range alloc.ips {
-		a.sharingKeyForIP[ip.String()] = &alloc.key
-		if a.portsInUse[ip.String()] == nil {
-			a.portsInUse[ip.String()] = map[Port]string{}
+	for ip, pool := range alloc.ipPools {
+		a.sharingKeyForIP[ip] = &alloc.key
+		if a.portsInUse[ip] == nil {
+			a.portsInUse[ip] = map[Port]string{}
 		}
 		for _, port := range alloc.ports {
-			a.portsInUse[ip.String()][port] = svc
+			a.portsInUse[ip][port] = svc
 		}
-		if a.servicesOnIP[ip.String()] == nil {
-			a.servicesOnIP[ip.String()] = map[string]bool{}
+		if a.servicesOnIP[ip] == nil {
+			a.servicesOnIP[ip] = map[string]bool{}
 		}
-		a.servicesOnIP[ip.String()][svc] = true
-		if a.poolIPsInUse[alloc.pool] == nil {
-			a.poolIPsInUse[alloc.pool] = map[string]int{}
+		a.servicesOnIP[ip][svc] = true
+		if a.poolIPsInUse[pool] == nil {
+			a.poolIPsInUse[pool] = map[netip.Addr]int{}
 		}
-		a.poolIPsInUse[alloc.pool][ip.String()]++
+		a.poolIPsInUse[pool][ip]++
 	}
-	stats.poolCapacity.WithLabelValues(alloc.pool).Set(float64(poolCount(a.pools.ByName[alloc.pool])))
-	stats.poolActive.WithLabelValues(alloc.pool).Set(float64(len(a.poolIPsInUse[alloc.pool])))
+	for _, pool := range alloc.poolsUnique() {
+		stats.poolCapacity.WithLabelValues(pool).Set(float64(poolCount(a.pools.ByName[pool])))
+		stats.poolActive.WithLabelValues(pool).Set(float64(len(a.poolIPsInUse[pool])))
+	}
+}
+
+func ConvertIpsToAddrs(ips []net.IP) []netip.Addr {
+	var out []netip.Addr
+	for _, ip := range ips {
+		addr, _ := netip.AddrFromSlice(ip)
+		out = append(out, addr)
+	}
+	return out
+}
+
+func ConvertAddrsToIps(ips []netip.Addr) []net.IP {
+	var out []net.IP
+	for _, ip := range ips {
+		out = append(out, ip.AsSlice())
+	}
+	return out
 }
 
 // Assign assigns the requested ip to svc, if the assignment is
 // permissible by sharingKey and backendKey.
-func (a *Allocator) Assign(svcKey string, svc *v1.Service, ips []net.IP, ports []Port, sharingKey, backendKey string) error {
-	pool := poolFor(a.pools.ByName, ips)
-	if pool == nil {
+func (a *Allocator) Assign(svcKey string, svc *v1.Service, ips []netip.Addr, ports []Port, sharingKey, backendKey string) error {
+	pools := poolsFor(a.pools.ByName, ips)
+	if len(pools) == 0 {
 		return fmt.Errorf("%q is not allowed in config", ips)
 	}
 	sk := &key{
 		sharing: sharingKey,
 		backend: backendKey,
 	}
-	if !a.isPoolCompatibleWithService(pool, svc) {
-		return fmt.Errorf("pool %s not compatible for ip assignment", pool.Name)
-	}
-	// Check the dual-stack constraints:
-	// - Two addresses
-	// - Different families, ipv4 and ipv6
-	if len(ips) > 2 {
-		return fmt.Errorf("more than two addresses %q", ips)
-	}
-	if len(ips) == 2 && (ipfamily.ForAddress(ips[0]) == ipfamily.ForAddress(ips[1])) {
-		return fmt.Errorf("%q %q has the same family", ips[0], ips[1])
+	for _, pool := range pools {
+		if !a.isPoolCompatibleWithService(pool, svc) {
+			return fmt.Errorf("pool %s not compatible for ip assignment", pool.Name)
+		}
 	}
 
 	for _, ip := range ips {
 		// Does the IP already have allocs? If so, needs to be the same
 		// sharing key, and have non-overlapping ports. If not, the
 		// proposed IP needs to be allowed by configuration.
-		if err := a.checkSharing(svcKey, ip.String(), ports, sk); err != nil {
+		if err := a.checkSharing(svcKey, ip, ports, sk); err != nil {
 			return err
 		}
+	}
+
+	ipPools := make(map[netip.Addr]string, 0)
+	for ip, pool := range pools {
+		ipPools[ip] = pool.Name
 	}
 
 	// Either the IP is entirely unused, or the requested use is
@@ -177,10 +233,9 @@ func (a *Allocator) Assign(svcKey string, svc *v1.Service, ips []net.IP, ports [
 	// an allocation" block above). Unassigning is idempotent, so it's
 	// unconditionally safe to do.
 	alloc := &alloc{
-		pool:  pool.Name,
-		ips:   ips,
-		ports: make([]Port, len(ports)),
-		key:   *sk,
+		ipPools: ipPools,
+		ports:   make([]Port, len(ports)),
+		key:     *sk,
 	}
 	copy(alloc.ports, ports)
 	a.assign(svcKey, alloc)
@@ -195,27 +250,29 @@ func (a *Allocator) Unassign(svc string) {
 
 	al := a.allocated[svc]
 	delete(a.allocated, svc)
-	for _, ip := range al.ips {
+	for ip, pool := range al.ipPools {
 		for _, port := range al.ports {
-			if curSvc := a.portsInUse[ip.String()][port]; curSvc != svc {
+			if curSvc := a.portsInUse[ip][port]; curSvc != svc {
 				panic(fmt.Sprintf("incoherent state, I thought port %q belonged to service %q, but it seems to belong to %q", port, svc, curSvc))
 			}
-			delete(a.portsInUse[ip.String()], port)
+			delete(a.portsInUse[ip], port)
 		}
 
-		delete(a.servicesOnIP[ip.String()], svc)
-		if len(a.portsInUse[ip.String()]) == 0 {
-			delete(a.portsInUse, ip.String())
-			delete(a.sharingKeyForIP, ip.String())
+		delete(a.servicesOnIP[ip], svc)
+		if len(a.portsInUse[ip]) == 0 {
+			delete(a.portsInUse, ip)
+			delete(a.sharingKeyForIP, ip)
 		}
-		a.poolIPsInUse[al.pool][ip.String()]--
-		if a.poolIPsInUse[al.pool][ip.String()] == 0 {
+		a.poolIPsInUse[pool][ip]--
+		if a.poolIPsInUse[pool][ip] == 0 {
 			// Explicitly delete unused IPs from the pool, so that len()
 			// is an accurate count of IPs in use.
-			delete(a.poolIPsInUse[al.pool], ip.String())
+			delete(a.poolIPsInUse[pool], ip)
 		}
 	}
-	stats.poolActive.WithLabelValues(al.pool).Set(float64(len(a.poolIPsInUse[al.pool])))
+	for _, pool := range al.poolsUnique() {
+		stats.poolActive.WithLabelValues(pool).Set(float64(len(a.poolIPsInUse[pool])))
+	}
 }
 
 // AllocateFromPool assigns an available IP from pool to service.
@@ -223,17 +280,18 @@ func (a *Allocator) AllocateFromPool(svcKey string, svc *v1.Service, serviceIPFa
 	if alloc := a.allocated[svcKey]; alloc != nil {
 		// Handle the case where the svc has already been assigned an IP but from the wrong family.
 		// This "should-not-happen" since the "serviceIPFamily" is an immutable field in services.
-		allocIPsFamily, err := ipfamily.ForAddressesIPs(alloc.ips)
+		ips := alloc.ips()
+		allocIPsFamily, err := ipfamily.ForAddrs(ips)
 		if err != nil {
 			return nil, err
 		}
 		if allocIPsFamily != serviceIPFamily {
 			return nil, fmt.Errorf("IP for wrong family assigned alloc %s service family %s", allocIPsFamily, serviceIPFamily)
 		}
-		if err := a.Assign(svcKey, svc, alloc.ips, ports, sharingKey, backendKey); err != nil {
+		if err := a.Assign(svcKey, svc, ips, ports, sharingKey, backendKey); err != nil {
 			return nil, err
 		}
-		return alloc.ips, nil
+		return ConvertAddrsToIps(ips), nil
 	}
 
 	pool := a.pools.ByName[poolName]
@@ -268,7 +326,7 @@ func (a *Allocator) AllocateFromPool(svcKey string, svc *v1.Service, serviceIPFa
 		// Woops, run out of IPs :( Fail.
 		return nil, fmt.Errorf("no available IPs in pool %q for %s IPFamily", poolName, serviceIPFamily)
 	}
-	err := a.Assign(svcKey, svc, ips, ports, sharingKey, backendKey)
+	err := a.Assign(svcKey, svc, ConvertIpsToAddrs(ips), ports, sharingKey, backendKey)
 	if err != nil {
 		return nil, err
 	}
@@ -278,10 +336,10 @@ func (a *Allocator) AllocateFromPool(svcKey string, svc *v1.Service, serviceIPFa
 // Allocate assigns any available and assignable IP to service.
 func (a *Allocator) Allocate(svcKey string, svc *v1.Service, serviceIPFamily ipfamily.Family, ports []Port, sharingKey, backendKey string) ([]net.IP, error) {
 	if alloc := a.allocated[svcKey]; alloc != nil {
-		if err := a.Assign(svcKey, svc, alloc.ips, ports, sharingKey, backendKey); err != nil {
+		if err := a.Assign(svcKey, svc, alloc.ips(), ports, sharingKey, backendKey); err != nil {
 			return nil, err
 		}
-		return alloc.ips, nil
+		return ConvertAddrsToIps(alloc.ips()), nil
 	}
 	pinnedPools := a.pinnedPoolsForService(svc)
 	for _, pool := range pinnedPools {
@@ -346,13 +404,21 @@ func (a *Allocator) isPoolCompatibleWithService(p *config.Pool, svc *v1.Service)
 	return true
 }
 
-// Pool returns the pool from which service's IP was allocated. If
-// service has no IP allocated, "" is returned.
-func (a *Allocator) Pool(svc string) string {
+// Pools returns the pools from which service's IP was allocated. If
+// service has no IP allocated, nil is returned.
+func (a *Allocator) Pools(svc string) *map[netip.Addr]string {
 	if alloc := a.allocated[svc]; alloc != nil {
-		return alloc.pool
+		return &alloc.ipPools
 	}
-	return ""
+	return nil
+}
+
+// PoolsUnique returns the unique set of pools a given service uses, or an empty slice
+func (a *Allocator) PoolsUnique(svc string) []string {
+	if alloc := a.allocated[svc]; alloc != nil {
+		return alloc.poolsUnique()
+	}
+	return make([]string, 0)
 }
 
 func sortPools(pools []*config.Pool) {
@@ -402,8 +468,8 @@ func poolCount(p *config.Pool) int64 {
 		sz := int64(math.Pow(2, float64(b-o)))
 
 		cur := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})
-		firstIP := cur.First().IP
-		lastIP := cur.Last().IP
+		firstIP, _ := netip.AddrFromSlice(cur.First().IP)
+		lastIP, _ := netip.AddrFromSlice(cur.Last().IP)
 
 		if p.AvoidBuggyIPs {
 			if o <= 24 {
@@ -428,37 +494,41 @@ func poolCount(p *config.Pool) int64 {
 }
 
 // poolFor returns the pool that owns the requested IPs, or "" if none.
-func poolFor(pools map[string]*config.Pool, ips []net.IP) *config.Pool {
-	for _, p := range pools {
-		cnt := 0
-		for _, ip := range ips {
-			if p.AvoidBuggyIPs && ipConfusesBuggyFirmwares(ip) {
-				continue
-			}
-			for _, cidr := range p.CIDR {
-				if cidr.Contains(ip) {
-					cnt++
-					break
+func poolsFor(pools map[string]*config.Pool, ips []netip.Addr) map[netip.Addr]*config.Pool {
+	out := make(map[netip.Addr]*config.Pool, 0)
+	for _, ip := range ips {
+		p := func() *config.Pool {
+			for _, p := range pools {
+				if p.AvoidBuggyIPs && ipConfusesBuggyFirmwares(ip) {
+					continue
+				}
+				for _, cidr := range p.CIDR {
+					if cidr.Contains(ip.AsSlice()) {
+						return p
+					}
 				}
 			}
-		}
-		if cnt == len(ips) {
-			return p
+			return nil
+		}()
+		if p != nil {
+			out[ip] = p
+		} else {
+			return nil
 		}
 	}
-	return nil
+	return out
 }
 
 // ipConfusesBuggyFirmwares returns true if ip is an IPv4 address ending in 0 or 255.
 //
 // Such addresses can confuse smurf protection on crappy CPE
 // firmwares, leading to packet drops.
-func ipConfusesBuggyFirmwares(ip net.IP) bool {
-	ip = ip.To4()
-	if ip == nil {
+func ipConfusesBuggyFirmwares(ip netip.Addr) bool {
+	if ip.Is6() && !ip.Is4In6() {
 		return false
 	}
-	return ip[3] == 0 || ip[3] == 255
+	raw := ip.As4()
+	return raw[3] == 0 || raw[3] == 255
 }
 
 func (a *Allocator) getIPFromCIDR(cidr *net.IPNet, avoidBuggyIPs bool, svc string, ports []Port, sharingKey, backendKey string) net.IP {
@@ -468,10 +538,11 @@ func (a *Allocator) getIPFromCIDR(cidr *net.IPNet, avoidBuggyIPs bool, svc strin
 	}
 	c := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})
 	for pos := c.First(); pos != nil; pos = c.Next() {
-		if avoidBuggyIPs && ipConfusesBuggyFirmwares(pos.IP) {
+		addr, _ := netip.AddrFromSlice(pos.IP)
+		if avoidBuggyIPs && ipConfusesBuggyFirmwares(addr) {
 			continue
 		}
-		if a.checkSharing(svc, pos.IP.String(), ports, sk) != nil {
+		if a.checkSharing(svc, addr, ports, sk) != nil {
 			continue
 		}
 		return pos.IP
@@ -479,7 +550,7 @@ func (a *Allocator) getIPFromCIDR(cidr *net.IPNet, avoidBuggyIPs bool, svc strin
 	return nil
 }
 
-func (a *Allocator) checkSharing(svc string, ip string, ports []Port, sk *key) error {
+func (a *Allocator) checkSharing(svc string, ip netip.Addr, ports []Port, sk *key) error {
 	if existingSK := a.sharingKeyForIP[ip]; existingSK != nil {
 		if err := sharingOK(existingSK, sk); err != nil {
 			// Sharing key is incompatible. However, if the owner is

--- a/internal/allocator/k8salloc/k8salloc.go
+++ b/internal/allocator/k8salloc/k8salloc.go
@@ -28,6 +28,9 @@ func SharingKey(svc *v1.Service) string {
 // BackendKey extracts the backend key for a service.
 func BackendKey(svc *v1.Service) string {
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+		if svc.Annotations["metallb.universe.tf/enforced-single-node"] == "yes" {
+			return ""
+		}
 		return labels.Set(svc.Spec.Selector).String()
 	}
 	// Cluster traffic policy can share services regardless of backends.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,6 +208,15 @@ func (p *Pools) IsEmpty(pool string) bool {
 	return p.ByName[pool] == nil
 }
 
+func (p *Pools) IsAnyEmpty(pools []string) bool {
+	for _, pool := range pools {
+		if p.IsEmpty(pool) {
+			return true
+		}
+	}
+	return false
+}
+
 // Parse loads and validates a Config from bs.
 func For(resources ClusterResources, validate Validate) (*Config, error) {
 	err := validate(resources)

--- a/internal/ipfamily/ipfamily_test.go
+++ b/internal/ipfamily/ipfamily_test.go
@@ -25,15 +25,15 @@ func TestIPFamilyForAddresses(t *testing.T) {
 			family: IPv6,
 		},
 		{
-			desc:   "ipv4 and ipv6 addresse",
+			desc:   "ipv4 and ipv6 address",
 			ips:    []string{"1.2.3.4", "100::1"},
 			family: DualStack,
 		},
 		{
 			desc:    "dual stack with same address family",
 			ips:     []string{"1.2.3.4", "5.6.7.8"},
-			family:  Unknown,
-			wantErr: true,
+			family:  IPv4,
+			wantErr: false,
 		},
 		{
 			desc:    "dual stack with empty address",
@@ -42,10 +42,16 @@ func TestIPFamilyForAddresses(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:    "more than 2 addresses",
-			ips:     []string{"1.1.1.1", "100::1", "2.2.2.2"},
+			desc:    "invalid address",
+			ips:     []string{"example.com"},
 			family:  Unknown,
 			wantErr: true,
+		},
+		{
+			desc:    "more than 2 addresses",
+			ips:     []string{"1.1.1.1", "100::1", "2.2.2.2"},
+			family:  DualStack,
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
This PR does two things:
* Adds `metallb.universe.tf/enforced-single-node=yes` annotation for single(ish) node deployments, which allow a user to bypass the restrictions on shared ips with `externalTrafficPolicy: Local`. This of course has a risk of blackholing traffic, which is why it's just an opt-in. It's useful for small clusters with strict node assignment.
* Allows the `metallb.universe.tf/loadBalancerIPs` annotation to specify multiple IPs of the same type and bind to all of them, even in different pools.
  * As a subitem, I ported _some_ of the usage of `net.IP` to `netip.Addr`.

Most of the PR is the second item.
I have not written many additional tests. I'm running with IPv4 only in L2 mode in my two test clusters successfully. I _may_ go ahead and write those tests, but that's contingent on this having any chance of getting merged -- I don't know of any philosophical conflicts with what I'm doing, but that's up to the maintainers here of course.