### PR TITLE
E2E: use the local kubectl instead of the one on the host

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"go.universe.tf/e2etest/bgptests"
 	"go.universe.tf/e2etest/l2tests"
 	testsconfig "go.universe.tf/e2etest/pkg/config"
+	"go.universe.tf/e2etest/pkg/executor"
 	frrprovider "go.universe.tf/e2etest/pkg/frr/provider"
 	"go.universe.tf/e2etest/pkg/iprange"
 	"go.universe.tf/e2etest/pkg/k8s"
@@ -60,6 +61,7 @@ var (
 	frrImage            string
 	hostContainerMode   string
 	withVRF             bool
+	kubectlPath         string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -78,6 +80,7 @@ func handleFlags() {
 	flag.StringVar(&hostContainerMode, "host-bgp-mode", string(bgptests.IBGPMode), "tells whether to run the host container in ebgp or ibgp mode")
 	flag.BoolVar(&withVRF, "with-vrf", false, "runs the tests against containers reacheable via linux vrfs. More coverage, but might not work depending on the OS")
 	flag.StringVar(&bgpMode, "bgp-mode", "", "says which bgp mode we are testing against. valid options are: native, frr, frr-k8s")
+	flag.StringVar(&executor.Kubectl, "kubectl", "kubectl", "the path for the kubectl binary")
 
 	flag.Parse()
 

--- a/e2etest/pkg/executor/executor.go
+++ b/e2etest/pkg/executor/executor.go
@@ -3,9 +3,12 @@
 package executor
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 )
+
+var Kubectl string
 
 type Executor interface {
 	Exec(cmd string, args ...string) (string, error)
@@ -58,7 +61,10 @@ func ForPod(namespace, name, container string) Executor {
 }
 
 func (p *podExecutor) Exec(cmd string, args ...string) (string, error) {
+	if Kubectl == "" {
+		return "", errors.New("the kubectl parameter is not set")
+	}
 	fullargs := append([]string{"exec", p.name, "-n", p.namespace, "-c", p.container, "--", cmd}, args...)
-	out, err := exec.Command("kubectl", fullargs...).CombinedOutput()
+	out, err := exec.Command(Kubectl, fullargs...).CombinedOutput()
 	return string(out), err
 }

--- a/tasks.py
+++ b/tasks.py
@@ -930,10 +930,10 @@ def e2etest(ctx, name="kind", export=None, kubeconfig=None, system_namespaces="k
     if external_frr_image != "":
         external_frr_image = "--frr-image=" + (external_frr_image)
     testrun = run("cd `git rev-parse --show-toplevel`/e2etest &&"
-                  "KUBECONFIG={} ginkgo {} --junit-report={} --timeout=3h {} {} -- --kubeconfig={} --service-pod-port={} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {} {} -bgp-mode={}  -with-vrf={} {} --host-bgp-mode={}".format(
+                  "KUBECONFIG={} ginkgo {} --junit-report={} --timeout=3h {} {} -- --kubeconfig={} --service-pod-port={} -ipv4-service-range={} -ipv6-service-range={} {} --report-path {} {} -node-nics {} -local-nics {} {} -bgp-mode={} -with-vrf={} {} --host-bgp-mode={} --kubectl={}".format(
         kubeconfig, ginkgo_params, junit_report, ginkgo_focus, ginkgo_skip, kubeconfig, service_pod_port, ipv4_service_range,
         ipv6_service_range, opt_skip_docker, report_path, prometheus_namespace, node_nics, local_nics,
-        external_containers, bgp_mode, with_vrf, external_frr_image, host_bgp_mode), warn="True")
+        external_containers, bgp_mode, with_vrf, external_frr_image, host_bgp_mode, kubectl_path), warn="True")
 
     if export != None:
         run("kind export logs {}".format(export))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Using the kubectl version on the host instead of a pinned one may result in flakiness / sudden unexpected behaviour.
Specifically, now we have a set of flakes like the one found in https://github.com/metallb/metallb/pull/2406

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
