### PR TITLE
update the location of the metrics exporter

### DIFF
--- a/design/crd-status.md
+++ b/design/crd-status.md
@@ -197,7 +197,7 @@ If BFD is not configured for a given `BGPPeer`, the exposed bfdStatus will be "N
 **A note about the implementation:** without entering to much into details,
 we will need to implement some sort of polling of the FRR status. Given the
 fact that this CR has no relation with the existing ones, a valid approach is
-to follow what was done for the [metrics exporter](https://github.com/metallb/metallb/blob/main/frr-metrics/exporter.go)
+to follow what was done for the [metrics exporter](https://github.com/metallb/metallb/blob/main/frr-tools/metrics/exporter.go)
 and have a different component (or even the exporter itself) polling FRR and filling
 the session status. The polling interval must be configurable and large enough to
 avoid impacts both on FRR and on the API.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind documentation

**What this PR does / why we need it**:

PR #1732 moved the location of the metrics exporter. This PR adjusts sources to changes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
update the location of the metrics exporter
```
