### PR TITLE
Update dockerfiles to build with latest golang patch

### DIFF
--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev
 WORKDIR $GOPATH/go.universe.tf/metallb

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev
 

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev
 WORKDIR $GOPATH/go.universe.tf/metallb


### PR DESCRIPTION
This is a small PR to keep up to date with the latest patch version of golang in the dockerfiles. 

The .9 and .10 versions have security fixes for CVEs that may show up in scans of this image (specifically https://github.com/golang/go/issues/63417)
- https://github.com/golang/go/issues?q=milestone%3AGo1.20.9+label%3ACherryPickApproved
- https://github.com/golang/go/issues?q=milestone%3AGo1.20.10+label%3ACherryPickApproved