### PR TITLE
bump k8s.io to 0.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,9 @@ require (
 	github.com/prometheus/client_golang v1.15.1
 	golang.org/x/sys v0.8.0
 	k8s.io/api v0.26.4
-	k8s.io/apiextensions-apiserver v0.26.1
+	k8s.io/apiextensions-apiserver v0.26.4
 	k8s.io/apimachinery v0.26.4
-	k8s.io/client-go v0.26.1
+	k8s.io/client-go v0.26.4
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20230115233650-391b47cb4029
 	sigs.k8s.io/controller-runtime v0.14.6
@@ -109,7 +109,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/component-base v0.26.4 // indirect
 	k8s.io/klog/v2 v2.90.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20230123231816-1cb3ae25d79a // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect


### PR DESCRIPTION
Possible panic when using client-go v0.26.0 - v0.26.3 (now is v0.26.1) for discovery

Related issues:

- https://github.com/kubernetes/kubernetes/issues/118361
- https://github.com/kubernetes/kubernetes/issues/119840
