### PR TITLE
Provide a ignore-exclude-lb flag

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -124,6 +124,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.frr.metricsPort | int | `7473` |  |
 | speaker.frr.resources | object | `{}` |  |
 | speaker.frrMetrics.resources | object | `{}` |  |
+| speaker.ignoreExcludeLB | bool | `false` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -244,6 +244,9 @@ spec:
         {{- if .Values.speaker.wanConfig }}
         - --ml-wan-config
         {{- end }}
+        {{- if .Values.speaker.ignoreExcludeLB}}
+        - --ignore-exclude-lb
+        {{- end }}
         env:
         - name: METALLB_NODE_NAME
           valueFrom:
@@ -330,7 +333,7 @@ spec:
         {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled .Values.speaker.excludeInterfaces.enabled }}
         volumeMounts:
           {{- if .Values.speaker.memberlist.enabled }}
-          - name: memberlist 
+          - name: memberlist
             mountPath: {{ .Values.speaker.memberlist.mlSecretKeyPath }}
           {{- end }}
           {{- if .Values.speaker.frr.enabled }}
@@ -525,7 +528,7 @@ spec:
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
-        operator: Exists        
+        operator: Exists
       {{- end }}
       {{- with .Values.speaker.tolerations }}
         {{- toYaml . | nindent 6 }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -299,7 +299,7 @@
       },
       "required": [ "podMonitor", "prometheusRule" ]
     },
-    "controller": { 
+    "controller": {
       "allOf": [
         { "$ref": "#/definitions/component" },
         { "description": "MetalLB Controller",
@@ -330,7 +330,7 @@
         }
       ]
     },
-    "speaker": { 
+    "speaker": {
       "allOf": [
         { "$ref": "#/definitions/component" },
         { "description": "MetalLB Speaker",
@@ -363,6 +363,9 @@
                   "type": "boolean"
                 }
               }
+            },
+            "ignoreExcludeLB": {
+              "type": "boolean"
             },
             "updateStrategy": {
               "type": "object",

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -268,6 +268,9 @@ speaker:
     mlSecretKeyPath: "/etc/ml_secret_key"
   excludeInterfaces:
     enabled: true
+  # ignore the exclude-from-external-loadbalancer label
+  ignoreExcludeLB: false
+
   image:
     repository: quay.io/metallb/speaker
     tag:

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -51,13 +51,14 @@ type peer struct {
 }
 
 type bgpController struct {
-	logger         log.Logger
-	myNode         string
-	nodeLabels     labels.Set
-	peers          []*peer
-	svcAds         map[string][]*bgp.Advertisement
-	bgpType        bgpImplementation
-	sessionManager bgp.SessionManager
+	logger          log.Logger
+	myNode          string
+	nodeLabels      labels.Set
+	peers           []*peer
+	svcAds          map[string][]*bgp.Advertisement
+	bgpType         bgpImplementation
+	sessionManager  bgp.SessionManager
+	ignoreExcludeLB bool
 }
 
 func (c *bgpController) SetConfig(l log.Logger, cfg *config.Config) error {
@@ -157,7 +158,7 @@ func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ []net.IP, po
 		return "nodeNetworkUnavailable"
 	}
 
-	if k8snodes.IsNodeExcludedFromBalancers(nodes[c.myNode]) {
+	if !c.ignoreExcludeLB && k8snodes.IsNodeExcludedFromBalancers(nodes[c.myNode]) {
 		level.Debug(l).Log("event", "skipping should announce bgp", "service", name, "reason", "speaker's node has labeled 'node.kubernetes.io/exclude-from-external-load-balancers'")
 		return "nodeLabeledExcludeBalancers"
 	}

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"sort"
-	"strings"
 	"testing"
 
 	"go.universe.tf/metallb/internal/config"
@@ -1261,7 +1260,7 @@ func TestShouldAnnounceNodeSelector(t *testing.T) {
 		{
 			desc:             "One service, etp local, endpoint on iris1, selector on both(split), c2 should announce",
 			balancer:         "test1",
-			eps:              epsOn("iris2"),
+			eps:              epsOn("iris1"),
 			L2Advertisements: advertisementSplit,
 			trafficPolicy:    v1.ServiceExternalTrafficPolicyTypeLocal,
 			c1ExpectedResult: map[string]string{
@@ -1313,10 +1312,6 @@ func TestShouldAnnounceNodeSelector(t *testing.T) {
 	}
 	l := log.NewNopLogger()
 	for _, test := range tests {
-		if !strings.Contains(test.desc, "ltp") {
-			continue
-		}
-
 		cfg := config.Config{
 			Pools: &config.Pools{ByName: map[string]*config.Pool{
 				"default": {

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -9,6 +9,9 @@ New features:
 
 - Bump FRR to 9.0.2 ([PR 2282](https://github.com/metallb/metallb/pull/2282), [Issue 2256](https://github.com/metallb/metallb/issues/2256))
 - Make the namse of webhook service and cert metallb specific to avoid name conflicts with other resources in the cluster. ([PR 2244](https://github.com/metallb/metallb/pull/2244), [Issue 2174](https://github.com/metallb/metallb/issues/2174)).
+New Features:
+
+- Provide a "ignore-exclude-lb" flag to ignore the `exclude-from-external-load-balancers` label ([PR 2280](https://github.com/metallb/metallb/pull/2280), [Issue 2274](https://github.com/metallb/metallb/issues/2274))
 
 BugFixes:
 

--- a/website/content/troubleshooting/_index.md
+++ b/website/content/troubleshooting/_index.md
@@ -87,6 +87,13 @@ A given speaker won't advertise the service if:
 - there are no L2Advertisements / BGPAdvertisements matching the speaker node (if node selectors are specified)
 - the Kubernetes API reports "network not available" on the speaker's node
 
+## MetalLB is not advertising my service from my control-plane nodes or from my single node cluster
+
+Make sure your nodes are not labeled with the
+[node.kubernetes.io/exclude-from-external-load-balancers](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers) label.
+MetalLB honors that label and won't announce any service from such nodes. One way to circumvent
+the issue is to provide the speakers with the `--ignore-exclude-lb` flag (either from Helm or via Kustomize).
+
 ## MetalLB says it advertises the service but reaching the service does not work
 
 ### Checking the L2 advertisement works


### PR DESCRIPTION
MetalLB now honors the node.kubernetes.io/exclude-from-external-load-balancers
but this might harm some deployments where there is only one node and
kubeadm still labels the control plane with such label.

Here we provide a knob to disable the behaviour and make metallb work in
such scenarios.
