### PR TITLE
CI: enforce the release notes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,29 @@ jobs:
         with:
           skip-upload: true
 
+  check-changelog:
+    runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+
+      - name: Check if release notes where changed
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [ "$file" = "website/content/release-notes/_index.md" ]; then
+              exit 0
+            fi
+          done
+          echo "Release notes must be changed"
+          exit 1
+
   commitlint:
     runs-on: ubuntu-22.04
     steps:

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -3,6 +3,12 @@ title: Release Notes
 weight: 8
 ---
 
+## Next release
+
+Chores:
+
+- Enforce adding a release notes entry on each PR ([PR 2191](https://github.com/metallb/metallb/pull/2191))
+
 ## Version 0.13.12
 
 - Change the version of go used to compile the binaries


### PR DESCRIPTION
Adding a CI rule that forces the contributor to touch the release notes. This should prevent mistakes / make the maintainers' life easier without resorting to do PR archeology to build the changelog.


