### PR TITLE
Fix parsing invalid addresses as IPv6

### DIFF
--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -28,6 +28,9 @@ func ForAddresses(ips []string) (Family, error) {
 	switch len(ips) {
 	case 1:
 		ip := net.ParseIP(ips[0])
+		if ip == nil {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips)
+		}
 		if ip.To4() != nil {
 			return IPv4, nil
 		}

--- a/internal/ipfamily/ipfamily_test.go
+++ b/internal/ipfamily/ipfamily_test.go
@@ -25,6 +25,12 @@ func TestIPFamilyForAddresses(t *testing.T) {
 			family: IPv6,
 		},
 		{
+			desc:    "one invalid address",
+			ips:     []string{"!.1.1.1"},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []string{"1.2.3.4", "100::1"},
 			family: DualStack,
@@ -38,6 +44,12 @@ func TestIPFamilyForAddresses(t *testing.T) {
 		{
 			desc:    "dual stack with empty address",
 			ips:     []string{"", ""},
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "dual stack with one invalid address",
+			ips:     []string{"!.1.1.1", "100::1"},
 			family:  Unknown,
 			wantErr: true,
 		},


### PR DESCRIPTION
Fixes a small part where we considered an invalid address as an IPv6 one
