### PR TITLE
Prevent session flapping when BFD is enabled and services are added / removed

### DIFF
--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -32,18 +32,24 @@ func NeighborInfo(neighborName string, exec executor.Executor) (*Neighbor, error
 	return neighbor, nil
 }
 
+type NeighborsMap map[string]*Neighbor
+
 // NeighborsInfo returns informations for the all the neighbors in the given
 // executor.
-func NeighborsInfo(exec executor.Executor) ([]*Neighbor, error) {
-	res, err := exec.Exec("vtysh", "-c", "show bgp neighbor json")
+func NeighborsInfo(exec executor.Executor) (NeighborsMap, error) {
+	jsonRes, err := exec.Exec("vtysh", "-c", "show bgp neighbor json")
 	if err != nil {
 		return nil, errors.Join(err, errors.New("Failed to query neighbours"))
 	}
-	neighbors, err := ParseNeighbours(res)
+	neighbors, err := ParseNeighbours(jsonRes)
 	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("Failed to parse neighbours %s", res))
+		return nil, errors.Join(err, fmt.Errorf("Failed to parse neighbours %s", jsonRes))
 	}
-	return neighbors, nil
+	res := map[string]*Neighbor{}
+	for _, n := range neighbors {
+		res[n.IP.String()] = n
+	}
+	return res, nil
 }
 
 // Routes returns informations about routes in the given executor

--- a/e2etest/pkg/frr/parse.go
+++ b/e2etest/pkg/frr/parse.go
@@ -27,6 +27,7 @@ type Neighbor struct {
 	ConfiguredKeepAliveTime int
 	ConfiguredConnectTime   int
 	AddressFamilies         []string
+	ConnectionsDropped      int
 }
 
 type Route struct {
@@ -55,6 +56,7 @@ type FRRNeighbor struct {
 	AddressFamilyInfo            map[string]struct {
 		SentPrefixCounter int `json:"sentPrefixCounter"`
 	} `json:"addressFamilyInfo"`
+	ConnectionsDropped int `json:"connectionsDropped"`
 }
 
 type GracefulRestartInfo struct {
@@ -177,6 +179,7 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			MsgStats:                n.MsgStats,
 			ConfiguredKeepAliveTime: n.ConfiguredKeepAliveTimeMSecs,
 			ConfiguredHoldTime:      n.ConfiguredHoldTimeMSecs,
+			ConnectionsDropped:      n.ConnectionsDropped,
 		}, nil
 	}
 	return nil, errors.New("no peers were returned")
@@ -206,7 +209,6 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 		for family, s := range n.AddressFamilyInfo {
 			prefixSent += s.SentPrefixCounter
 			addressFamilies = append(addressFamilies, family)
-
 		}
 		res = append(res, &Neighbor{
 			IP:                      ip,
@@ -222,6 +224,7 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			ConfiguredHoldTime:      n.ConfiguredHoldTimeMSecs,
 			ConfiguredConnectTime:   n.ConnectRetryTimer,
 			AddressFamilies:         addressFamilies,
+			ConnectionsDropped:      n.ConnectionsDropped,
 		})
 	}
 	return res, nil

--- a/e2etest/pkg/frr/parse_test.go
+++ b/e2etest/pkg/frr/parse_test.go
@@ -88,8 +88,7 @@ func TestNeighbour(t *testing.T) {
           "sentPrefixCounter":%d
         }
       },
-      "connectionsEstablished":0,
-      "connectionsDropped":0,
+      "connectionsDropped":2,
       "lastResetTimerMsecs":253000,
       "lastResetDueTo":"Waiting for peer OPEN",
       "lastResetCode":32,
@@ -185,6 +184,9 @@ func TestNeighbour(t *testing.T) {
 			}
 			if n.ConfiguredKeepAliveTime != 30000 {
 				t.Fatal("unexpected configured keepalivetime time", n.ConfiguredKeepAliveTime)
+			}
+			if n.ConnectionsDropped != 2 {
+				t.Fatal("unexpected connections dropped", n.ConnectionsDropped)
 			}
 		})
 	}

--- a/e2etest/pkg/frr/validation.go
+++ b/e2etest/pkg/frr/validation.go
@@ -15,7 +15,7 @@ import (
 // frr instance. We only care about established connections, as the
 // frr instance may be configured with more nodes than are currently
 // paired.
-func NeighborsMatchNodes(nodes []v1.Node, neighbors []*Neighbor, ipFamily ipfamily.Family, vrfName string) error {
+func NeighborsMatchNodes(nodes []v1.Node, neighbors NeighborsMap, ipFamily ipfamily.Family, vrfName string) error {
 	nodesIPs := map[string]struct{}{}
 
 	ips, err := k8s.NodeIPsForFamily(nodes, ipFamily, vrfName)

--- a/internal/bgp/frr/templates/neighborsession.tmpl
+++ b/internal/bgp/frr/templates/neighborsession.tmpl
@@ -20,6 +20,7 @@
   neighbor {{.neighbor.Addr}} graceful-restart
   {{- end }}
   {{- if ne .neighbor.BFDProfile "" }}
+  neighbor {{.neighbor.Addr}} bfd
   neighbor {{.neighbor.Addr}} bfd profile {{.neighbor.BFDProfile}}
   {{- end }}
   {{- if  mustDisableConnectedCheck .neighbor.IPFamily .routerASN .neighbor.ASN .neighbor.EBGPMultiHop }}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -29,6 +29,7 @@ router bgp 100
   neighbor 10.2.2.254 timers 2 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
+  neighbor 10.2.2.254 bfd
   neighbor 10.2.2.254 bfd profile foo
 
   address-family ipv4 unicast


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

  The generated configuration file has the format

  `neighbor xxxx bfd profile zzz`

  which works, but causes session flapping whenever the configuration is
  reloaded, as the converted configuration contains two entries:

```
  neighbor xxxx bfd
  neighbor xxxx bfd profile zzz
```

  Reloading the configuration causes the first line to be removed:
```
  Lines To Delete
  ===============
  ip forwarding
  ipv6 forwarding
  router bgp 64520
   no neighbor 10.74.239.52 bfd
```
  which causes the session to flap. Here we generate also the

  `neighbor xxxx bfd`

  entry to avoid flaps.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix session flapping when adding / removing services and BFD is enabled.
```
