### PR TITLE
PR classify: fail if there is no text for rel notes

### DIFF
--- a/.github/workflows/classify.yaml
+++ b/.github/workflows/classify.yaml
@@ -31,8 +31,6 @@ jobs:
           text: ${{ github.event.pull_request.body }}
           regex: '(?<!> )\/kind (\w+)'
 
-
-
       - name: Check
         run: |
           if [[ ! "${{ steps.regex-match.outputs.group1 }}" =~ ^(api-change|bug|cleanup|deprecation|design|documentation|failing|feature|flake|regression)$ ]]; then
@@ -53,3 +51,16 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: kind/${{ steps.regex-match.outputs.group1 }}
+
+      - name: Check release notes were not deleted
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            if (!pr.data.body.includes("```release-note")) {
+              throw new Error("Please don't cancel the ```release-note ``` section as it is used to build the release notes");
+            }

--- a/website/content/release-notes/.gitattributes
+++ b/website/content/release-notes/.gitattributes
@@ -1,1 +1,0 @@
-_index.md merge=union


### PR DESCRIPTION
We run a simple check against the release-note entry of the PR body, to notify the users that that section is required for release notes.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

This can't be tested as part of the PR itself, however I tested it here https://github.com/fedepaol/relnotestexperients/pull/19

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```



