### PR TITLE
Communities / LocalPref routemaps: create one route map per neigh

### DIFF
--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -79,6 +79,15 @@ type neighborConfig struct {
 	VRFName             string
 	HasV4Advertisements bool
 	HasV6Advertisements bool
+	// It has at least one advertisement with these communities
+	CommunitiesV4 []string
+	CommunitiesV6 []string
+	// It has at least one advertisement with these large communities
+	LargeCommunitiesV4 []string
+	LargeCommunitiesV6 []string
+	// It has at least one advertisement with these local preferences
+	LocalPrefsV4 []uint32
+	LocalPrefsV6 []uint32
 }
 
 func (n *neighborConfig) ID() string {

--- a/internal/bgp/frr/templates/filters.tmpl
+++ b/internal/bgp/frr/templates/filters.tmpl
@@ -1,27 +1,16 @@
 {{- define "localpreffilter" -}}
-{{$localPrefixListName :=localPrefPrefixList .neighbor .advertisement.LocalPref}}
+{{$localPrefixListName :=localPrefPrefixList .neighbor .advertisement.LocalPref -}}
 {{frrIPFamily .advertisement.IPFamily}} prefix-list {{$localPrefixListName}} seq {{counter $localPrefixListName}} permit {{.advertisement.Prefix}}
-route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
-  match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}}
-  set local-preference {{.advertisement.LocalPref}}
-  on-match next
 {{- end -}}
 
 {{- define "communityfilter" -}}
-{{$communityPrefixlistName :=communityPrefixList .neighbor .community}}
+{{$communityPrefixlistName :=communityPrefixList .neighbor .community -}}
 {{frrIPFamily .advertisement.IPFamily}} prefix-list {{$communityPrefixlistName}} seq {{counter $communityPrefixlistName}} permit {{.advertisement.Prefix}}
-route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
-  match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{communityPrefixList .neighbor .community}}
-  set community {{.community}} additive
-  on-match next
 {{- end -}}
 
 {{- define "largecommunityfilter" -}}
-{{frrIPFamily .advertisement.IPFamily}} prefix-list {{largeCommunityPrefixList .neighbor .largecommunity}} permit {{.advertisement.Prefix}}
-route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
-  match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{largeCommunityPrefixList .neighbor .largecommunity}}
-  set large-community {{.largecommunity}} additive
-  on-match next
+{{$largeCommunityPrefixlistName :=largeCommunityPrefixList .neighbor .largecommunity -}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{largeCommunityPrefixList .neighbor .largecommunity}} seq {{counter $largeCommunityPrefixlistName}} permit {{.advertisement.Prefix}}
 {{- end -}}
 
 {{- /* The prefixes are per router in FRR, but MetalLB api allows to associate a given BGPAdvertisement to a service IP,
@@ -31,6 +20,49 @@ route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
 {{- define "neighborfilters" -}}
 
 route-map {{.neighbor.ID}}-in deny 20
+
+{{- range $c := .neighbor.LocalPrefsV4 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ip address prefix-list {{localPrefPrefixList $.neighbor . }}
+  set local-preference {{.}}
+  on-match next
+{{- end -}}
+
+{{- range $c := .neighbor.LocalPrefsV6 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ipv6 address prefix-list {{localPrefPrefixList $.neighbor . }}
+  set local-preference {{.}}
+  on-match next
+{{- end -}}
+
+{{- range $c := .neighbor.LargeCommunitiesV4 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ip address prefix-list {{largeCommunityPrefixList $.neighbor .}}
+  set large-community {{.}} additive
+  on-match next
+{{- end -}}
+
+{{- range $c := .neighbor.LargeCommunitiesV6 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ipv6 address prefix-list {{largeCommunityPrefixList $.neighbor .}}
+  set large-community {{.}} additive
+  on-match next
+{{- end -}}
+
+{{- range $c := .neighbor.CommunitiesV4 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ip address prefix-list {{communityPrefixList $.neighbor .}}
+  set community {{.}} additive
+  on-match next
+{{- end -}}
+
+{{- range $c := .neighbor.CommunitiesV6 }}
+route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
+  match ipv6 address prefix-list {{communityPrefixList $.neighbor .}}
+  set community {{.}} additive
+  on-match next
+{{- end -}}
+
 {{- range $a := .neighbor.Advertisements }}
 {{/* Advertisements for which we must enable set the local pref */}}
 {{- if not (eq $a.LocalPref 0)}}
@@ -46,7 +78,7 @@ route-map {{.neighbor.ID}}-in deny 20
 {{- end }}
 {{/* this advertisement is allowed to the specific neighbor  */}}
 {{$plistName:=allowedPrefixList $.neighbor}}
- {{frrIPFamily $a.IPFamily}} prefix-list {{$plistName}} seq {{counter $plistName}} permit {{$a.Prefix}}
+{{frrIPFamily $a.IPFamily}} prefix-list {{$plistName}} seq {{counter $plistName}} permit {{$a.Prefix}}
 {{- end }}
 
 

--- a/internal/bgp/frr/testdata/TestLargeCommunities.golden
+++ b/internal/bgp/frr/testdata/TestLargeCommunities.golden
@@ -4,32 +4,30 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
-
-
-ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-
-ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 2
-  match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
-  set community 3333:4444 additive
-  on-match next
-ip prefix-list 10.2.2.254-large:1111:2222:3333-ipv4-community-prefixes permit 172.16.1.10/24
-route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-large:1111:2222:3333-ipv4-community-prefixes
   set large-community 1111:2222:3333 additive
   on-match next
-ip prefix-list 10.2.2.254-large:2222:3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
-route-map 10.2.2.254-out permit 4
+route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-large:2222:3333:4444-ipv4-community-prefixes
   set large-community 2222:3333:4444 additive
   on-match next
+route-map 10.2.2.254-out permit 4
+  match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
+  set community 3333:4444 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-large:1111:2222:3333-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-large:2222:3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
 

--- a/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
+++ b/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
@@ -1,0 +1,109 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
+  set community 1111:2222 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.0/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.0/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.1/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.1/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 3 permit 172.16.1.2/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 3 permit 172.16.1.2/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 4 permit 172.16.1.3/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 4 permit 172.16.1.3/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 5 permit 172.16.1.4/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 5 permit 172.16.1.4/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 6 permit 172.16.1.5/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 6 permit 172.16.1.5/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 7 permit 172.16.1.6/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 7 permit 172.16.1.6/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 8 permit 172.16.1.7/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 8 permit 172.16.1.7/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 9 permit 172.16.1.8/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 9 permit 172.16.1.8/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 10 permit 172.16.1.9/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 10 permit 172.16.1.9/24
+
+
+
+
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 11 deny any
+
+route-map 10.2.2.254-out permit 2
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 3
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 timers connect 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.0/24
+    network 172.16.1.1/24
+    network 172.16.1.2/24
+    network 172.16.1.3/24
+    network 172.16.1.4/24
+    network 172.16.1.5/24
+    network 172.16.1.6/24
+    network 172.16.1.7/24
+    network 172.16.1.8/24
+    network 172.16.1.9/24
+  exit-address-family
+
+

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -4,28 +4,25 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
-
-
-ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-
-ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
+ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -7,7 +7,7 @@ route-map 10.2.2.254-in deny 20
 
 
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
@@ -7,7 +7,7 @@ route-map 10.2.2.254-red-in deny 20
 
 
 
- ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -7,7 +7,7 @@ route-map 10.2.2.254-in deny 20
 
 
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
@@ -4,28 +4,25 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
-
-
-ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-
-ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 3
   match ip address prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
+ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -4,20 +4,19 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
-
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
-
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
@@ -7,7 +7,7 @@ route-map 10.2.2.254-in deny 20
 
 
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
 

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -4,78 +4,64 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
-
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
-  match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
-  set community 1111:2222 additive
-  on-match next
-
-
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
-
-
-ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
-route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
-route-map 10.2.2.254-out permit 3
+route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 
 
 ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
-route-map 10.2.2.254-out permit 4
+route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-pl-ipv4
-route-map 10.2.2.254-out permit 5
+route-map 10.2.2.254-out permit 4
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.255-in deny 20
-
-
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.255-out permit 1
-  match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
-  set community 1111:2222 additive
-  on-match next
-
-
- ip prefix-list 10.2.2.255-pl-ipv4 seq 1 permit 172.16.1.10/24
-
-
-ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
-route-map 10.2.2.255-out permit 2
   match ip address prefix-list 10.2.2.255-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
-route-map 10.2.2.255-out permit 3
+route-map 10.2.2.255-out permit 2
   match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.255-pl-ipv4 seq 2 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
+
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 
 
 ipv6 prefix-list 10.2.2.255-pl-ipv4 seq 3 deny any
 
-route-map 10.2.2.255-out permit 4
+route-map 10.2.2.255-out permit 3
   match ip address prefix-list 10.2.2.255-pl-ipv4
-route-map 10.2.2.255-out permit 5
+route-map 10.2.2.255-out permit 4
   match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
@@ -4,78 +4,64 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
-
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
-  match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
-  set community 1111:2222 additive
-  on-match next
-
-
- ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
-
-
-ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
-route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
-route-map 10.2.2.254-out permit 3
+route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 
 
 ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
-route-map 10.2.2.254-out permit 4
+route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-pl-ipv4
-route-map 10.2.2.254-out permit 5
+route-map 10.2.2.254-out permit 4
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.255-red-in deny 20
-
-
-ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.255-red-out permit 1
-  match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
-  set community 1111:2222 additive
-  on-match next
-
-
- ip prefix-list 10.2.2.255-red-pl-ipv4 seq 1 permit 172.16.1.10/24
-
-
-ip prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
-route-map 10.2.2.255-red-out permit 2
   match ip address prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-
-ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
-route-map 10.2.2.255-red-out permit 3
+route-map 10.2.2.255-red-out permit 2
   match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
- ip prefix-list 10.2.2.255-red-pl-ipv4 seq 2 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
+
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 
 
 ipv6 prefix-list 10.2.2.255-red-pl-ipv4 seq 3 deny any
 
-route-map 10.2.2.255-red-out permit 4
+route-map 10.2.2.255-red-out permit 3
   match ip address prefix-list 10.2.2.255-red-pl-ipv4
-route-map 10.2.2.255-red-out permit 5
+route-map 10.2.2.255-red-out permit 4
   match ipv6 address prefix-list 10.2.2.255-red-pl-ipv4
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
@@ -4,20 +4,19 @@ hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
-
-
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-
- ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
-
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 
 
- ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 
 

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -16,6 +16,7 @@ BugFixes:
 - Remove dangling AddressPool leftovers ([PR 2272](https://github.com/metallb/metallb/pull/2272) [Issue 2270](https://github.com/metallb/metallb/issues/2270))
 - Helm: fix the creation of the metrics-certs volume under the presence of the speakerMetricsTLSSecret value, regardless of FRR being enabled ([PR 2286](https://github.com/metallb/metallb/pull/2286))
 - Docs: remove outdated information about multiprotocol services ([PR 2228](https://github.com/metallb/metallb/pull/2228)).
+- FRR Config: generate the route-map for each local pref / community / large community only once ([PR 2292](https://github.com/metallb/metallb/pull/2292))
 
 Chores:
 


### PR DESCRIPTION
The current implementation creates one route map per localpref / community, duplicating the same route-map for each advertisement (while what we really need is one route map, many prefix-lists entries, one per service).

Here we collect all the communities / localpref / large communities per neighbor, and we use it to generate a route-map per neighbor per community / localpref only once.