### PR TITLE
Bump composite workflow actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Upload ${{ matrix.image }} artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           name: image-tar-${{ matrix.image }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,7 +21,7 @@ jobs:
        fuzz-seconds: 600
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/.github/workflows/composite/collectlogs/action.yaml
+++ b/.github/workflows/composite/collectlogs/action.yaml
@@ -15,7 +15,7 @@ runs:
         sudo chmod -R o+r /tmp/kind_logs
 
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: /tmp/kind_logs/

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -4,7 +4,7 @@ description: "Install deps required for metallb CI"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
         cache: true
@@ -20,7 +20,7 @@ runs:
         go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
 
     - name: Download MetalLB images
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: metallb-images
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup


**What this PR does / why we need it**:

This PR cleans up the composite workflow(s) action dependency. These are running on fairly old versions of the actions and are throwing the following warnings in CI

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v3, actions/download-artifact@v3, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
