### PR TITLE
Use docker buildx version instead of ls for buildx check.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -77,7 +77,7 @@ def _docker_build_cmd():
     if cmd:
         out = cmd
     else:
-        out = run("docker buildx ls >/dev/null"
+        out = run("docker buildx version >/dev/null"
                   "&& echo 'docker buildx build --load' "
                   "|| echo 'docker build'", hide=True).stdout.strip()
     return out


### PR DESCRIPTION
In case one of the configured buildx contexts are unavailable (e.g. remote host not reachable), docker buildx ls will hang for several seconds.

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

The container build task _docker_build_cmd checks for buildx support. It uses `docker buildx ls`. However, if docker was configured with multiple contexts and some of those are not reachable for some reason the command waits for timeouts.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
