### PR TITLE
make webhook secret's name configurable

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -143,6 +143,7 @@ func main() {
 		certServiceName     = flag.String("cert-service-name", "webhook-service", "The service name used to generate the TLS cert's hostname")
 		loadBalancerClass   = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
 		webhookMode         = flag.String("webhook-mode", "enabled", "webhook mode: can be enabled, disabled or only webhook if we want the controller to act as webhook endpoint only")
+		webhookSecretName   = flag.String("webhook-secret", "webhook-server-cert", "webhook secret: the name of webhook secret, default is webhook-server-cert")
 	)
 	flag.Parse()
 
@@ -189,6 +190,7 @@ func main() {
 		ValidateConfig:      validation,
 		EnableWebhook:       true,
 		DisableCertRotation: *disableCertRotation,
+		WebhookSecretName:   *webhookSecretName,
 		CertDir:             *certDir,
 		CertServiceName:     *certServiceName,
 		LoadBalancerClass:   *loadBalancerClass,

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -61,7 +61,6 @@ var (
 	validatingWebhookName           = "metallb-webhook-configuration"
 	addresspoolConvertingWebhookCRD = "addresspools.metallb.io"
 	bgppeerConvertingWebhookCRD     = "bgppeers.metallb.io"
-	webhookSecretName               = "webhook-server-cert" //#nosec G101
 )
 
 func init() {
@@ -108,6 +107,7 @@ type Config struct {
 	ValidateConfig      config.Validate
 	EnableWebhook       bool
 	DisableCertRotation bool
+	WebhookSecretName   string
 	CertDir             string
 	CertServiceName     string
 	LoadBalancerClass   string

--- a/internal/k8s/webhook.go
+++ b/internal/k8s/webhook.go
@@ -35,7 +35,7 @@ func enableCertRotation(notifyFinished chan struct{}, cfg *Config, mgr manager.M
 	err := rotator.AddRotator(mgr, &rotator.CertRotator{
 		SecretKey: types.NamespacedName{
 			Namespace: cfg.Namespace,
-			Name:      webhookSecretName,
+			Name:      cfg.WebhookSecretName,
 		},
 		CertDir:        cfg.CertDir,
 		CAName:         caName,


### PR DESCRIPTION
It appears that webhookSecretName is hardcoded to 'webhook-server-cert', With this PR, we can configure it via the controller's flag: --webhook-secret.

Fixes: https://github.com/metallb/metallb/issues/1993
