### PR TITLE
Publish metallb-crds chart

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -141,15 +141,22 @@ jobs:
 
           exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://github.com/$GITHUB_REPOSITORY/releases/tag/$repo-chart-$tag -w %{http_code} -o /dev/null)
           if [[ $exists != "200" ]]; then
-            echo "Creating release..."
-            # package chart
+            echo "Creating release for base chart..."
             ./cr package charts/$repo
-            # upload chart to github releases
             ./cr upload \
                 --owner "$owner" \
                 --git-repo "$repo" \
                 --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
                 --token "${{ secrets.GITHUB_TOKEN }}"
+
+            echo "Creating release for CRD chart..."
+            ./cr package charts/$repo/charts/crds
+            ./cr upload \
+                --owner "$owner" \
+                --git-repo "$repo" \
+                --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
+                --token "${{ secrets.GITHUB_TOKEN }}"
+
             # Update index and push to github pages
             ./cr index \
                 --owner "$owner" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -139,9 +139,10 @@ jobs:
           owner=$(dirname "$GITHUB_REPOSITORY")
           tag="${GITHUB_REF_NAME:1}"
 
-          exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://github.com/$GITHUB_REPOSITORY/releases/tag/$repo-chart-$tag -w %{http_code} -o /dev/null)
+          exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://github.com/$owner/$repo/releases/tag/$repo-chart-$tag -w %{http_code} -o /dev/null)
           if [[ $exists != "200" ]]; then
-            echo "Creating release for base chart..."
+
+            echo "Creating Github release for base chart..."
             ./cr package charts/$repo
             ./cr upload \
                 --owner "$owner" \
@@ -149,7 +150,7 @@ jobs:
                 --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
                 --token "${{ secrets.GITHUB_TOKEN }}"
 
-            echo "Creating release for CRD chart..."
+            echo "Creating Github release for CRD chart..."
             ./cr package charts/$repo/charts/crds
             ./cr upload \
                 --owner "$owner" \

--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/metallb/metallb
 icon: https://metallb.universe.tf/images/logo/metallb-white.png
 dependencies:
-- name: crds
+- name: metallb-crds
   condition: crds.enabled
   version: 0.0.0
 

--- a/charts/metallb/charts/crds/Chart.yaml
+++ b/charts/metallb/charts/crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: crds
+name: metallb-crds
 description: MetalLB CRDs
 home: https://metallb.universe.tf
 sources:


### PR DESCRIPTION
This PR publishes the CRDs subchart located at `charts/metallb/charts/crds`. The reason for this is to support separating the installation of CRDs from the installation of other metallb resources.