### PR TITLE
fix(chart,prometheusrules): alert not matching labels

### DIFF
--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
           }} has a stale config for > 1 minute'`}}
-      expr: metallb_k8s_client_config_stale_bool{job="{{ include "metallb.name" . }}"} == 1
+      expr: metallb_k8s_client_config_stale_bool{job=~"{{ template "metallb.fullname" . }}.*"} == 1
       for: 1m
       {{- with .Values.prometheus.prometheusRule.staleConfig.labels }}
       labels:
@@ -33,7 +33,7 @@ spec:
       annotations:
         message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
           }} has not loaded for > 1 minute'`}}
-      expr: metallb_k8s_client_config_loaded_bool{job="{{ include "metallb.name" . }}"} == 0
+      expr: metallb_k8s_client_config_loaded_bool{job=~"{{ template "metallb.fullname" . }}.*"} == 0
       for: 1m
       {{- with .Values.prometheus.prometheusRule.configNotLoaded.labels }}
       labels:
@@ -71,7 +71,7 @@ spec:
       annotations:
         message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
           }} has BGP session {{ $labels.peer }} down for > 1 minute'`}}
-      expr: metallb_bgp_session_up{job="{{ include "metallb.name" . }}"} == 0
+      expr: metallb_bgp_session_up{job=~"{{ template "metallb.fullname" . }}.*"} == 0
       for: 1m
       {{- with .Values.prometheus.prometheusRule.bgpSessionDown.labels }}
       labels:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
PrometheusRule labels doesn't match default configuration. This results in no active alerts by default. 

Example previously:
```
expr: metallb_bgp_session_up{job="metallb"} == 0
```

Example now:
```
expr: metallb_bgp_session_up{job=~"metallb.*"} == 0
```

Metric inside of prometheus (not matching in the previous example):
```
metallb_bgp_session_up{job="metallb-speaker-monitor-service"}
```

**Special notes for your reviewer**:
Used values for testing:
```
prometheus:
  serviceAccount: metallb
  namespace: metallb
  serviceMonitor:
    enabled: true
  prometheusRule:
    enabled: true
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
fix(chart,prometheusrules): alert not matching labels for e.g. speakers
```
