### PR TITLE
Change default BGP mode to frr in dev-env command

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -317,7 +317,7 @@ def generate_manifest(ctx, crd_options="crd:crdVersions=v1", bgp_type="native", 
     "ip_family": "Optional ipfamily of the cluster."
                  "Default: ipv4, supported families are 'ipv6' and 'dual'.",
     "bgp_type": "Type of BGP implementation to use."
-                "Supported: 'native' (default), 'frr'",
+                "Supported: 'frr' (default), 'native'",
     "frr_volume_dir": "FRR router config directory to be mounted inside frr container. "
                       "Default: ./dev-env/bgp/frr-volume",
     "log_level": "Log level for the controller and the speaker."
@@ -332,7 +332,7 @@ def generate_manifest(ctx, crd_options="crd:crdVersions=v1", bgp_type="native", 
                 "Default: False.",
 })
 def dev_env(ctx, architecture="amd64", name="kind", protocol=None, frr_volume_dir="",
-        node_img=None, ip_family="ipv4", bgp_type="native", log_level="info",
+        node_img=None, ip_family="ipv4", bgp_type="frr", log_level="info",
         helm_install=False, build_images=True, with_prometheus=False, with_api_audit=False):
     """Build and run MetalLB in a local Kind cluster.
 

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -15,6 +15,7 @@ Chores:
 - Support running the e2es on frr-k8s deployments ([PR 2180](https://github.com/metallb/metallb/pull/2180))
 - E2E: Receive prefixes using frr-k8s alongside MetalLB ([PR 2211](https://github.com/metallb/metallb/pull/2211))
 - CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
+- Dev-env: change the default BGP mode to FRR ([PR 2196](https://github.com/metallb/metallb/pull/2196))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
Change the default BGP mode in the tasks.py dev-env command to FRR.

The rationale for this is that we no longer develop features for the native mode, and it makes sense to set the development environment to default to FRR.
