### PR TITLE
Use distroless image to build controller and speaker containers

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -210,14 +210,14 @@ spec:
         # Copies the reloader to the shared volume between the speaker and reloader.
         - name: cp-reloader
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /frr-reloader.sh /etc/frr_reloader/"]
+          command: ["/cp-tool","/frr-reloader.sh","/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /frr-metrics /etc/frr_metrics/"]
+          command: ["/cp-tool","/frr-metrics","/etc/frr_metrics/frr-metrics"]
           volumeMounts:
             - name: metrics
               mountPath: /etc/frr_metrics

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -39,14 +39,14 @@ spec:
         # Copies the reloader to the shared volume between the speaker and reloader.
         - name: cp-reloader
           image: quay.io/metallb/speaker:main
-          command: ["/bin/sh", "-c", "cp -f /frr-reloader.sh /etc/frr_reloader/"]
+          command: ["/cp-tool","/frr-reloader.sh","/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
         # Copies the metrics exporter
         - name: cp-metrics
           image: quay.io/metallb/speaker:main
-          command: ["/bin/sh", "-c", "cp -f /frr-metrics /etc/frr_metrics/"]
+          command: ["/cp-tool","/frr-metrics","/etc/frr_metrics/frr-metrics"]
           volumeMounts:
             - name: metrics
               mountPath: /etc/frr_metrics

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2154,18 +2154,18 @@ spec:
         - mountPath: /etc/frr
           name: frr-conf
       - command:
-        - /bin/sh
-        - -c
-        - cp -f /frr-reloader.sh /etc/frr_reloader/
+        - /cp-tool
+        - /frr-reloader.sh
+        - /etc/frr_reloader/frr-reloader.sh
         image: quay.io/metallb/speaker:main
         name: cp-reloader
         volumeMounts:
         - mountPath: /etc/frr_reloader
           name: reloader
       - command:
-        - /bin/sh
-        - -c
-        - cp -f /frr-metrics /etc/frr_metrics/
+        - /cp-tool
+        - /frr-metrics
+        - /etc/frr_metrics/frr-metrics
         image: quay.io/metallb/speaker:main
         name: cp-metrics
         volumeMounts:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1977,18 +1977,18 @@ spec:
         - mountPath: /etc/frr
           name: frr-conf
       - command:
-        - /bin/sh
-        - -c
-        - cp -f /frr-reloader.sh /etc/frr_reloader/
+        - /cp-tool
+        - /frr-reloader.sh
+        - /etc/frr_reloader/frr-reloader.sh
         image: quay.io/metallb/speaker:main
         name: cp-reloader
         volumeMounts:
         - mountPath: /etc/frr_reloader
           name: reloader
       - command:
-        - /bin/sh
-        - -c
-        - cp -f /frr-metrics /etc/frr_metrics/
+        - /cp-tool
+        - /frr-metrics
+        - /etc/frr_metrics/frr-metrics
         image: quay.io/metallb/speaker:main
         name: cp-metrics
         volumeMounts:

--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
   ./configmaptocrs
 
-FROM docker.io/alpine:latest
+FROM gcr.io/distroless/static:latest
 
 COPY --from=builder /build/configmaptocrs /configmaptocrs
 COPY LICENSE /
@@ -47,6 +47,6 @@ LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.licenses="Apache-2.0" \
   org.opencontainers.image.description="Metallb Configmap to CRs converter" \
   org.opencontainers.image.title="configmap to crs" \
-  org.opencontainers.image.base.name="docker.io/alpine:latest"
+  org.opencontainers.image.base.name="gcr.io/distroless/static:latest"
 
 ENTRYPOINT ["/configmaptocrs"]

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
   ./controller
 
-FROM docker.io/alpine:latest
+FROM gcr.io/distroless/static:latest
 
 COPY --from=builder /build/controller /controller
 COPY LICENSE /
@@ -47,6 +47,6 @@ LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.licenses="Apache-2.0" \
   org.opencontainers.image.description="Metallb Controller" \
   org.opencontainers.image.title="controller" \
-  org.opencontainers.image.base.name="docker.io/alpine:latest"
+  org.opencontainers.image.base.name="gcr.io/distroless/static:latest"
 
 ENTRYPOINT ["/controller"]

--- a/e2etest/l2tests/interface_selector.go
+++ b/e2etest/l2tests/interface_selector.go
@@ -25,6 +25,8 @@ import (
 	"go.universe.tf/e2etest/pkg/status"
 )
 
+const agnostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+
 var (
 	NodeNics  []string
 	LocalNics []string
@@ -170,7 +172,7 @@ var _ = ginkgo.Describe("L2-interface selector", func() {
 			}, 1*time.Minute, 1*time.Second).Should(Not(HaveOccurred()))
 			speakerPod, err := metallb.SpeakerPodInNode(cs, svcNode.Name)
 			Expect(err).NotTo(HaveOccurred())
-			selectorMac, err := mac.GetIfaceMac(NodeNics[0], executor.ForPod(speakerPod.Namespace, speakerPod.Name, "speaker"))
+			selectorMac, err := mac.GetIfaceMac(NodeNics[0], executor.ForPodDebug(speakerPod.Namespace, speakerPod.Name, "speaker", agnostImage))
 			Expect(err).NotTo(HaveOccurred())
 
 			ingressIP := jigservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])

--- a/frr-tools/cp-tool/cp-tool.go
+++ b/frr-tools/cp-tool/cp-tool.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func CopyFile(src, dst string) error {
+	srcFile := filepath.Clean(src)
+	destFile := filepath.Clean(dst)
+	source, err := os.Open(srcFile)
+	if err != nil {
+		err = fmt.Errorf("failed to open source file %s: %w", srcFile, err)
+		return err
+	}
+	defer source.Close()
+
+	srcStat, err := os.Stat(srcFile)
+	if err != nil {
+		err = fmt.Errorf("failed to check stats for %s: %w", srcFile, err)
+		return err
+	}
+
+	destination, err := os.Create(destFile)
+	if err != nil {
+		err = fmt.Errorf("failed to create destination file: %s: %w", destFile, err)
+		return err
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		err = fmt.Errorf("failed to copy %s to %s: %w", srcFile, destFile, err)
+		return err
+	}
+
+	err = os.Chmod(destFile, srcStat.Mode())
+	if err != nil {
+		err = fmt.Errorf("failed to apply permission on %s", destFile)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Printf("Please provide two command line arguments.")
+		return
+	}
+
+	sourceFile, destinationFile := os.Args[1], os.Args[2]
+
+	err := CopyFile(sourceFile, destinationFile)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -30,11 +30,18 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=bind,source=api,target=api \
   --mount=type=bind,source=speaker,target=speaker \
   --mount=type=bind,source=frr-tools/metrics,target=frr-tools/metrics \
+  --mount=type=bind,source=frr-tools/cp-tool,target=frr-tools/cp-tool \
   # build frr metrics
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
   go build -v -o /build/frr-metrics \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
   frr-tools/metrics/exporter.go \
+  && \
+  #build cp-tool
+  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+  go build -v -o /build/cp-tool \
+  -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+  frr-tools/cp-tool/cp-tool.go \
   && \
   # build speaker
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
@@ -42,9 +49,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
   ./speaker
 
-FROM docker.io/alpine:latest
+FROM gcr.io/distroless/static:latest
 
 
+COPY --from=builder /build/cp-tool /cp-tool
 COPY --from=builder /build/speaker /speaker
 COPY --from=builder /build/frr-metrics /frr-metrics
 COPY frr-tools/reloader/frr-reloader.sh /frr-reloader.sh
@@ -58,6 +66,6 @@ LABEL org.opencontainers.image.authors="metallb" \
   org.opencontainers.image.licenses="Apache-2.0" \
   org.opencontainers.image.description="Metallb speaker" \
   org.opencontainers.image.title="speaker" \
-  org.opencontainers.image.base.name="docker.io/alpine:latest"
+  org.opencontainers.image.base.name="gcr.io/distroless/static:latest"
 
 ENTRYPOINT ["/speaker"]

--- a/website/content/troubleshooting/_index.md
+++ b/website/content/troubleshooting/_index.md
@@ -288,3 +288,11 @@ Additionally, the status of the service and of the endpoints must be provided:
 kubectl get endpointslices <my-service> -o yaml
 kubectl get svc <my_service> -o yaml
 ```
+
+### How to debug the speaker and the controller containers
+
+Due to the fact that both the speaker and the controller containers are based on a distroless image, an ephemeral container should be used to debug inside them: 
+
+```bash
+kubectl debug -it -n metallb-system -c <ephemeral container name> --target=speaker --image=<ephemeral image name> <speaker pod>
+```


### PR DESCRIPTION
Inspired by https://github.com/metallb/metallb/pull/2117
fixes https://github.com/metallb/metallb/issues/2110

A big thank you to @oribon and @georgettica for the detail discussion in #2117 which is **the** design document I followed to this solution. Also appreciate @oribon 's help during design implementation, that I was able to run local integration and e2e tests! 

**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:
gcr.io/distroless/static base image is used to replace the original docker.io/alpine image, for a distroless solution that controller and speaker images will be built from scratch. Since distroless base image has no shell entry, there are two major impacts with this solution:

1. Some of the frr init containers which need to move files around will need a local copy tool. 
2. Some of the e2e tests which need to execute certain commands (e.g. "ifconfig") from inside the speaker will need to have an ephemeral container attached to the pod to complete the task. 

In this PR, a local copy tool (cp-tool) was introduced to cope with the first concern, and a podDebugExecutor was introduced under e2etest to attach a debug ephemeral container when there is a need to execute additional commands.

**Special notes for your reviewer**:

**Release note**:

```release-note
The speaker and the controller containers are now based on a distroless image, reducing the attack surface
```
