### PR TITLE
#364: Detect and reject configurations of service IP range overrlaps with node IPs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,8 @@ import (
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/metallb/internal/bgp/community"
+	"go.universe.tf/metallb/internal/ipfamily"
+	k8snodes "go.universe.tf/metallb/internal/k8s/nodes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -314,6 +316,13 @@ func poolsFor(resources ClusterResources) (*Pools, error) {
 			for _, m := range allCIDRs {
 				if cidrsOverlap(cidr, m) {
 					return nil, fmt.Errorf("CIDR %q in pool %q overlaps with already defined CIDR %q", cidr, p.Name, m)
+				}
+			}
+			// Check pool CIDR is not overlapping with Node IPs
+			nodeIps := k8snodes.NodeIPsForFamily(resources.Nodes, ipfamily.ForCIDR(cidr))
+			for _, nodeIp := range nodeIps {
+				if cidr.Contains(nodeIp) {
+					return nil, fmt.Errorf("pool cidr %q contains nodeIp %q", cidr, nodeIp)
 				}
 			}
 			allCIDRs = append(allCIDRs, cidr)

--- a/internal/k8s/nodes/nodes.go
+++ b/internal/k8s/nodes/nodes.go
@@ -3,6 +3,9 @@
 package nodes
 
 import (
+	"net"
+
+	"go.universe.tf/metallb/internal/ipfamily"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -36,4 +39,21 @@ func IsNodeExcludedFromBalancers(n *corev1.Node) bool {
 		return true
 	}
 	return false
+}
+
+// NodeIPsForFamily returns all input node nodeIP based on ipfamily
+func NodeIPsForFamily(nodes []corev1.Node, family ipfamily.Family) []net.IP {
+	var nodeIPs []net.IP
+	for _, n := range nodes {
+		for _, a := range n.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP {
+				nodeIP := net.ParseIP(a.Address)
+				if family != ipfamily.DualStack && ipfamily.ForAddress(nodeIP) != family {
+					continue
+				}
+				nodeIPs = append(nodeIPs, nodeIP)
+			}
+		}
+	}
+	return nodeIPs
 }

--- a/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook.go
@@ -103,8 +103,13 @@ func validateIPAddressPoolCreate(ipAddress *v1beta1.IPAddressPool) error {
 		return err
 	}
 
+	nodes, err := getExistingNodes()
+	if err != nil {
+		return err
+	}
+
 	toValidate := ipAddressListWithUpdate(existingIPAddressPoolList, ipAddress)
-	err = Validator.Validate(toValidate)
+	err = Validator.Validate(toValidate, nodes)
 	if err != nil {
 		level.Error(Logger).Log("webhook", "ipAddress", "action", "create", "name", ipAddress.Name, "namespace", ipAddress.Namespace, "error", err)
 		return err
@@ -121,8 +126,13 @@ func validateIPAddressPoolUpdate(ipAddress *v1beta1.IPAddressPool, _ *v1beta1.IP
 		return err
 	}
 
+	nodes, err := getExistingNodes()
+	if err != nil {
+		return err
+	}
+
 	toValidate := ipAddressListWithUpdate(existingIPAddressPoolList, ipAddress)
-	err = Validator.Validate(toValidate)
+	err = Validator.Validate(toValidate, nodes)
 	if err != nil {
 		level.Error(Logger).Log("webhook", "ipAddress", "action", "update", "name", ipAddress.Name, "namespace", ipAddress.Namespace, "error", err)
 		return err

--- a/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook_test.go
+++ b/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/go-cmp/cmp"
 	"go.universe.tf/metallb/api/v1beta1"
+	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,9 +30,14 @@ func TestValidateIPAddressPool(t *testing.T) {
 			},
 		}, nil
 	}
+	toRestoreNodes := getExistingNodes
+	getExistingNodes = func() (*v1core.NodeList, error) {
+		return &v1core.NodeList{}, nil
+	}
 
 	defer func() {
 		getExistingIPAddressPools = toRestoreIPAddressPools
+		getExistingNodes = toRestoreNodes
 	}()
 
 	tests := []struct {


### PR DESCRIPTION
issue:
Probably due to inadequate documentation, people think that they can define service IPs that overlap with node IPs. This breaks things in multiple ways (ARP poisoning in L2 mode, wrong kube-proxy rules executed in all modes...), and is not at all a supported mode of operation.
The controller should detect and reject such configurations, as well as refuse to allocate IPs if they overlap with node IPs.

Fixed #364: Detect and reject configurations where service IP range overlaps with node IPs
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
 /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
Probably due to inadequate documentation, people think that they can define service IPs that overlap with node IPs. This breaks things in multiple ways (ARP poisoning in L2 mode, wrong kube-proxy rules executed in all modes...), and is not at all a supported mode of operation.
This PR does two things:
1. Add a webhook validation to check IPAddressPool IP range, if it is overlap with node IPs, reject the configuration of IPAddressPool
2. Add check for service configuration when user defines loadbalancerIP via spec.loadBalancerIP or metallb.universe.tf/loadBalancerIPs annotation. If there's any conflict with node IPs, service will stay in pending state. 

**Special notes for your reviewer**:
- Webhook validation rejection for IPAddressPool has explicit error message so it is easy for user to adjust the configuration. Also webhook validation on IPAddressPool does the rejection before automatic IP allocation take place at service configuration stage. 
- There is no webhook validation for service configuration, leaving service in pending state is intuitive, since user can only know what went wrong by checking the log of the controller. So I tried to limit the checking of service configuration to only user configured loadBlancerIP annotation fields. 
- This PR doesn't cover the scenario of nodeIP changes, i.e. via scale-in/scale-out nodes. But I would expect that after initial prevention of overlapping nodeIPs with loadbalancer IPs subnets. The chance that new node IPs overlapping with existing loadbalancer IP subnets should be very small. 

**Release note**:
Might need to warn user not to use the nodeIPs subnet for loadbalance IPs. 