### PR TITLE
docs: fix typo in layer 2 mode docs

### DIFF
--- a/website/content/concepts/layer2.md
+++ b/website/content/concepts/layer2.md
@@ -82,7 +82,7 @@ announcing a given IP.
 
 ### Adding or removing nodes
 
-Given the leader election algoritm described above, removing a node does not change the
+Given the leader election algorithm described above, removing a node does not change the
 speaker announcing the VIP, while adding a node will change it only if it becomes the new
 first element of the list.
 


### PR DESCRIPTION
I was just skimming through the docs of the Layer 2 mode and found this small typo.