### PR TITLE
Charts: don't log history in liveness probe

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -443,6 +443,9 @@ spec:
           {{- if .Values.prometheus.secureMetricsPort }}
           - --host=localhost
           {{- end }}
+        env:
+          - name: VTYSH_HISTFILE
+            value: /dev/null
         ports:
           - containerPort: {{ .Values.speaker.frr.metricsPort }}
             name: monitoring

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -105,6 +105,9 @@ spec:
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473
+          env:
+            - name: VTYSH_HISTFILE
+              value: /dev/null
           ports:
             - containerPort: 7473
               name: monitoring

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2054,6 +2054,9 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
+        env:
+        - name: VTYSH_HISTFILE
+          value: /dev/null
         image: quay.io/frrouting/frr:9.0.2
         name: frr-metrics
         ports:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1877,6 +1877,9 @@ spec:
         - --metrics-port=7473
         command:
         - /etc/frr_metrics/frr-metrics
+        env:
+        - name: VTYSH_HISTFILE
+          value: /dev/null
         image: quay.io/frrouting/frr:9.0.2
         name: frr-metrics
         ports:


### PR DESCRIPTION
frr-metrics liveness probe runs a show daemons command repeatedly and append that at the end of a file. When the file is longer than 1k lines the history gets truncated which involves a few system calls like renames. When the system is under stress this rename call can take a few seconds, exceeding the timeout of the liveness probe.

When this happens repeatedly frr process gets restarted.

This was noticed as part of the investigation in
https://issues.redhat.com/browse/OCPBUGS-34761?focusedId=24850879&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24850879

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

fix occasional frr crash

**Special notes for your reviewer**:

replaces https://github.com/metallb/metallb-operator/pull/473
would love to have that in OCP 4.14

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
