### PR TITLE
Allow custom bind address for memberlist

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -130,6 +130,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.livenessProbe.timeoutSeconds | int | `1` |  |
 | speaker.logLevel | string | `"info"` | Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
 | speaker.memberlist.enabled | bool | `true` |  |
+| speaker.memberlist.mlBindAddrOverride | string | `""` |  |
 | speaker.memberlist.mlBindPort | int | `7946` |  |
 | speaker.memberlist.mlSecretKeyPath | string | `"/etc/ml_secret_key"` |  |
 | speaker.nodeSelector | object | `{}` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -241,10 +241,15 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         {{- if .Values.speaker.memberlist.enabled }}
+        {{- if .Values.speaker.memberlist.mlBindAddrOverride }}
+        - name: METALLB_ML_BIND_ADDR
+          value: "{{ .Values.speaker.memberlist.mlBindAddrOverride }}"
+        {{ else }}
         - name: METALLB_ML_BIND_ADDR
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        {{ end }}
         - name: METALLB_ML_LABELS
           value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
         - name: METALLB_ML_BIND_PORT

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -317,6 +317,9 @@
                 "mlBindPort": {
                   "type": "integer"
                 },
+                "mlBindAddrOverride": {
+                  "type": "string"
+                },
                 "mlSecretKeyPath": {
                   "type": "string"
                 }

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -260,6 +260,7 @@ speaker:
   memberlist:
     enabled: true
     mlBindPort: 7946
+    mlBindAddrOverride: ""
     mlSecretKeyPath: "/etc/ml_secret_key"
   excludeInterfaces:
     enabled: true


### PR DESCRIPTION
The bind address for memberlist is currently always set to the pod's IP address:
` - name: METALLB_ML_BIND_ADDR
          valueFrom:
            fieldRef:
              fieldPath: status.podIP`
This PR allows this to be customised. 

In my scenario I wanted it to listen to a different address as the speaker pods were connecting to each other via a VIP which didn't work unless I changed the bind address.

The current behaviour is kept as the default behaviour, but it can be overridden using the new `speaker.memberlist.mlBindAddrOverride` configuration in values.yaml.