### PR TITLE
Service L2 status: remove the duplicate validation

### DIFF
--- a/api/v1beta1/servicel2status_types.go
+++ b/api/v1beta1/servicel2status_types.go
@@ -27,7 +27,6 @@ type MetalLBServiceL2Status struct {
 	// Node indicates the node that receives the directed traffic
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	Node string `json:"node,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// ServiceName indicates the service this status represents
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	ServiceName string `json:"serviceName,omitempty"`

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -1191,8 +1191,6 @@ spec:
                   x-kubernetes-validations:
                     - message: Value is immutable
                       rule: self == oldSelf
-                    - message: Value is immutable
-                      rule: self == oldSelf
                 serviceNamespace:
                   description: ServiceNamespace indicates the namespace of the service
                   type: string

--- a/config/crd/bases/metallb.io_servicel2statuses.yaml
+++ b/config/crd/bases/metallb.io_servicel2statuses.yaml
@@ -76,8 +76,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -1746,8 +1746,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -1746,8 +1746,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -1238,8 +1238,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1238,8 +1238,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -1238,8 +1238,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1238,8 +1238,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-                - message: Value is immutable
-                  rule: self == oldSelf
               serviceNamespace:
                 description: ServiceNamespace indicates the namespace of the service
                 type: string


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

We are adding the same check twice, making flux complain.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix the double immutable field validation in the ServiceL2Status CRD, which may make the validation of the CRD to fail.
```
