### PR TITLE
bug: fix ip pool total count caculate failed

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -460,7 +460,8 @@ func poolCount(p *config.Pool) (int64, int64, int64) {
 				if ipConfusesBuggyFirmwares(firstIP) {
 					sz--
 				}
-				if ipConfusesBuggyFirmwares(lastIP) {
+
+				if !lastIP.Equal(firstIP) && ipConfusesBuggyFirmwares(lastIP) {
 					sz--
 				}
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
BUG
> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

when ippool address contains a x.x.x.0/32  or  x.x.x.255/32 IP  , the metric of metallb_allocator_addresses_total will be -1

because the firstIP is equal lastIP, it should only count once, but actually twice.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
