### PR TITLE
Charts: fix the metrics-certs volume of the speaker

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -165,6 +165,11 @@ spec:
         {{- toYaml .Values.speaker.securityContext | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.prometheus.speakerMetricsTLSSecret }}
+        - name: metrics-certs
+          secret:
+            secretName: {{ .Values.prometheus.speakerMetricsTLSSecret }}
+      {{- end }}
       {{- if .Values.speaker.memberlist.enabled }}
         - name: memberlist
           secret:
@@ -189,11 +194,6 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
-      {{- if .Values.prometheus.speakerMetricsTLSSecret }}
-        - name: metrics-certs
-          secret:
-            secretName: {{ .Values.prometheus.speakerMetricsTLSSecret }}
-      {{- end }}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -9,8 +9,7 @@ BugFixes:
 
 - Fix the non existing conversion webhook in the Helm CRDs ([PR 2269](https://github.com/metallb/metallb/pull/2269))
 - Remove dangling AddressPool leftovers ([PR 2272](https://github.com/metallb/metallb/pull/2272) [Issue 2270](https://github.com/metallb/metallb/issues/2270))
-## Next release
-
+- Helm: fix the creation of the metrics-certs volume under the presence of the speakerMetricsTLSSecret value, regardless of FRR being enabled ([PR 2286](https://github.com/metallb/metallb/pull/2286))
 Chores:
 
 - Add Helm to upgrade documentation ([PR 2268](https://github.com/metallb/metallb/pull/2268))


### PR DESCRIPTION
The creation of the metrics-certs volume is conditioned by FRR mode, while it should only be conditioned by the presence of the name of the secret in the values.


