### PR TITLE
Added speaker monitor service labels

### DIFF
--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -70,6 +70,7 @@ metadata:
   {{- end }}
   labels:
     name: {{ template "metallb.fullname" . }}-speaker-monitor-service
+    {{- include "metallb.labels" . | nindent 4 }}
   name: {{ template "metallb.fullname" . }}-speaker-monitor-service
   namespace: {{ .Release.Namespace | quote }}
 spec:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug


**What this PR does / why we need it**:
Fixes #2389

**Special notes for your reviewer**:
You can verify the rendered template for metallb-spekaer-monitor-service as follows;

1. Render helm chart
```
helm template metallb  --set prometheus.serviceMonitor.enabled=true --set prometheus.serviceAccount=prometheus-monitoring-kube-prometheus --set prometheus.namespace=monitoring > /tmp/metallb-new.yaml
```
2. Check `/tmp/metallb-new.yaml` file for `metallb-speaker-monitor-service` if it contains label `app.kubernetes.io/name` with value `metallb`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Propagate the metallb labels to the speaker's service monitor service
```
