### PR TITLE
Add Kustomize dependency

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -333,7 +333,7 @@ def generate_manifest(ctx, crd_options="crd:crdVersions=v1", bgp_type="native", 
         layer = bgp_type
         if with_prometheus:
             layer = "prometheus-" + layer
-        res = run("{} kustomize config/{} > {}".format(kubectl_path, layer, output))
+        res = run("{} build config/{} > {}".format(kustomize_path, layer, output))
         if not res.ok:
             raise Exit(message="Failed to kustomize manifests")
 

--- a/tasks.py
+++ b/tasks.py
@@ -1072,7 +1072,7 @@ def fetch_controller_gen():
 @cache
 def fetch_kustomize():
     kustomize_zipfile = f"kustomize_{kustomize_version}_$(go env GOOS)_$(go env GOARCH).tar.gz"
-    curl_command = f"curl -L -o {kustomize_path}/{kustomize_zipfile} https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/{kustomize_version}/{kustomize_file}"
+    curl_command = f"curl -L -o {kustomize_path}/{kustomize_zipfile} https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/{kustomize_version}/{kustomize_zipfile}"
     tar_command = f"tar xzf {kustomize_path}/{kustomize_zipfile} && -C {build_path}/bin && rm -rf {kustomize_path}"
     get_version_command = f"{kustomize_path} version"
     fetch_dependency(kustomize_path, kustomize_version, curl_command+tar_command, get_version_command, "Version:")


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind dependencies

**What this PR does / why we need it**:

This PR adds the dependency for Kustomize as requested in #1307 in the python script to fetch dependencies, the controller-gen was not required anymore.
We can use this PR also to update the tasks.py file in case there are some dependencies to update. Further we should verify the kustomize version.

**Release note**:

```release-note
NONE
```
