### PR TITLE
Docs: fix typo in advanced_l2_configuration

### DIFF
--- a/website/content/configuration/_advanced_l2_configuration.md
+++ b/website/content/configuration/_advanced_l2_configuration.md
@@ -131,7 +131,7 @@ metadata:
   name: example-advertisement10
   namespace: metallb-system
 spec:
-  ipaddresspools:
+  ipAddressPools:
   - pool1
   nodeSelector:
   - kubernetes.io/hostname: hostB


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind documentation

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```