### PR TITLE
Improve error message when keepalivetime is invalid

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -394,7 +394,8 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 
 	// keepalive must be lower than holdtime
 	if keepaliveTime > holdTime {
-		return nil, fmt.Errorf("invalid keepaliveTime %q", p.Spec.KeepaliveTime)
+		return nil, fmt.Errorf("invalid keepaliveTime %q must be smaller than holdtime %q",
+			keepaliveTime, holdTime)
 	}
 
 	// Ideally we would set a default RouterID here, instead of having

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -725,6 +725,36 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid keepalivetime larger than default holdtime",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:         42,
+							ASN:           42,
+							Address:       "1.2.3.4",
+							KeepaliveTime: metav1.Duration{Duration: 91 * time.Second}},
+					},
+				},
+			},
+		},
+		{
+			desc: "invalid keepalivetime larger than holdtime",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:         42,
+							ASN:           42,
+							Address:       "1.2.3.4",
+							HoldTime:      metav1.Duration{Duration: 30 * time.Second},
+							KeepaliveTime: metav1.Duration{Duration: 90 * time.Second}},
+					},
+				},
+			},
+		},
+
+		{
 			desc: "invalid hold time (too short)",
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{


### PR DESCRIPTION
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
The current return error on the validation webhook looks like
```
Error from server (Forbidden): error when creating "peers.yaml": admission webhook "bgppeersvalidationwebhook.metallb.io" denied the request: parsing peer peer-with-kt-greater-than-ht: invalid keepaliveTime {"1m0s"}
```
which does not clue the real reason why that fails validation which is that keepalive time is greater than holdtime.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
