### PR TITLE
Release notes: use the k8s release tool

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
-Thanks for sending a pull request! A few things before we get started:
-
+<!-- Thanks for sending a pull request!
 1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
 2. For non-trivial pull requests, please [file an
    issue](https://github.com/metallb/metallb/issues/new) first, and get
@@ -10,3 +9,32 @@ Thanks for sending a pull request! A few things before we get started:
 3. If the PR fixes a particular bug, please include the words "Fixed
    #<issue number>" in the PR text, so that the bug auto-closes when
    the PR is merged.
+-->
+
+**Is this a BUG FIX or a FEATURE ?**:
+
+> Uncomment only one, leave it on its own line:
+>
+> /kind bug
+> /kind cleanup
+> /kind feature
+> /kind design
+> /kind flake
+> /kind failing
+> /kind documentation
+> /kind regression
+
+**What this PR does / why we need it**:
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
+3. If no release note is required, just write "NONE".
+-->
+
+```release-note
+
+```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,29 +41,6 @@ jobs:
         with:
           skip-upload: true
 
-  check-changelog:
-    runs-on: ubuntu-22.04
-    if: github.actor != 'dependabot[bot]'
-    steps:
-      - name: Checkout Source
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v42
-
-      - name: Check if release notes where changed
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            if [ "$file" = "website/content/release-notes/_index.md" ]; then
-              exit 0
-            fi
-          done
-          echo "Release notes must be changed"
-          exit 1
-
   commitlint:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/classify.yaml
+++ b/.github/workflows/classify.yaml
@@ -1,0 +1,55 @@
+name: Add Labels
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            kind/api-change
+            kind/bug
+            kind/cleanup
+            kind/deprecation
+            kind/design
+            kind/documentation
+            kind/failing
+            kind/feature
+            kind/flake
+            kind/regression
+
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.pull_request.body }}
+          regex: '(?<!> )\/kind (\w+)'
+
+
+
+      - name: Check
+        run: |
+          if [[ ! "${{ steps.regex-match.outputs.group1 }}" =~ ^(api-change|bug|cleanup|deprecation|design|documentation|failing|feature|flake|regression)$ ]]; then
+            echo "kind must belong to
+                  - api-change \
+                  - bug \
+                  - cleanup \
+                  - deprecation \
+                  - design \
+                  - documentation \
+                  - failing \
+                  - feature \
+                  - flake \
+                  - regression \
+            please add /kind [type] to the body of the PR"
+            exit 1
+          fi
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: kind/${{ steps.regex-match.outputs.group1 }}

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -13,17 +13,51 @@ Are you actually ready to release? Check the milestone on github and
 verify that all its issues are closed. If there are open issues,
 you'll have to either resolve them, or bump to the next version.
 
+### Merge the main branch
 
-### Cherry-pick relevant commits
-
-MetalLB uses release branches to track releases. Relevant commits should be cherry-picked onto the release branch.
+MetalLB uses release branches to track releases. In case a new release is cut as a mirror of main, merge can
+be used.
 For example:
+
+```bash
+git checkout v0.9
+git merge main
+git push
+```
+
+#### Using cherry picks
+
+In case only a subset of the changes are brought to the new release, cherry-pick
+must be used.
 
 ```bash
 git checkout v0.9
 git cherry-pick -x f1f86ed658c1e8a6f90f967ed94881d61476b4c0
 git push
 ```
+
+Note that this will break the release notes generator. If this fix is a backport, please
+consider filing a backport PR.
+
+### Generate the release notes
+
+A convenience generator script is added under `website/gen_relnotes.sh`. The syntax is
+as follows:
+
+```bash
+website/gen_relnotes.sh <branch> <first commit> <last commit>
+```
+
+Where branch is the branch being released, first and last commit is the interval
+we want to generate the release notes for.
+
+The `GITHUB_TOKEN` environment variable must be set with a github token which has the following permissions:
+
+Read access to:
+
+- Contents
+- Pull requests
+- Commit statuses
 
 ### Finalize release notes
 

--- a/website/gen_relnotes.sh
+++ b/website/gen_relnotes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+set -x
+
+if [[ ! -v GITHUB_TOKEN ]]; then
+    echo "GITHUB_TOKEN is not set, please set it with a token with read permissions on commits and PRs"
+    exit 1
+fi
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+branch=$1
+from=$2
+to=$3
+release_notes=$(mktemp)
+
+end() {
+    rm $release_notes
+}
+
+trap end EXIT SIGINT SIGTERM SIGSTOP
+
+GOFLAGS=-mod=mod go run k8s.io/release/cmd/release-notes@v0.16.5 \
+    --branch $branch \
+    --required-author "" \
+    --org metallb \
+    --dependencies=false \
+    --repo metallb \
+    --start-sha $from \
+    --end-sha $to \
+    --output $release_notes
+
+cat $release_notes


### PR DESCRIPTION
Trying to migrate the current way to enforce the release notes:

- remove the mandatory need to change the rel notes
- provide a pr template aligned to k8s, with a field for rel notes
- provide a gh action to assign the right label to the pr, that can be used by the tool

When this is established, it will be possible to use the tool to generate the release notes automatically.
This goes under the assumption that no cherry-pick is done without a corresponding PR.

/kind cleanup
