### PR TITLE
chore: update go to 1.21.9

### DIFF
--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.9 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=type=bind,source=go.sum,target=go.sum \
-    --mount=type=bind,source=go.mod,target=go.mod \
-    go mod download -x
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
 
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.9 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=type=bind,source=go.sum,target=go.sum \
-    --mount=type=bind,source=go.mod,target=go.mod \
-    go mod download -x
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
 
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.8 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.21.9 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=type=bind,source=go.sum,target=go.sum \
-    --mount=type=bind,source=go.mod,target=go.mod \
-    go mod download -x
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
 
 ARG GIT_COMMIT=dev
 ARG GIT_BRANCH=dev


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Updates to the latest 1.21.x version, which includes a net/http CVE fix - https://github.com/golang/go/issues?q=milestone%3AGo1.21.9+label%3ACherryPickApproved

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
NONE
```
