### PR TITLE
Override GOBIN for inv dev-env

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -294,8 +294,8 @@ def validate_kind_version():
 
 def generate_manifest(ctx, crd_options="crd:crdVersions=v1", bgp_type="native", output=None, with_prometheus=False):
     _fetch_kubectl()
-    run("GOPATH={} go install sigs.k8s.io/controller-tools/cmd/controller-gen@{}".format(build_path, controller_gen_version))
-    res = run("{}/bin/controller-gen {} rbac:roleName=manager-role webhook paths=\"./api/...\" output:crd:artifacts:config=config/crd/bases".format(build_path, crd_options))
+    run("GOBIN={}/bin/ GOPATH={} go install sigs.k8s.io/controller-tools/cmd/controller-gen@{}".format(build_path, build_path, controller_gen_version), echo=True)
+    res = run("{}/bin/controller-gen {} rbac:roleName=manager-role webhook paths=\"./api/...\" output:crd:artifacts:config=config/crd/bases".format(build_path, crd_options), echo=True)
     if not res.ok:
         raise Exit(message="Failed to generate manifests")
 

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -18,6 +18,7 @@ Chores:
 - CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
 - Dev-env: change the default BGP mode to FRR ([PR 2196](https://github.com/metallb/metallb/pull/2196))
 - Webhooks: avoid transient errors ([PR 2202](https://github.com/metallb/metallb/pull/2202)), [ISSUE 2173](https://github.com/metallb/metallb/issues/2173))
+- Dev-env: Override GOBIN for inv dev-env ([PR 2219](https://github.com/metallb/metallb/pull/2219))
 
 ## Version 0.13.12
 


### PR DESCRIPTION
When GOBIN is already set, go install will install the binary to that path. However,  line 'run("{}/bin/controller-gen...' expects controller-gen to be installed under build/bin/controller-gen. Force GOBIN to the correct value, always.

Reported-at: https://github.com/metallb/metallb/issues/2218