### PR TITLE
CI/E2E: relabel the frr metrics from frr-k8s to show as MetalLB's

### DIFF
--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3279,6 +3279,17 @@ spec:
     tlsConfig:
       insecureSkipVerify: true
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    metricRelabelings:
+    - regex: frrk8s_bgp_(.*)
+      replacement: metallb_bgp_$1
+      sourceLabels:
+      - __name__
+      targetLabel: __name__
+    - regex: frrk8s_bfd_(.*)
+      replacement: metallb_bfd_$1
+      sourceLabels:
+      - __name__
+      targetLabel: __name__
     path: /metrics
     port: frrmetricshttps
     scheme: https

--- a/config/prometheus-frr-k8s/kustomization.yaml
+++ b/config/prometheus-frr-k8s/kustomization.yaml
@@ -18,4 +18,10 @@ patches:
   - path: ignore-ns.yaml
   - path: ignore-prom-role.yaml
   - path: ignore-prom-rolebinding.yaml
+  - path: relabel-metrics.yaml
+    target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      name: frr-k8s-metrics-monitor
 namespace: metallb-system

--- a/config/prometheus-frr-k8s/relabel-metrics.yaml
+++ b/config/prometheus-frr-k8s/relabel-metrics.yaml
@@ -1,0 +1,14 @@
+- op: test
+  path: /spec/endpoints/1/port
+  value: frrmetricshttps
+- op: replace
+  path: /spec/endpoints/1/metricRelabelings
+  value:
+  - sourceLabels: [__name__]
+    regex: "frrk8s_bgp_(.*)"
+    targetLabel: "__name__"
+    replacement: "metallb_bgp_$1"
+  - sourceLabels: [__name__]
+    regex: "frrk8s_bfd_(.*)"
+    targetLabel: "__name__"
+    replacement: "metallb_bfd_$1"

--- a/e2etest/bgptests/metrics.go
+++ b/e2etest/bgptests/metrics.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_opens_sent{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_opens_sent{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_opens_received{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_opens_received{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_updates_total_received{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_updates_total_received{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_keepalives_sent{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_keepalives_sent{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_keepalives_received{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_keepalives_received{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -197,7 +197,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_route_refresh_sent{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_route_refresh_sent{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -207,7 +207,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_total_sent{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_total_sent{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 							return err
 						}
 
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_total_received{%s} >= 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_total_received{%s} >= 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -324,7 +324,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_session_up{%s} == 1`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_session_up{%s} == 1`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -332,7 +332,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_announced_prefixes_total{%s} == 0`, metricsPrefix, selector.labelsForQueryBGP), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_announced_prefixes_total{%s} == 0`, selector.labelsForQueryBGP), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_session_up{peer="%s"} == 1`, metricsPrefix, addr), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_session_up{peer="%s"} == 1`, addr), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -395,7 +395,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_announced_prefixes_total{peer="%s"} == 1`, metricsPrefix, addr), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_announced_prefixes_total{peer="%s"} == 1`, addr), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bgp_updates_total{peer="%s"} >= 1`, metricsPrefix, addr), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bgp_updates_total{peer="%s"} >= 1`, addr), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -480,7 +480,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_session_up{%s} == 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_session_up{%s} == 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -489,7 +489,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_control_packet_input{%s} >= 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_control_packet_input{%s} >= 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -498,7 +498,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_control_packet_output{%s} >= 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_control_packet_output{%s} >= 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -507,7 +507,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_session_down_events{%s} >= 0`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_session_down_events{%s} >= 0`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -516,7 +516,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_session_up_events{%s} >= 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_session_up_events{%s} >= 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -525,7 +525,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_zebra_notifications{%s} >= 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_zebra_notifications{%s} >= 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_echo_packet_input{%s} >= %d`, metricsPrefix, selector.labelsForQueryBFD, echoVal), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_echo_packet_input{%s} >= %d`, selector.labelsForQueryBFD, echoVal), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -548,7 +548,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 						if err != nil {
 							return err
 						}
-						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_echo_packet_output{%s} >= %d`, metricsPrefix, selector.labelsForQueryBFD, echoVal), metrics.There)
+						err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_echo_packet_output{%s} >= %d`, selector.labelsForQueryBFD, echoVal), metrics.There)
 						if err != nil {
 							return err
 						}
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_session_up{%s} == 0`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_session_up{%s} == 0`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}
@@ -595,7 +595,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					if err != nil {
 						return err
 					}
-					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`%s_bfd_session_down_events{%s} >= 1`, metricsPrefix, selector.labelsForQueryBFD), metrics.There)
+					err = metrics.ValidateOnPrometheus(promPod, fmt.Sprintf(`metallb_bfd_session_down_events{%s} >= 1`, selector.labelsForQueryBFD), metrics.There)
 					if err != nil {
 						return err
 					}

--- a/tasks.py
+++ b/tasks.py
@@ -424,7 +424,16 @@ apiServer:
         if bgp_type == "frr-k8s":
             frr_values="--set frrk8s.enabled=true --set speaker.frr.enabled=false --set frr-k8s.prometheus.serviceMonitor.enabled=false "
             if with_prometheus:
-                frr_values="--set frrk8s.enabled=true --set speaker.frr.enabled=false --set frr-k8s.prometheus.serviceMonitor.enabled=true "
+                frr_values=("--set frrk8s.enabled=true --set speaker.frr.enabled=false --set frr-k8s.prometheus.serviceMonitor.enabled=true "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].sourceLabels=\{__name__\} "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].regex=\"frrk8s_bgp_(.*)\" "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].targetLabel=\"__name__\" "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].replacement=\"metallb_bgp_\$1\" "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].sourceLabels=\{__name__\} "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].regex=\"frrk8s_bfd_(.*)\" "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].targetLabel=\"__name__\" "
+                            "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].replacement=\"metallb_bfd_\$1\" "
+                           )
 
         run("helm install metallb charts/metallb/ --set controller.image.tag=dev-{} "
                 "--set speaker.image.tag=dev-{} --set speaker.logLevel=debug "

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -14,6 +14,7 @@ Chores:
 - Move webhooks out of API package ([PR 2193](https://github.com/metallb/metallb/pull/2193))
 - Support running the e2es on frr-k8s deployments ([PR 2180](https://github.com/metallb/metallb/pull/2180))
 - E2E: Receive prefixes using frr-k8s alongside MetalLB ([PR 2211](https://github.com/metallb/metallb/pull/2211))
+- CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
We would like to expose the frr metrics coming from frr-k8s as metallb's because it is the same set of metrics (for frr mode) and would make the integration smoother when the servicemonitors are set up in a similar way.
