### PR TITLE
Warn users when skipping BGP announcements

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -154,12 +154,12 @@ func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ []net.IP, po
 	}
 
 	if k8snodes.IsNetworkUnavailable(nodes[c.myNode]) {
-		level.Debug(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has NodeNetworkUnavailable condition")
+		level.Warn(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has NodeNetworkUnavailable condition")
 		return "nodeNetworkUnavailable"
 	}
 
 	if !c.ignoreExcludeLB && k8snodes.IsNodeExcludedFromBalancers(nodes[c.myNode]) {
-		level.Debug(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has labeled 'node.kubernetes.io/exclude-from-external-load-balancers'")
+		level.Warn(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has labeled 'node.kubernetes.io/exclude-from-external-load-balancers'")
 		return "nodeLabeledExcludeBalancers"
 	}
 


### PR DESCRIPTION
Instead of forcing users to turn on debug logging to figure out why their BGP announcements aren't going out, make these warnings.

This is pretty trivial, but I won't be upset if nobody likes it.

/kind cleanup

```release-note
The log level of the logs for skipping the BGP announcement because of the 'node.kubernetes.io/exclude-from-external-load-balancer' label and the network unavailable condition are now warning instead of debug.
```
