### PR TITLE
Remove outdated information about k8s mixed protocol support

### DIFF
--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -14,6 +14,8 @@ BugFixes:
 - Fix the non existing conversion webhook in the Helm CRDs ([PR 2269](https://github.com/metallb/metallb/pull/2269))
 - Remove dangling AddressPool leftovers ([PR 2272](https://github.com/metallb/metallb/pull/2272) [Issue 2270](https://github.com/metallb/metallb/issues/2270))
 - Helm: fix the creation of the metrics-certs volume under the presence of the speakerMetricsTLSSecret value, regardless of FRR being enabled ([PR 2286](https://github.com/metallb/metallb/pull/2286))
+- Docs: remove outdated information about multiprotocol services ([PR 2228](https://github.com/metallb/metallb/pull/2228)).
+
 Chores:
 
 - Add Helm to upgrade documentation ([PR 2268](https://github.com/metallb/metallb/pull/2268))

--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -248,15 +248,7 @@ spec:
     app: dns
 ```
 
-[Kubernetes does not currently allow multiprotocol LoadBalancer services](https://github.com/kubernetes/kubernetes/issues/23880). This
-would normally make it impossible to run services like DNS, because
-they have to listen on both TCP and UDP. To work around this
-limitation of Kubernetes with MetalLB, create two services (one for
-TCP, one for UDP), both with the same pod selector. Then, give them
-the same sharing key and `spec.loadBalancerIP` to colocate the TCP and
-UDP serving ports on the same IP address.
-
-The second reason is much simpler: if you have more services than
+This might be useful in case you have more services than
 available IP addresses, and you can't or don't want to get more
 addresses, the only alternative is to colocate multiple services per
 IP address.


### PR DESCRIPTION
k8s now supports mixed protocol services of type LoadBalancer
Mixed protocol support was merged in k8s with [kubernetes/pull/94028](https://github.com/kubernetes/kubernetes/pull/94028).

Thanks for sending a pull request! A few things before we get started:

1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
