### PR TITLE
Fix shared ip service

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"go.universe.tf/metallb/internal/allocator"
+	"go.universe.tf/metallb/internal/allocator/k8salloc"
 	"go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/k8s"
 	"go.universe.tf/metallb/internal/k8s/controllers"
@@ -76,6 +77,9 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	// a reason.
 	svc := svcRo.DeepCopy()
 	syncStateRes := controllers.SyncStateSuccess
+	if k8salloc.SharingKey(svc) != "" {
+		syncStateRes = controllers.SyncStateReprocessAll
+	}
 
 	prevIPs := c.ips.IPs(name)
 


### PR DESCRIPTION
Draft for fixing #2403

note that this draft is mostly for showing the e2etest that reproduces this bug,
the fix itself is not good as this causes infinite reconcile update loops for shared ip services.