### PR TITLE
Implement NodeExcludeBalancers to exclude nodes as external loadbalancer

### DIFF
--- a/internal/k8s/nodes/nodes.go
+++ b/internal/k8s/nodes/nodes.go
@@ -25,3 +25,15 @@ func conditionStatus(n *corev1.Node, ct corev1.NodeConditionType) corev1.Conditi
 
 	return corev1.ConditionUnknown
 }
+
+// IsNodeExcludedFromBalancers returns true if the given node has labeld node.kubernetes.io/exclude-from-external-load-balancers".
+func IsNodeExcludedFromBalancers(n *corev1.Node) bool {
+	if n == nil {
+		return false
+	}
+
+	if _, ok := n.Labels[corev1.LabelNodeExcludeBalancers]; ok {
+		return true
+	}
+	return false
+}

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -175,6 +175,12 @@ func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ []net.IP, po
 		level.Debug(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has NodeNetworkUnavailable condition")
 		return "nodeNetworkUnavailable"
 	}
+
+	if k8snodes.IsNodeExcludedFromBalancers(nodes[c.myNode]) {
+		level.Debug(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has labeled 'node.kubernetes.io/exclude-from-external-load-balancers'")
+		return "nodeLabeledExcludeBalancers"
+	}
+
 	// Should we advertise?
 	// Yes, if externalTrafficPolicy is
 	//  Cluster && any healthy endpoint exists

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -238,6 +238,11 @@ func speakersForPool(speakers map[string]bool, pool *config.Pool, nodes map[stri
 		if k8snodes.IsNetworkUnavailable(nodes[s]) {
 			continue
 		}
+
+		if k8snodes.IsNodeExcludedFromBalancers(nodes[s]) {
+			continue
+		}
+
 		if poolMatchesNodeL2(pool, s) {
 			res[s] = true
 		}

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -26,6 +26,7 @@ Chores:
 - Metrics: add ipv4/6 addresses_in_use_total and addresses_total ([PR 2151](https://github.com/metallb/metallb/pull/2151))
 - Squash the prefixes in FRR mode, avoiding duplicate prefixes in the FRR configuration ([PR 2234](https://github.com/metallb/metallb/pull/2234))
 - BGP: move the matching peer logic one level up ([PR 2233](https://github.com/metallb/metallb/pull/2233))
+- Implement NodeExcludeBalancers to exclude nodes as external loadbalancer ([PR 2073](https://github.com/metallb/metallb/pull/2073), [ISSUE 2021](https://github.com/metallb/metallb/issues/2021))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
The label specifies that the node should not be considered as a target for external load-balancers which use nodes as a second hop.

Fixed https://github.com/metallb/metallb/issues/2021
