### PR TITLE
Docs: fix the typo on the installation page

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -146,7 +146,7 @@ resources:
 
 ## Installation with Helm
 
-You can install MetallLB with [Helm](https://helm.sh/)
+You can install MetalLB with [Helm](https://helm.sh/)
 by using the Helm chart repository: `https://metallb.github.io/metallb`
 
 ```bash


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**: /kind documentation

**What this PR does / why we need it**:

Fix the typo on the installation page.
`MetallLB` => `MetalLB`

**Special notes for your reviewer**:
NONE

**Release note**:

```release-note
NONE
```
