### PR TITLE
Fix Gosec error in the configmaptocrs

### DIFF
--- a/configmaptocrs/main.go
+++ b/configmaptocrs/main.go
@@ -229,8 +229,8 @@ func bfdProfileFor(c *configFile) []v1beta1.BFDProfile {
 				TransmitInterval: bfd.TransmitInterval,
 				DetectMultiplier: bfd.DetectMultiplier,
 				EchoInterval:     bfd.EchoInterval,
-				EchoMode:         &bfd.EchoMode,
-				PassiveMode:      &bfd.PassiveMode,
+				EchoMode:         &c.BFDProfiles[i].EchoMode,
+				PassiveMode:      &c.BFDProfiles[i].PassiveMode,
 				MinimumTTL:       bfd.MinimumTTL,
 			},
 		}

--- a/configmaptocrs/testdata/configmap-data/config-data-bfdprofile.golden
+++ b/configmaptocrs/testdata/configmap-data/config-data-bfdprofile.golden
@@ -8,9 +8,9 @@ metadata:
 spec:
   detectMultiplier: 200
   echoInterval: 62
-  echoMode: true
+  echoMode: false
   minimumTtl: 254
-  passiveMode: true
+  passiveMode: false
   receiveInterval: 280
   transmitInterval: 270
 status: {}

--- a/configmaptocrs/testdata/configmap-yaml/config-yaml-bfdprofile.golden
+++ b/configmaptocrs/testdata/configmap-yaml/config-yaml-bfdprofile.golden
@@ -8,9 +8,9 @@ metadata:
 spec:
   detectMultiplier: 200
   echoInterval: 62
-  echoMode: true
+  echoMode: false
   minimumTtl: 254
-  passiveMode: true
+  passiveMode: false
   receiveInterval: 280
   transmitInterval: 270
 status: {}


### PR DESCRIPTION
Fix Gosec error inside the configmaptocrs:
G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)

This is also a bug fix because it didn't create
the correct echoMode and passiveMode values in the CRD. Updated the golden files.