### PR TITLE
Update doc references from metallb.universe.tf -> metallb.io

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -71,7 +71,7 @@ MetalLB implements a FRR Mode that uses an [FRR](https://frrouting.org/) contain
 
 Despite being less battle tested than the native BGP implementation, the FRR mode is currently used by those users that require either BFD or IPV6, and it is the only supported method in the MetalLB version distributed with OpenShift. The long term plan is to make it the only BGP implementation available in MetalLB.
 
-Please see the [installation](https://metallb.universe.tf/installation/) section for instructions on how to enable it.
+Please see the [installation](https://metallb.io/installation/) section for instructions on how to enable it.
 
 ## Contributing
 

--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -170,7 +170,7 @@ us confident of the change.
 
 ## The website
 
-The website at <https://metallb.universe.tf> is pinned to the latest
+The website at <https://metallb.io> is pinned to the latest
 released version, so that users who don't care about ongoing
 development see documentation that is consistent with the released
 code.

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -68,7 +68,7 @@ bugfixes (e.g. security issues, long-term pain point resolved), point
 those out as well.
 
 Also update the documentation link so that the soon-to-be latest
-release's documentation link points to `metallb.universe.tf`, and the
+release's documentation link points to `metallb.io`, and the
 previous releases point to `vX-Y-Z--metallb.netlify.com`, which is the
 website pinned at that tagged release.
 
@@ -135,7 +135,7 @@ CI that the deploy has completed.
 Move the `live-website` branch to the newly created tag with `git
 branch -f live-website vX.Y.Z`, then force-push the branch with `git
 push -f origin live-website`. This will trigger Netlify to
-redeploy [metallb.universe.tf](https://metallb.universe.tf) with
+redeploy [metallb.io](https://metallb.io) with
 updated documentation for the new version.
 
 ### Update Slack

--- a/website/content/concepts/bgp.md
+++ b/website/content/concepts/bgp.md
@@ -127,7 +127,7 @@ layer.
 
 When the FRR mode is enabled, the following additional features are available:
 
-- BGP sessions with [BFD support](https://metallb.universe.tf/concepts/bgp/#limitations)
+- BGP sessions with [BFD support](https://metallb.io/concepts/bgp/#limitations)
 - IPv6 Support for BGP and BFD
 - Multi Protocol BGP
 

--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -63,7 +63,7 @@ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/config/m
 ```
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), apply the manifests:
+If you want to deploy MetalLB using the [FRR mode](https://metallb.io/configuration/#enabling-bfd-support-for-bgp-sessions), apply the manifests:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/config/manifests/metallb-frr.yaml
@@ -123,7 +123,7 @@ resources:
   - github.com/metallb/metallb/config/native?ref=main
 ```
 
-In order to deploy the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions):
+In order to deploy the [FRR mode](https://metallb.io/configuration/#enabling-bfd-support-for-bgp-sessions):
 
 ```yaml
 # kustomization.yml
@@ -176,7 +176,7 @@ If you are using MetalLB with a kubernetes version that enforces [pod security a
 {{% /notice %}}
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), the following value must be set:
+If you want to deploy MetalLB using the [FRR mode](https://metallb.io/configuration/#enabling-bfd-support-for-bgp-sessions), the following value must be set:
 
 ```yaml
 speaker:
@@ -199,7 +199,7 @@ frrk8s:
 The MetalLB Operator is available on OperatorHub at [operatorhub.io/operator/metallb-operator](https://operatorhub.io/operator/metallb-operator). It eases the deployment and life-cycle of MetalLB in a cluster and allows configuring MetalLB via CRDs.
 
 {{% notice note %}}
-If you want to deploy MetalLB using the [FRR mode](https://metallb.universe.tf/configuration/#enabling-bfd-support-for-bgp-sessions), you must edit the ClusterServiceVersion resource
+If you want to deploy MetalLB using the [FRR mode](https://metallb.io/configuration/#enabling-bfd-support-for-bgp-sessions), you must edit the ClusterServiceVersion resource
 named `metallb-operator`:
 
 ```bash
@@ -239,7 +239,7 @@ To override this behavior, you can set the `FRR_LOGGING_LEVEL` speaker's environ
 
 ## Upgrade
 
-When upgrading MetalLB, always check the [release notes](https://metallb.universe.tf/release-notes/)
+When upgrading MetalLB, always check the [release notes](https://metallb.io/release-notes/)
 to see the changes and required actions, if any. Pay special attention to the release notes when
 upgrading to newer major/minor releases.
 
@@ -253,8 +253,8 @@ methods described above:
 When upgrading via Helm, note that the chart is designed to automatically upgrade the CRDs;
 there is no need to upgrade them manually.
 
-Please take the known limitations for [layer2](https://metallb.universe.tf/concepts/layer2/#limitations)
-and [bgp](https://metallb.universe.tf/concepts/bgp/#limitations) into account when performing an
+Please take the known limitations for [layer2](https://metallb.io/concepts/layer2/#limitations)
+and [bgp](https://metallb.io/concepts/bgp/#limitations) into account when performing an
 upgrade.
 
 ## Setting the LoadBalancer Class

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -281,7 +281,7 @@ v0.12.x version, but now the feature is covered by tests too ([PR 1444](https://
 Changes in behavior:
 
 - the biggest change is the introduction of CRDs and removing support for the configuration via ConfigMap. In order to ease the transition
-  to the new configuration, we provide a conversion tool from ConfigMap to resources (see the "Backward compatibility" section from [the main page](https://metallb.universe.tf/#backward-compatibility)).
+  to the new configuration, we provide a conversion tool from ConfigMap to resources (see the "Backward compatibility" section from [the main page](https://metallb.io/#backward-compatibility)).
 
 - the internal architecture was radically changed in order to accommodate CRDs, so please do not hesitate to [file an issue](https://github.com/metallb/metallb/issues).
 
@@ -513,7 +513,7 @@ cabot, Tomofumi Hayashi, Tony Perez, and Yuan Liu. Thank you!
 
 ## Version 0.9.6
 
-[Documentation for this release](https://metallb.universe.tf)
+[Documentation for this release](https://metallb.io)
 
 Bugfixes:
 
@@ -701,9 +701,9 @@ New features:
   separate public and private interfaces.
 - The website has updated compatibility grids for both [Kubernetes
   network
-  addons](https://metallb.universe.tf/installation/network-addons/)
+  addons](https://metallb.io/installation/network-addons/)
   and [cloud
-  providers](https://metallb.universe.tf/installation/cloud/), listing
+  providers](https://metallb.io/installation/cloud/), listing
   known issues and configuration tips.
 - MetalLB now publishes a Kubernetes event to a service, indicating
   which nodes are announcing that service. This makes it much easier

--- a/website/content/troubleshooting/_index.md
+++ b/website/content/troubleshooting/_index.md
@@ -65,7 +65,7 @@ and IPV6 addresses
 - if the service asks for a specific IP, an IPAddressPool providing that IP exists and its selectors
 are compatible with the service
 - if the service asks for a specific IP used also by other services, make sure that they respect the
-sharing properties described in the [official docs](https://metallb.universe.tf/usage/#ip-address-sharing).
+sharing properties described in the [official docs](https://metallb.io/usage/#ip-address-sharing).
 
 ## Troubleshooting service advertisements
 


### PR DESCRIPTION


**Is this a BUG FIX or a FEATURE ?**:

 /kind documentation


**What this PR does / why we need it**:
This updates doc updates references to the `metallb.universe.tf` site with new references to the `metallb.io` site. Any annotation references remain as they are still valid.

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
NONE
```
