### PR TITLE
Care only about NetworkUnavailable condition.

### DIFF
--- a/internal/k8s/controllers/node_controller.go
+++ b/internal/k8s/controllers/node_controller.go
@@ -18,10 +18,10 @@ package controllers
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	k8snodes "go.universe.tf/metallb/internal/k8s/nodes"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -82,9 +82,9 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				level.Error(r.Logger).Log("controller", "NodeReconciler", "error", "old object is not node", "name", oldNodeObj.GetName())
 				return true
 			}
-			// If there is no changes in node labels, ignore event.
+			// If there is no changes in node labels or conditions' network availability status, ignore event.
 			if labels.Equals(labels.Set(oldNodeObj.Labels), labels.Set(newNodeObj.Labels)) &&
-				reflect.DeepEqual(oldNodeObj.Status.Conditions, newNodeObj.Status.Conditions) {
+				k8snodes.IsNetworkUnavailable(oldNodeObj) == k8snodes.IsNetworkUnavailable(newNodeObj) {
 				return false
 			}
 			return true


### PR DESCRIPTION
There are cases wherein a node's condition like "lastHeartbeatTime" can get updated every few seconds waking up node reconciler. This is just a no-op. But the logs get inundated with "start reconcile" and "end reconcile" messages. This gets worse in large clusters.

Fixed #2451

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Limit processing the node events when label changes or when only the NetworkUnavailable condition changes, as opposed to processing when every condition (including heartbeats!) changes.
```
