### PR TITLE
Update to Go 1.20.12

### DIFF
--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.12 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.12 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.10 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.20.12 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -14,6 +14,7 @@ Chores:
 - Move webhooks out of API package ([PR 2193](https://github.com/metallb/metallb/pull/2193))
 - Support running the e2es on frr-k8s deployments ([PR 2180](https://github.com/metallb/metallb/pull/2180))
 - E2E: Receive prefixes using frr-k8s alongside MetalLB ([PR 2211](https://github.com/metallb/metallb/pull/2211))
+- Images updated to Go 1.20.12 ([PR 2213](https://github.com/metallb/metallb/pull/2213))
 - CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
 
 ## Version 0.13.12
@@ -22,7 +23,7 @@ Chores:
 - Disable http2 on the webhook listener
 - Bump the kubernetes dependencies
 
-This release includes contributions from Federico Paolinelli, Ori Braunshtein, Micha Nagel
+This release includes contributions from Federico Paolinelli, Ori Braunshtein, Micah Nagel
 
 ## Version 0.13.11
 


### PR DESCRIPTION
This updates the dockerfiles to the latest go minor version, 1.20.12.

Included is a fix for CVE - https://github.com/golang/go/issues/64433