### PR TITLE
feat(helmchart): add extraContainers to speaker

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -24,6 +24,7 @@ Kubernetes: `>= 1.19.0-0`
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` |  |
 | controller.enabled | bool | `true` |  |
+| controller.extraContainers | list | `[]` |  |
 | controller.image.pullPolicy | string | `nil` |  |
 | controller.image.repository | string | `"quay.io/metallb/controller"` |  |
 | controller.image.tag | string | `nil` |  |
@@ -111,6 +112,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.affinity | object | `{}` |  |
 | speaker.enabled | bool | `true` |  |
 | speaker.excludeInterfaces.enabled | bool | `true` |  |
+| speaker.extraContainers | list | `[]` |  |
 | speaker.frr.enabled | bool | `true` |  |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -153,6 +153,9 @@ spec:
             readOnly: true
         {{- end }}
       {{ end }}
+      {{- if .Values.controller.extraContainers }}
+      {{- toYaml .Values.controller.extraContainers | nindent 6 }}
+      {{- end }}
       nodeSelector:
         "kubernetes.io/os": linux
         {{- with .Values.controller.nodeSelector }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -490,6 +490,9 @@ spec:
             readOnly: true
         {{- end }}
       {{ end }}
+      {{- if .Values.speaker.extraContainers }}
+      {{- toYaml .Values.speaker.extraContainers | nindent 6 }}
+      {{- end }}
       nodeSelector:
         "kubernetes.io/os": linux
         {{- with .Values.speaker.nodeSelector }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -319,6 +319,12 @@
             },
             "webhookMode" : {
               "type": "string"
+            },
+            "extraContainers": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             }
           }
         }
@@ -403,6 +409,12 @@
               "type": "object",
               "properties": {
                 "resources": { "type": "object" }
+              }
+            },
+            "extraContainers": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           },

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -299,6 +299,31 @@
       },
       "required": [ "podMonitor", "prometheusRule" ]
     },
+    "controller": { 
+      "allOf": [
+        { "$ref": "#/definitions/component" },
+        { "description": "MetalLB Controller",
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [ "type" ]
+            },
+            "command" : {
+              "type": "string"
+            },
+            "webhookMode" : {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
     "speaker": { 
       "allOf": [
         { "$ref": "#/definitions/component" },
@@ -400,31 +425,6 @@
         }
       }
     }
-  },
-  "controller": { 
-    "allOf": [
-      { "$ref": "#/definitions/component" },
-      { "description": "MetalLB Controller",
-        "type": "object",
-        "properties": {
-          "strategy": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              }
-            },
-            "required": [ "type" ]
-          },
-          "command" : {
-            "type": "string"
-          },
-          "webhookMode" : {
-            "type": "string"
-          }
-        }
-      }
-    ]
   },
   "required": [
     "controller",

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -249,6 +249,8 @@ controller:
     successThreshold: 1
     timeoutSeconds: 1
 
+  extraContainers: []
+
 # speaker contains configuration specific to the MetalLB speaker
 # daemonset.
 speaker:
@@ -338,6 +340,8 @@ speaker:
 
   frrMetrics:
     resources: {}
+
+  extraContainers: []
 
 crds:
   enabled: true


### PR DESCRIPTION
In the environment we are using we would like to deploy a container right next to every MetalLB Speaker. The easiest and most reliable way for us would be to use the functionality this PR would add.

If you want me to add this to the `controller.yaml` too, feel free to tell me.