### PR TITLE
fix: python syntax error -> invalid escape sequence in tasks.py

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -455,14 +455,14 @@ apiServer:
             if with_prometheus:
                 frr_values = (
                     "--set frrk8s.enabled=true --set speaker.frr.enabled=false --set frr-k8s.prometheus.serviceMonitor.enabled=true "
-                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].sourceLabels=\{__name__\} "
+                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].sourceLabels=\\{__name__\\} "
                     "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].regex=\"frrk8s_bgp_(.*)\" "
                     "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].targetLabel=\"__name__\" "
-                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].replacement=\"metallb_bgp_\$1\" "
-                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].sourceLabels=\{__name__\} "
+                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].replacement=\"metallb_bgp_\\$1\" "
+                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].sourceLabels=\\{__name__\\} "
                     "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].regex=\"frrk8s_bfd_(.*)\" "
                     "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].targetLabel=\"__name__\" "
-                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].replacement=\"metallb_bfd_\$1\" "
+                    "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].replacement=\"metallb_bfd_\\$1\" "
                 )
 
         run("helm install metallb charts/metallb/ --set controller.image.tag=dev-{} "


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

- related issue
#2374 

- Python 3.12 specification change causes invalid escape sequences to be output as SyntaxError in tasks.py.

> ❯ asdf local python 3.12.3
❯ inv --list
/Users/tozastation/ghq/github.com/tozastation/metallb/tasks.py:458: SyntaxWarning: invalid escape sequence '\{'
  "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].sourceLabels=\{__name__\} "
/Users/tozastation/ghq/github.com/tozastation/metallb/tasks.py:461: SyntaxWarning: invalid escape sequence '\$'
  "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[0].replacement=\"metallb_bgp_\$1\" "
/Users/tozastation/ghq/github.com/tozastation/metallb/tasks.py:462: SyntaxWarning: invalid escape sequence '\{'
  "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].sourceLabels=\{__name__\} "
/Users/tozastation/ghq/github.com/tozastation/metallb/tasks.py:465: SyntaxWarning: invalid escape sequence '\$'
  "--set frr-k8s.prometheus.serviceMonitor.metricRelabelings[1].replacement=\"metallb_bfd_\$1\" "

- Specification changes in python 3.12.0

https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)

**Special notes for your reviewer**:

- After modification, checked
  - Using the diff command, I checked that there was no difference in the Frrk8s Service Monitor output before and after the modification. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
BugFixes:
Fix the python syntax error in tasks.py
```
