### PR TITLE
Use AES-256 for memberlist message encryption

### DIFF
--- a/internal/speakerlist/speakerlist.go
+++ b/internal/speakerlist/speakerlist.go
@@ -76,7 +76,7 @@ func New(logger log.Logger, nodeName, bindAddr, bindPort, secret, namespace, lab
 		level.Warn(logger).Log("op", "startup", "warning", "no ml-secret-key set, memberlist traffic will not be encrypted")
 	} else {
 		sha := sha256.New()
-		mconfig.SecretKey = sha.Sum([]byte(secret))[:16]
+		mconfig.SecretKey = sha.Sum([]byte(secret))[:32]
 	}
 
 	// This channel is used by the Rejoin() method which runs on k8s node


### PR DESCRIPTION
`SpeakerList` currently configures memberlist to use AES-128 to encrypt the messages involved in the cluster membership management. This PR increases the size of `SecretKey` to make memberlist use AES-256 instead.

Closes #1982. 