### PR TITLE
dev-env: wait until the lb exclusion is effective

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,6 +326,10 @@ jobs:
           sed -i 's/native/frr/g' bin/metallb-operator.yaml
           kubectl apply -f bin/metallb-operator.yaml
 
+      - name: Remove the exclude from external lb label from the master node
+        run: |
+          env "PATH=$PATH" inv remove-lb-exclusion-from-nodes
+
       - name: Ensure MetalLB operator is ready
         run: |
           COUNT=0


### PR DESCRIPTION
We saw a flake where the first test fails, probably because the lb exclusion is not effective yet. So here we:

- move the exclusion from the e2e command to the dev-env command, so it will work when testing / tinkering too
- active wait until all the labels are removed
