### PR TITLE
Charts: don't deploy metallb-excludel2 cm if the speaker is disabled

### DIFF
--- a/charts/metallb/templates/exclude-l2-config.yaml
+++ b/charts/metallb/templates/exclude-l2-config.yaml
@@ -1,9 +1,11 @@
-{{- if .Values.speaker.excludeInterfaces.enabled }}
+{{- if and .Values.speaker.enabled .Values.speaker.excludeInterfaces.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: metallb-excludel2
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "metallb.labels" . | nindent 4 }}
 data:
   excludel2.yaml: |
     announcedInterfacesToExclude:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

- no need to install "metallb-excludel2" cm, when speaker component is disabled
- added common labels for "metallb-excludel2" cm the same way as for another manifests

**Special notes for your reviewer**:

NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The metallb-excludel2 configmap is not deployed from the Helm chart if the speaker is disabled.
```