### PR TITLE
improve speaker logging when no available nodes

### DIFF
--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -114,6 +114,12 @@ func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce 
 	} else {
 		availableNodes = nodesWithActiveSpeakers(forPool)
 	}
+
+	if len(availableNodes) == 0 {
+		level.Debug(l).Log("event", "skipping should announce l2", "service", name, "reason", "no available nodes")
+		return "notOwner"
+	}
+
 	level.Debug(l).Log("event", "shouldannounce", "protocol", "l2", "nodes", availableNodes, "service", name)
 
 	// Using the first IP should work for both single and dual stack.


### PR DESCRIPTION
we should skip announcing L2 service and log it when no available nodes

Fixes https://github.com/metallb/metallb/issues/2005
