### PR TITLE
Add support for speaker securityContext

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -144,6 +144,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.reloader.resources | object | `{}` |  |
 | speaker.resources | object | `{}` |  |
 | speaker.runtimeClassName | string | `""` |  |
+| speaker.securityContext | object | `{}` |  |
 | speaker.serviceAccount.annotations | object | `{}` |  |
 | speaker.serviceAccount.create | bool | `true` |  |
 | speaker.serviceAccount.name | string | `""` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -154,6 +154,10 @@ spec:
       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
+      {{- if .Values.speaker.securityContext }}
+      securityContext:
+        {{- toYaml .Values.speaker.securityContext | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.speaker.memberlist.enabled }}
         - name: memberlist

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -342,6 +342,9 @@
             "runtimeClassName": {
               "type": "string"
             },
+            "securityContext": {
+              "type": "object"
+            },
             "secretName": {
               "type": "string"
             },

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -282,6 +282,7 @@ speaker:
     # true, a name is generated using the fullname template
     name: ""
     annotations: {}
+  securityContext: {}
   ## Defines a secret name for the controller to generate a memberlist encryption secret
   ## By default secretName: {{ "metallb.fullname" }}-memberlist
   ##


### PR DESCRIPTION
Small addition to support setting the pod level security context on the speaker daemonset.

This is useful in some environments where explicit securityContext must be set for pods, or potentially when using a rebuilt image with a different (user/group could be different).