### PR TITLE
Webhook does not process transient errors properly

### DIFF
--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -5,16 +5,19 @@ package config
 import (
 	"testing"
 
-	"go.universe.tf/metallb/api/v1beta2"
+	"github.com/google/go-cmp/cmp"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestValidator(t *testing.T) {
 	v := validator{DontValidate}
 
-	bgpPeerList := v1beta2.BGPPeerList{
-		Items: []v1beta2.BGPPeer{
+	bgpPeerList := metallbv1beta2.BGPPeerList{
+		Items: []metallbv1beta2.BGPPeer{
 			{
-				Spec: v1beta2.BGPPeerSpec{
+				Spec: metallbv1beta2.BGPPeerSpec{
 					MyASN:      42,
 					ASN:        42,
 					Address:    "1.2.3.4",
@@ -26,5 +29,133 @@ func TestValidator(t *testing.T) {
 	err := v.Validate(&bgpPeerList)
 	if err != nil {
 		t.Error("The validator should not fail for non existing bfd profile")
+	}
+}
+
+func TestResetTransientErrorsFields(t *testing.T) {
+	tests := []struct {
+		desc             string
+		clusterResources ClusterResources
+		expected         ClusterResources
+	}{
+		{
+			desc:             "empty resource",
+			clusterResources: ClusterResources{},
+			expected:         ClusterResources{},
+		},
+		{
+			desc: "BFDProfiles, PasswordSecrets and Community references are reset",
+			clusterResources: ClusterResources{
+				Peers: []metallbv1beta2.BGPPeer{
+					{
+						Spec: metallbv1beta2.BGPPeerSpec{
+							BFDProfile: "myBFDProfile",
+							MyASN:      64512,
+							ASN:        64512,
+							Address:    "172.30.0.3",
+							PasswordSecret: v1.SecretReference{
+								Name:      "myName",
+								Namespace: "myNamespace",
+							},
+						},
+					},
+				},
+				Communities: []metallbv1beta1.Community{
+					{
+						Spec: metallbv1beta1.CommunitySpec{
+							Communities: []metallbv1beta1.CommunityAlias{
+								{
+									Name:  "myCommunityAlias",
+									Value: "65000:100",
+								},
+							},
+						},
+					},
+				},
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+					{
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							Communities: []string{
+								"11111:11aaaa",
+								"larg:12345:12345:12345",
+								"alias",
+								"myCommunityAlias",
+							},
+						},
+					},
+				},
+				LegacyAddressPools: []metallbv1beta1.AddressPool{
+					{
+						Spec: metallbv1beta1.AddressPoolSpec{
+							BGPAdvertisements: []metallbv1beta1.LegacyBgpAdvertisement{
+								{
+									Communities: []string{
+										"11111:11aaaa",
+										"larg:12345:12345:12345",
+										"alias",
+										"myCommunityAlias",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ClusterResources{
+				Peers: []metallbv1beta2.BGPPeer{
+					{
+						Spec: metallbv1beta2.BGPPeerSpec{
+							BFDProfile:     "",
+							MyASN:          64512,
+							ASN:            64512,
+							Address:        "172.30.0.3",
+							PasswordSecret: v1.SecretReference{},
+						},
+					},
+				},
+				Communities: []metallbv1beta1.Community{
+					{
+						Spec: metallbv1beta1.CommunitySpec{
+							Communities: []metallbv1beta1.CommunityAlias{
+								{
+									Name:  "myCommunityAlias",
+									Value: "65000:100",
+								},
+							},
+						},
+					},
+				},
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+					{
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							Communities: []string{
+								"11111:11aaaa",
+								"larg:12345:12345:12345",
+							},
+						},
+					},
+				},
+				LegacyAddressPools: []metallbv1beta1.AddressPool{
+					{
+						Spec: metallbv1beta1.AddressPoolSpec{
+							BGPAdvertisements: []metallbv1beta1.LegacyBgpAdvertisement{
+								{
+									Communities: []string{
+										"11111:11aaaa",
+										"larg:12345:12345:12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		result := resetTransientErrorsFields(test.clusterResources)
+		if !cmp.Equal(result, test.expected) {
+			t.Fatalf("test %s failed, unexpected clusterResources (-want +got)\n%s", test.desc, cmp.Diff(result, test.expected))
+		}
 	}
 }

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -17,6 +17,7 @@ Chores:
 - Images updated to Go 1.20.12 ([PR 2213](https://github.com/metallb/metallb/pull/2213))
 - CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
 - Dev-env: change the default BGP mode to FRR ([PR 2196](https://github.com/metallb/metallb/pull/2196))
+- Webhooks: avoid transient errors ([PR 2202](https://github.com/metallb/metallb/pull/2202)), [ISSUE 2173](https://github.com/metallb/metallb/issues/2173))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
Fixed  #2173 

There are TransientErrors that can occasionally result in overlooking genuine issues. The solution is to reset the fields that might be causing a TransientError.
