### PR TITLE
Add sleep to the reloader validation test

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1235,6 +1235,9 @@ var _ = ginkgo.Describe("BGP", func() {
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectNoError(err)
 
+			// Sleep to let the speaker time to reload the config and produce logs
+			time.Sleep(5 * time.Second)
+
 			speakerPods, err := metallb.SpeakerPods(cs)
 			framework.ExpectNoError(err)
 


### PR DESCRIPTION
Add 5 seconds sleep to give the speaker time to run the reload logic and produce logs, to prevent flakes in the "FRR validate reload feedback" test case.