### PR TITLE
Remove IP verifications in SetPools

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -81,6 +81,11 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		syncStateRes = controllers.SyncStateErrorNoRetry
 	}
 
+	if reflect.DeepEqual(svcRo, svc) {
+		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
+		return syncStateRes
+	}
+
 	if len(prevIPs) != 0 && !c.isServiceAllocated(name) {
 		// Only reprocess all if the previous IP(s) are still contained within a pool.
 		if c.ips.PoolForIP(prevIPs) != nil {
@@ -90,10 +95,6 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 			level.Info(l).Log("event", "serviceUpdated", "msg", "removed loadbalancer from service, services will be reprocessed")
 			syncStateRes = controllers.SyncStateReprocessAll
 		}
-	}
-	if reflect.DeepEqual(svcRo, svc) {
-		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
-		return syncStateRes
 	}
 
 	toWrite := svcRo.DeepCopy()

--- a/controller/service.go
+++ b/controller/service.go
@@ -50,6 +50,13 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		return nil
 	}
 
+	// Return if pools are empty.
+	if len(c.pools.ByName) == 0 {
+		level.Debug(l).Log("event", "clearAssignment", "reason", "noConfig", "msg", "pools are empty")
+		c.clearServiceState(key, svc)
+		return ErrConverge
+	}
+
 	// If the ClusterIPs is malformed or not set we can't determine the
 	// ipFamily to use.
 	if len(svc.Spec.ClusterIPs) == 0 && svc.Spec.ClusterIP == "" {

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	"go.universe.tf/e2etest/pkg/config"
 	"go.universe.tf/e2etest/pkg/k8s"
 	"go.universe.tf/e2etest/pkg/metallb"
@@ -23,6 +22,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const secondNamespace = "test-namespace"
@@ -215,6 +215,95 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			for i := 0; i < numOfRestarts; i++ {
 				restartAndAssert()
 			}
+		})
+	})
+
+	ginkgo.Context("IPV4 removing pools", func() {
+		var pool1 metallbv1beta1.IPAddressPool
+		var pool2 metallbv1beta1.IPAddressPool
+
+		ginkgo.AfterEach(func() {
+			// Clean previous configuration.
+			err := ConfigUpdater.Clean()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.BeforeEach(func() {
+			pool1 = metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-1"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.5.0/32",
+					},
+					AllocateTo: &metallbv1beta1.ServiceAllocation{Priority: 20, Namespaces: []string{f.Namespace.Name}},
+				},
+			}
+			pool2 = metallbv1beta1.IPAddressPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns-pool-2"},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: []string{
+						"192.168.10.0/32",
+					},
+				},
+			}
+
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{pool1, pool2},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("removes all pools", func() {
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			defer func() {
+				service.Delete(cs, svc1)
+			}()
+
+			ginkgo.By("validate LoadBalancer IP is allocated from pool1")
+			err := config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool1}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting all pools")
+			err = ConfigUpdater.Client().DeleteAllOf(context.Background(), &metallbv1beta1.IPAddressPool{}, client.InNamespace(ConfigUpdater.Namespace()))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("validate LoadBalancer IP is removed from the svc")
+			gomega.Eventually(func() int {
+				s, err := cs.CoreV1().Services(svc1.Namespace).Get(context.Background(), svc1.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				return len(s.Status.LoadBalancer.Ingress)
+			}, time.Minute, 1*time.Second).Should(gomega.Equal(0))
+		})
+
+		ginkgo.It("reallocates svc after deleting a pool", func() {
+			svc1, _ := service.CreateWithBackend(cs, f.Namespace.Name, "svc-test-ns-pool-1")
+			defer func() {
+				service.Delete(cs, svc1)
+			}()
+
+			ginkgo.By("validate LoadBalancer IP is allocated from pool1")
+			err := config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool1}, e2eservice.GetIngressPoint(
+				&svc1.Status.LoadBalancer.Ingress[0]))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting pool 1")
+			p := &metallbv1beta1.IPAddressPool{}
+			err = ConfigUpdater.Client().Get(context.Background(), client.ObjectKey{Namespace: ConfigUpdater.Namespace(), Name: pool1.Name}, p)
+			framework.ExpectNoError(err)
+			err = ConfigUpdater.Client().Delete(context.Background(), p)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("validate LoadBalancer IP is re-allocated from pool2")
+			gomega.Eventually(func() error {
+				svc1, err := cs.CoreV1().Services(svc1.Namespace).Get(context.Background(), svc1.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				err = config.ValidateIPInRange([]metallbv1beta1.IPAddressPool{pool2}, e2eservice.GetIngressPoint(
+					&svc1.Status.LoadBalancer.Ingress[0]))
+				return err
+			}, time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 		})
 	})
 

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -66,18 +66,7 @@ func New() *Allocator {
 }
 
 // SetPools updates the set of address pools that the allocator owns.
-func (a *Allocator) SetPools(pools *config.Pools) error {
-	// All the fancy sharing stuff only influences how new allocations
-	// can be created. For changing the underlying configuration, the
-	// only question we have to answer is: can we fit all allocated
-	// IPs into address pools under the new configuration?
-	for svc, alloc := range a.allocated {
-		pool := poolFor(pools.ByName, alloc.ips)
-		if pool == nil {
-			return fmt.Errorf("new config not compatible with assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
-		}
-	}
-
+func (a *Allocator) SetPools(pools *config.Pools) {
 	for n := range a.pools.ByName {
 		if pools.ByName[n] == nil {
 			stats.poolCapacity.DeleteLabelValues(n)
@@ -92,7 +81,8 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 	for svc, alloc := range a.allocated {
 		pool := poolFor(a.pools.ByName, alloc.ips)
 		if pool == nil {
-			return fmt.Errorf("can't retrieve new pool for assigned IPs: service %q cannot own %q under new config", svc, alloc.ips)
+			a.Unassign(svc)
+			continue
 		}
 		if pool.Name != alloc.pool {
 			a.Unassign(svc)
@@ -108,8 +98,6 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 		stats.poolCapacity.WithLabelValues(n).Set(float64(poolCount(p)))
 		stats.poolActive.WithLabelValues(n).Set(float64(len(a.poolIPsInUse[n])))
 	}
-
-	return nil
 }
 
 // assign unconditionally updates internal state to reflect svc's
@@ -353,6 +341,19 @@ func (a *Allocator) Pool(svc string) string {
 		return alloc.pool
 	}
 	return ""
+}
+
+// IPs returns the allocated IPs of a service.
+func (a *Allocator) IPs(svc string) []net.IP {
+	if alloc := a.allocated[svc]; alloc != nil {
+		return alloc.ips
+	}
+	return nil
+}
+
+// PoolForIP returns the pool structure associated with an IP.
+func (a *Allocator) PoolForIP(ips []net.IP) *config.Pool {
+	return poolFor(a.pools.ByName, ips)
 }
 
 func sortPools(pools []*config.Pool) {


### PR DESCRIPTION
This is https://github.com/metallb/metallb/pull/1948 plus the fixes suggested in the last phase of the PR.

Pool changes might invalidate the LB IPs of services. When this happens, the pool controller ignores the new configuration and continues operating with the current one. This PR modifies this behavior by always accepting the new configuration and letting the service controller to clear the IPs of the affected services.

Fixes https://github.com/metallb/metallb/issues/462
