### PR TITLE
Fix typo in publicly available docs about manifest branch

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -75,7 +75,7 @@ If you want to deploy MetalLB using the [experimental FRR-K8s mode]({{% relref "
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.3/config/manifests/metallb-frr-k8s.yaml
 ```
 
-Please do note that these manifests deploy MetalLB from the main development branch. We highly encourage cloud operators to deploy a stable released version of MetalLB on production environments!
+These manifests deploy MetalLB from a release branch. Indeed, we highly encourage cloud operators to deploy a stable released version of MetalLB (instead of manifests from the main branch) on production environments!
 
 {{% /notice %}}
 


### PR DESCRIPTION
The branch published on the website is actually v0.14 but `_index.md` is using the same text as in the `main` branch misleading warning against using the displayed manifests.

**Is this a BUG FIX or a FEATURE ?**:

/kind documentation

**What this PR does / why we need it**:

The branch published on the website is actually v0.14 but `_index.md` is using the same text as in the `main` branch misleading warning against using the displayed manifests.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
