### PR TITLE
E2E: allow to specify v4 / v6 prefixes to inject

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
-	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/e2etest/l2tests"
 	"go.universe.tf/e2etest/pkg/config"
 	"go.universe.tf/e2etest/pkg/executor"
@@ -33,6 +31,8 @@ import (
 	"go.universe.tf/e2etest/pkg/mac"
 	"go.universe.tf/e2etest/pkg/metallb"
 	"go.universe.tf/e2etest/pkg/pointer"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1062,7 +1062,11 @@ var _ = ginkgo.Describe("BGP", func() {
 
 			for _, c := range FRRContainers {
 				err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily, func(frr *frrcontainer.FRR) {
-					frr.NeighborConfig.ToAdvertise = []string{toInject}
+					if pairingIPFamily == ipfamily.IPv4 {
+						frr.NeighborConfig.ToAdvertiseV4 = []string{toInject}
+					} else {
+						frr.NeighborConfig.ToAdvertiseV6 = []string{toInject}
+					}
 				})
 				framework.ExpectNoError(err)
 			}
@@ -1130,7 +1134,11 @@ var _ = ginkgo.Describe("BGP", func() {
 				err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily, func(frr *frrcontainer.FRR) {
 					// We advertise a different route for each different container, to ensure all
 					// of them are able to advertise regardless of the configuration
-					frr.NeighborConfig.ToAdvertise = []string{fmt.Sprintf(toInject, i+1), toFilter}
+					if pairingIPFamily == ipfamily.IPv4 {
+						frr.NeighborConfig.ToAdvertiseV4 = []string{fmt.Sprintf(toInject, i+1), toFilter}
+					} else {
+						frr.NeighborConfig.ToAdvertiseV6 = []string{fmt.Sprintf(toInject, i+1), toFilter}
+					}
 				})
 				framework.ExpectNoError(err)
 			}

--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 	consts "go.universe.tf/e2etest/pkg/frr/consts"
-	"go.universe.tf/e2etest/pkg/k8s"
 	"go.universe.tf/e2etest/pkg/ipfamily"
+	"go.universe.tf/e2etest/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -61,7 +61,7 @@ router bgp {{$ROUTERASN}}
 {{range .AcceptV4Neighbors }}
     neighbor {{.Addr}} next-hop-self
     neighbor {{.Addr}} activate
-    {{range .ToAdvertise }}
+    {{range .ToAdvertiseV4 }}
     network {{.}}
     {{- end }}
 {{- end }}
@@ -73,7 +73,7 @@ router bgp {{$ROUTERASN}}
     neighbor {{.Addr}} next-hop-self
     neighbor {{.Addr}} activate
     neighbor {{.Addr}} route-map RMAP in
-    {{range .ToAdvertise }}
+    {{range .ToAdvertiseV6 }}
     network {{.}}
     {{- end }}
 {{- end }}
@@ -94,12 +94,13 @@ type RouterConfig struct {
 }
 
 type NeighborConfig struct {
-	ASN         uint32
-	Addr        string
-	Password    string
-	BFDEnabled  bool
-	ToAdvertise []string
-	MultiHop    bool
+	ASN           uint32
+	Addr          string
+	Password      string
+	BFDEnabled    bool
+	ToAdvertiseV4 []string
+	ToAdvertiseV6 []string
+	MultiHop      bool
 }
 
 type MultiProtocol bool


### PR DESCRIPTION
Until now we were testing injection with single stack, so the "toAnnounce" prefixes where added either to the v4 or to the v6 family section. Here we change it to allow the user to specify both ipv4 prefixes and ipv6 prefixes.