### PR TITLE
controller: improve docker build cache

### DIFF
--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,40 +1,38 @@
 # syntax=docker/dockerfile:1.2
 
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
-ARG GIT_COMMIT=dev
-ARG GIT_BRANCH=dev
 WORKDIR $GOPATH/go.universe.tf/metallb
 
-# Cache the downloads
-COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
 
-# COPY internals
-COPY internal internal
-COPY api api
-
-# COPY configmaptocrs
-COPY configmaptocrs/*.go configmaptocrs/
-
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
 ARG TARGETARCH
 ARG TARGETOS
 ARG TARGETPLATFORM
 
-# have to manually convert as building the different arms can cause issues
 # Extract variant
+# have to manually convert as building the different arms can cause issues
 RUN case ${TARGETPLATFORM} in \
   "linux/arm/v6") export VARIANT="6" ;; \
   "linux/arm/v7") export VARIANT="7" ;; \
   *) export VARIANT="" ;; \
   esac
 
-# Cache builds directory for faster rebuild
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  --mount=type=bind,source=internal,target=internal \
+  --mount=type=bind,source=api,target=api \
+  --mount=type=bind,source=configmaptocrs,target=configmaptocrs \
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
   go build -v -o /build/configmaptocrs \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
-  go.universe.tf/metallb/configmaptocrs
+  ./configmaptocrs
 
 FROM docker.io/alpine:latest
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,36 +1,38 @@
 # syntax=docker/dockerfile:1.2
 
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
+WORKDIR $GOPATH/go.universe.tf/metallb
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
+
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev
-
-WORKDIR $GOPATH/go.universe.tf/metallb
-# Caching dependencies
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY controller/*.go .
-COPY internal internal
-COPY api api
-
 ARG TARGETARCH
 ARG TARGETOS
 ARG TARGETPLATFORM
 
 # Extract variant
+# have to manually convert as building the different arms can cause issues
 RUN case ${TARGETPLATFORM} in \
   "linux/arm/v6") export VARIANT="6" ;; \
   "linux/arm/v7") export VARIANT="7" ;; \
   *) export VARIANT="" ;; \
   esac
 
-# have to manually convert as building the different arms can cause issues
-# Cache builds directory for faster rebuild
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  --mount=type=bind,source=internal,target=internal \
+  --mount=type=bind,source=api,target=api \
+  --mount=type=bind,source=controller,target=controller \
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
   go build -v -o /build/controller \
-  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'"
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  ./controller
 
 FROM docker.io/alpine:latest
 

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,37 +1,35 @@
 # syntax=docker/dockerfile:1.2
 
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
-ARG GIT_COMMIT=dev
-ARG GIT_BRANCH=dev
 WORKDIR $GOPATH/go.universe.tf/metallb
 
-# Cache the downloads
-COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
 
-# Copy speaker
-COPY speaker/*.go speaker/
-# Copy frr-metrics
-COPY frr-tools/metrics ./frr-tools/metrics/
-# COPY internals
-COPY internal internal
-COPY api api
-
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
 ARG TARGETARCH
 ARG TARGETOS
 ARG TARGETPLATFORM
 
-# have to manually convert as building the different arms can cause issues
 # Extract variant
+# have to manually convert as building the different arms can cause issues
 RUN case ${TARGETPLATFORM} in \
   "linux/arm/v6") export VARIANT="6" ;; \
   "linux/arm/v7") export VARIANT="7" ;; \
   *) export VARIANT="" ;; \
   esac
 
-# Cache builds directory for faster rebuild
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  --mount=type=bind,source=internal,target=internal \
+  --mount=type=bind,source=api,target=api \
+  --mount=type=bind,source=speaker,target=speaker \
+  --mount=type=bind,source=frr-tools/metrics,target=frr-tools/metrics \
   # build frr metrics
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
   go build -v -o /build/frr-metrics \
@@ -42,7 +40,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
   go build -v -o /build/speaker \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
-  go.universe.tf/metallb/speaker
+  ./speaker
 
 FROM docker.io/alpine:latest
 

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -9,6 +9,7 @@ Chores:
 
 - Enforce adding a release notes entry on each PR ([PR 2191](https://github.com/metallb/metallb/pull/2191))
 - Dev-env: don't run tests against VRFs by default ([PR 2201](https://github.com/metallb/metallb/pull/2201), [ISSUE 2197](https://github.com/metallb/metallb/issues/2197))
+- Dev-env: improve docker build times ([PR 2205](https://github.com/metallb/metallb/pull/2205))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
The goal of this PR is to speed up Docker builds, because I'm on a slow network and every time I ran `inv dev-env` it took a long time.

1. I moved towards the bottom lines, such as

```
ARG GIT_COMMIT=dev
ARG GIT_BRANCH=dev
```

so they don't invalidate the other docker layers when the value changes (i.e., go mod download).

2. The second thing is to reduce the number of layers by replacing instructions such as:

```
COPY go.mod go.sum ./
```

with

```
--mount=type=bind,source=go.sum,target=go.sum \
--mount=type=bind,source=go.mod,target=go.mod \
```

this way the files are mounted from the host instead of copied to a new layer.

3. I added a cache mount for downloaded go modules:

```
RUN --mount=type=cache,target=/go/pkg/mod/ \
    ...
    go mod download -x
```