### PR TITLE
Speaker: hide the L2ServiceStatus generation behind a flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,7 +227,8 @@ jobs:
           HELM_FLAGS=""
           echo '/etc/frr/core-%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern
           if [ ${{ matrix.deployment }} = "helm" ]; then export SPEAKER_SELECTOR="app.kubernetes.io/component=speaker" && export CONTROLLER_SELECTOR="app.kubernetes.io/component=controller"; fi
-          SKIP="none"
+          # TODO restore to NONE when https://github.com/metallb/metallb/issues/2311 is fixed
+          SKIP="L2ServiceStatus"
           WITH_VRF="--with-vrf"
           FOCUS=""
           if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|DUALSTACK"; WITH_VRF=""; fi
@@ -330,7 +331,8 @@ jobs:
           spec:
             logLevel: debug
           EOF
-          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE" -e /tmp/kind_logs
+          # TOOD remove skipping L2ServiceStatus once https://github.com/metallb/metallb/issues/2311 is fixed
+          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}
@@ -366,7 +368,7 @@ jobs:
       - name: E2E
         run: |
           FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
-          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --focus "$FOCUS" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --focus "$FOCUS" --skip L2ServiceStatus -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}

--- a/e2etest/l2tests/interface_selector.go
+++ b/e2etest/l2tests/interface_selector.go
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("L2-interface selector", func() {
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.It("Validate ServiceL2Status interface", func() {
+		ginkgo.It("Validate L2ServiceStatus interface", func() {
 			ginkgo.By("use the 1st interface for announcing")
 			resources := config.Resources{
 				L2Advs: []metallbv1beta1.L2Advertisement{

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -129,6 +129,15 @@ var _ = ginkgo.Describe("L2", func() {
 			gomega.Eventually(func() error {
 				return service.ValidateL2(svc)
 			}, 2*time.Minute, 1*time.Second).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should expose the status as L2ServiceStatus", func() {
+			svc, _ := service.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", service.TrafficPolicyCluster)
+
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
+			}()
 
 			ginkgo.By("checking correct serviceL2Status object is populated")
 
@@ -800,9 +809,8 @@ var _ = ginkgo.Describe("L2", func() {
 					Name: fmt.Sprintf("test-addresspool%d", i+1),
 				},
 				Spec: metallbv1beta1.IPAddressPoolSpec{
-					Addresses: []string{addressesRange},
+					Addresses:  []string{addressesRange},
 					AutoAssign: &autoAssign,
-
 				},
 			}
 			pools = append(pools, pool)

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -119,6 +119,7 @@ type Config struct {
 	Listener
 	Layer2StatusChan    <-chan event.GenericEvent
 	Layer2StatusFetcher controllers.StatusFetcher
+	EnableL2Status      bool
 }
 
 // New connects to masterAddr, using kubeconfig to authenticate.
@@ -278,7 +279,7 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	// metallb controller doesn't need this reconciler
-	if cfg.Layer2StatusChan != nil {
+	if cfg.EnableL2Status && cfg.Layer2StatusChan != nil {
 		if err = (&controllers.Layer2StatusReconciler{
 			Client:        mgr.GetClient(),
 			Logger:        cfg.Logger,


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Because of https://github.com/metallb/metallb/issues/2311 we are going to move the status instances to the metallb namespace. This might require a change in the permissions too (from cluster to namespaced) so the new version of MetalLB might not be able to delete the "legacy" instances of the CRD because they belong to namespaces the new metallb might not have permissions on.

Because of this, we hide the feature behind a flag, effectively disabling it until the issue is fixed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Hide the L2ServiceStatus behind a feature flag until https://github.com/metallb/metallb/issues/2311 is fixed.
```
