### PR TITLE
RelNotes: union instead of merge

### DIFF
--- a/website/content/release-notes/.gitattributes
+++ b/website/content/release-notes/.gitattributes
@@ -1,0 +1,1 @@
+_index.md merge=union


### PR DESCRIPTION
The rel notes are appended, so it makes sense to do union instead of merging, otherwise each PR will cause a conflict.
