### PR TITLE
Disable http2 for the controller webhook

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -149,6 +149,7 @@ func main() {
 		loadBalancerClass   = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
 		webhookMode         = flag.String("webhook-mode", "enabled", "webhook mode: can be enabled, disabled or only webhook if we want the controller to act as webhook endpoint only")
 		webhookSecretName   = flag.String("webhook-secret", "webhook-server-cert", "webhook secret: the name of webhook secret, default is webhook-server-cert")
+		webhookHTTP2        = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
 	)
 	flag.Parse()
 
@@ -194,6 +195,7 @@ func main() {
 		},
 		ValidateConfig:      validation,
 		EnableWebhook:       true,
+		WebhookWithHTTP2:    *webhookHTTP2,
 		DisableCertRotation: *disableCertRotation,
 		WebhookSecretName:   *webhookSecretName,
 		CertDir:             *certDir,

--- a/controller/main.go
+++ b/controller/main.go
@@ -202,9 +202,11 @@ func main() {
 	}
 	switch *webhookMode {
 	case "enabled":
+		cfg.EnableWebhook = true
 	case "disabled":
 		cfg.EnableWebhook = false
 	case "onlywebhook":
+		cfg.EnableWebhook = true
 		cfg.Listener = k8s.Listener{}
 	default:
 		level.Error(logger).Log("op", "startup", "error", "invalid webhookmode value", "value", *webhookMode)


### PR DESCRIPTION
This is optional, and should remediate the http2 fast reset bug.
