### PR TITLE
Helm chart: Avoid speaker resources creation when speaker is disabled

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -84,7 +84,7 @@ spec:
         - name: METALLB_DEPLOYMENT
           value: {{ template "metallb.fullname" . }}-controller
         {{- end }}
-        {{- if .Values.speaker.frr.enabled }}
+        {{- if and .Values.speaker.enabled .Values.speaker.frr.enabled }}
         - name: METALLB_BGP_TYPE
           value: frr
         {{- end }}

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -36,6 +36,7 @@ spec:
     relabelings:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -73,6 +74,7 @@ spec:
 {{- if .Values.prometheus.podMonitor.relabelings }}
     relabelings:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
+{{- end }}
 {{- end }}
 ---
 {{- if .Values.prometheus.rbacPrometheus }}

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -41,6 +41,7 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 {{- end }}
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -109,6 +110,7 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["communities"]
   verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -117,7 +119,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
-{{- if .Values.speaker.memberlist.enabled }}
+{{- if and .Values.speaker.enabled .Values.speaker.memberlist.enabled }}
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "list", "watch"]
@@ -166,6 +168,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "metallb.fullname" . }}:controller
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -195,6 +198,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "metallb.speaker.serviceAccountName" . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/metallb/templates/service-accounts.yaml
+++ b/charts/metallb/templates/service-accounts.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- if .Values.speaker.serviceAccount.create }}
+{{- if and .Values.speaker.enabled .Values.speaker.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if .Values.speaker.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -89,6 +90,7 @@ spec:
 {{- end }}
   sessionAffinity: None
   type: ClusterIP
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -99,7 +99,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
-    app.kubernetes.io/component: speaker
     {{- if .Values.prometheus.serviceMonitor.controller.additionalLabels }}
 {{ toYaml .Values.prometheus.serviceMonitor.controller.additionalLabels | indent 4 }}
     {{- end }}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Some speaker related resources and configuration are created even if `speaker.enabled` value is set to `false`. This PR aims to avoid this resources creation and extra configuration when `speaker.enabled` value is set to `false`.

**Special notes for your reviewer**:
If you have any doubt feel free to ask :smile: 

**Release note**:

```release-note
Helm chart: Avoid speaker resources creation when speaker is disabled
```
