### PR TITLE
Add option to keep watching services without a loadbalancer class

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -66,6 +66,7 @@ Kubernetes: `>= 1.19.0-0`
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | loadBalancerClass | string | `""` |  |
+| watchLoadBalancerWithoutClass | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | prometheus.controllerMetricsTLSSecret | string | `""` |  |
 | prometheus.metricsPort | int | `7472` |  |

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.loadBalancerClass }}
         - --lb-class={{ .Values.loadBalancerClass }}
         {{- end }}
+        {{- if .Values.watchLoadBalancerWithoutClass }}
+        - --watch-lb-without-class
+        {{- end }}
         {{- if .Values.controller.webhookMode }}
         - --webhook-mode={{ .Values.controller.webhookMode }}
         {{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -246,6 +246,9 @@ spec:
         {{- if .Values.loadBalancerClass }}
         - --lb-class={{ .Values.loadBalancerClass }}
         {{- end }}
+        {{- if .Values.watchLoadBalancerWithoutClass }}
+        - --watch-lb-without-class
+        {{- end }}
         {{- if .Values.speaker.wanConfig }}
         - --ml-wan-config
         {{- end }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -162,6 +162,9 @@
     "loadBalancerClass": {
       "type":"string"
     },
+    "watchLoadBalancerWithoutClass": {
+      "type": "boolean"
+    },
     "rbac": {
       "description": "RBAC configuration",
       "type": "object",

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -6,6 +6,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 loadBalancerClass: ""
+watchLoadBalancerWithoutClass: false
 
 # To configure MetalLB, you must specify ONE of the following two
 # options.

--- a/controller/main.go
+++ b/controller/main.go
@@ -138,21 +138,22 @@ func (c *controller) SetPools(l log.Logger, pools *config.Pools) controllers.Syn
 
 func main() {
 	var (
-		port                = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
-		namespace           = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config / memberlist secret namespace")
-		mlSecret            = flag.String("ml-secret-name", os.Getenv("METALLB_ML_SECRET_NAME"), "name of the memberlist secret to create")
-		deployName          = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")
-		logLevel            = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
-		enablePprof         = flag.Bool("enable-pprof", false, "Enable pprof profiling")
-		disableCertRotation = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")
-		certDir             = flag.String("cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory where certs are stored")
-		certServiceName     = flag.String("cert-service-name", "metallb-webhook-service", "The service name used to generate the TLS cert's hostname")
-		loadBalancerClass   = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
-		webhookMode         = flag.String("webhook-mode", "enabled", "webhook mode: can be enabled, disabled or only webhook if we want the controller to act as webhook endpoint only")
-		webhookSecretName   = flag.String("webhook-secret", "metallb-webhook-cert", "webhook secret: the name of webhook secret, default is metallb-webhook-cert")
-		webhookHTTP2        = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
-		tlsMinVersion       = flag.String("tls-min-version", "", "Minimum TLS version supported for the webhook server, Possible values: "+strings.Join(cliflag.TLSPossibleVersions(), ", "))
-		tlsCipherSuites     = flag.String("tls-cipher-suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"+
+		port                          = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
+		namespace                     = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config / memberlist secret namespace")
+		mlSecret                      = flag.String("ml-secret-name", os.Getenv("METALLB_ML_SECRET_NAME"), "name of the memberlist secret to create")
+		deployName                    = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")
+		logLevel                      = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
+		enablePprof                   = flag.Bool("enable-pprof", false, "Enable pprof profiling")
+		disableCertRotation           = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")
+		certDir                       = flag.String("cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory where certs are stored")
+		certServiceName               = flag.String("cert-service-name", "metallb-webhook-service", "The service name used to generate the TLS cert's hostname")
+		loadBalancerClass             = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
+		watchLoadBalancerWithoutClass = flag.Bool("watch-lb-without-class", false, "when load balancer class is enabled, metallb will also handle services that do not specify any spec.loadBalancerClass")
+		webhookMode                   = flag.String("webhook-mode", "enabled", "webhook mode: can be enabled, disabled or only webhook if we want the controller to act as webhook endpoint only")
+		webhookSecretName             = flag.String("webhook-secret", "metallb-webhook-cert", "webhook secret: the name of webhook secret, default is metallb-webhook-cert")
+		webhookHTTP2                  = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
+		tlsMinVersion                 = flag.String("tls-min-version", "", "Minimum TLS version supported for the webhook server, Possible values: "+strings.Join(cliflag.TLSPossibleVersions(), ", "))
+		tlsCipherSuites               = flag.String("tls-cipher-suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"+
 			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"+
 			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384", "Comma-separated list of cipher suites for the webhook server")
 	)
@@ -214,16 +215,17 @@ func main() {
 			ServiceChanged: c.SetBalancer,
 			PoolChanged:    c.SetPools,
 		},
-		ValidateConfig:      validation,
-		EnableWebhook:       true,
-		WebhookWithHTTP2:    *webhookHTTP2,
-		WebHookMinVersion:   webhookTLSMinVersion,
-		WebHookCipherSuites: webhookTLSCipherSuites,
-		DisableCertRotation: *disableCertRotation,
-		WebhookSecretName:   *webhookSecretName,
-		CertDir:             *certDir,
-		CertServiceName:     *certServiceName,
-		LoadBalancerClass:   *loadBalancerClass,
+		ValidateConfig:                validation,
+		EnableWebhook:                 true,
+		WebhookWithHTTP2:              *webhookHTTP2,
+		WebHookMinVersion:             webhookTLSMinVersion,
+		WebHookCipherSuites:           webhookTLSCipherSuites,
+		DisableCertRotation:           *disableCertRotation,
+		WebhookSecretName:             *webhookSecretName,
+		CertDir:                       *certDir,
+		CertServiceName:               *certServiceName,
+		LoadBalancerClass:             *loadBalancerClass,
+		WatchLoadBalancerWithoutClass: *watchLoadBalancerWithoutClass,
 	}
 	switch *webhookMode {
 	case "enabled":

--- a/internal/k8s/controllers/service_controller_reload.go
+++ b/internal/k8s/controllers/service_controller_reload.go
@@ -78,7 +78,7 @@ func (r *ServiceReconciler) reprocessAll(ctx context.Context, req ctrl.Request) 
 	retry := false
 	for _, service := range sortedServices {
 		service := service // so we can use &service
-		if filterByLoadBalancerClass(&service, r.LoadBalancerClass) {
+		if filterByLoadBalancerClass(&service, r.LoadBalancerClass, r.WatchLoadBalancerWithoutClass) {
 			level.Debug(r.Logger).Log("controller", "ServiceReconciler", "filtered service", req.NamespacedName)
 			continue
 		}

--- a/internal/k8s/controllers/service_controller_test.go
+++ b/internal/k8s/controllers/service_controller_test.go
@@ -266,40 +266,53 @@ func TestServiceController(t *testing.T) {
 
 func TestLBClass(t *testing.T) {
 	tests := []struct {
-		desc           string
-		serviceLBClass *string
-		metallLBClass  string
-		shouldFilter   bool
+		desc            string
+		serviceLBClass  *string
+		metallLBClass   string
+		watchEmptyClass bool
+		shouldFilter    bool
 	}{
 		{
-			desc:           "Empty serviceclass, metallb default",
-			serviceLBClass: nil,
-			metallLBClass:  "",
-			shouldFilter:   false,
+			desc:            "Empty serviceclass, metallb default, watch empty class ignored",
+			serviceLBClass:  nil,
+			metallLBClass:   "",
+			watchEmptyClass: false,
+			shouldFilter:    false,
 		},
 		{
-			desc:           "Empty serviceclass, metallb specific",
-			serviceLBClass: nil,
-			metallLBClass:  "foo",
-			shouldFilter:   true,
+			desc:            "Empty serviceclass, metallb specific, watch empty class false",
+			serviceLBClass:  nil,
+			metallLBClass:   "foo",
+			watchEmptyClass: false,
+			shouldFilter:    true,
 		},
 		{
-			desc:           "Set serviceclass, metallb default",
-			serviceLBClass: ptr.To[string]("foo"),
-			metallLBClass:  "",
-			shouldFilter:   true,
+			desc:            "Empty serviceclass, metallb specific, watch empty class true",
+			serviceLBClass:  nil,
+			metallLBClass:   "foo",
+			watchEmptyClass: true,
+			shouldFilter:    false,
 		},
 		{
-			desc:           "Set serviceclass, metallb different",
-			serviceLBClass: ptr.To[string]("foo"),
-			metallLBClass:  "bar",
-			shouldFilter:   true,
+			desc:            "Set serviceclass, metallb default",
+			serviceLBClass:  ptr.To[string]("foo"),
+			metallLBClass:   "",
+			watchEmptyClass: false,
+			shouldFilter:    true,
 		},
 		{
-			desc:           "Set serviceclass, metallb same",
-			serviceLBClass: ptr.To[string]("foo"),
-			metallLBClass:  "foo",
-			shouldFilter:   false,
+			desc:            "Set serviceclass, metallb different",
+			serviceLBClass:  ptr.To[string]("foo"),
+			metallLBClass:   "bar",
+			watchEmptyClass: false,
+			shouldFilter:    true,
+		},
+		{
+			desc:            "Set serviceclass, metallb same",
+			serviceLBClass:  ptr.To[string]("foo"),
+			metallLBClass:   "foo",
+			watchEmptyClass: false,
+			shouldFilter:    false,
 		},
 	}
 	for _, test := range tests {
@@ -308,7 +321,7 @@ func TestLBClass(t *testing.T) {
 				LoadBalancerClass: test.serviceLBClass,
 			},
 		}
-		filters := filterByLoadBalancerClass(svc, test.metallLBClass)
+		filters := filterByLoadBalancerClass(svc, test.metallLBClass, test.watchEmptyClass)
 		if filters != test.shouldFilter {
 			t.Errorf("test %s failed: expected filter: %v, got: %v",
 				test.desc, test.shouldFilter, filters)

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -98,27 +98,28 @@ type Client struct {
 // Config specifies the configuration of the Kubernetes
 // client/watcher.
 type Config struct {
-	ProcessName         string
-	NodeName            string
-	PodName             string
-	MetricsHost         string
-	MetricsPort         int
-	EnablePprof         bool
-	ReadEndpoints       bool
-	Logger              log.Logger
-	Namespace           string
-	ValidateConfig      config.Validate
-	EnableWebhook       bool
-	WebHookMinVersion   uint16
-	WebHookCipherSuites []uint16
-	DisableCertRotation bool
-	WebhookSecretName   string
-	CertDir             string
-	CertServiceName     string
-	LoadBalancerClass   string
-	WebhookWithHTTP2    bool
-	WithFRRK8s          bool
-	FRRK8sNamespace     string
+	ProcessName                   string
+	NodeName                      string
+	PodName                       string
+	MetricsHost                   string
+	MetricsPort                   int
+	EnablePprof                   bool
+	ReadEndpoints                 bool
+	Logger                        log.Logger
+	Namespace                     string
+	ValidateConfig                config.Validate
+	EnableWebhook                 bool
+	WebHookMinVersion             uint16
+	WebHookCipherSuites           []uint16
+	DisableCertRotation           bool
+	WebhookSecretName             string
+	CertDir                       string
+	CertServiceName               string
+	LoadBalancerClass             string
+	WatchLoadBalancerWithoutClass bool
+	WebhookWithHTTP2              bool
+	WithFRRK8s                    bool
+	FRRK8sNamespace               string
 	Listener
 	Layer2StatusChan    <-chan event.GenericEvent
 	Layer2StatusFetcher controllers.StatusFetcher
@@ -264,13 +265,14 @@ func New(cfg *Config) (*Client, error) {
 
 	if cfg.ServiceChanged != nil {
 		if err = (&controllers.ServiceReconciler{
-			Client:            mgr.GetClient(),
-			Logger:            cfg.Logger,
-			Scheme:            mgr.GetScheme(),
-			Handler:           cfg.ServiceHandler,
-			Endpoints:         cfg.ReadEndpoints,
-			Reload:            reloadChan,
-			LoadBalancerClass: cfg.LoadBalancerClass,
+			Client:                        mgr.GetClient(),
+			Logger:                        cfg.Logger,
+			Scheme:                        mgr.GetScheme(),
+			Handler:                       cfg.ServiceHandler,
+			Endpoints:                     cfg.ReadEndpoints,
+			Reload:                        reloadChan,
+			LoadBalancerClass:             cfg.LoadBalancerClass,
+			WatchLoadBalancerWithoutClass: cfg.WatchLoadBalancerWithoutClass,
 		}).SetupWithManager(mgr); err != nil {
 			level.Error(c.logger).Log("error", err, "unable to create controller", "service")
 			return nil, errors.Join(err, errors.New("failed to create service reconciler"))

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -72,21 +72,22 @@ func main() {
 	prometheus.MustRegister(announcing)
 
 	var (
-		namespace         = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config file and speakers namespace")
-		host              = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
-		mlBindAddr        = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
-		mlBindPort        = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
-		mlLabels          = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
-		mlSecretKeyPath   = flag.String("ml-secret-key-path", os.Getenv("METALLB_ML_SECRET_KEY_PATH"), "Path to where the MemberList's secret key is mounted")
-		mlWANConfig       = flag.Bool("ml-wan-config", false, "WAN network type for MemberList default config, bool")
-		myNode            = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
-		myPod             = flag.String("pod-name", os.Getenv("METALLB_POD_NAME"), "name of this MetalLB speaker pod")
-		port              = flag.Int("port", 7472, "HTTP listening port")
-		logLevel          = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
-		enablePprof       = flag.Bool("enable-pprof", false, "Enable pprof profiling")
-		loadBalancerClass = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
-		ignoreLBExclude   = flag.Bool("ignore-exclude-lb", false, "ignore the exclude-from-external-load-balancers label")
-		frrK8sNamespace   = flag.String("frrk8s-namespace", os.Getenv("FRRK8S_NAMESPACE"), "the namespace frr-k8s is being deployed on")
+		namespace                     = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config file and speakers namespace")
+		host                          = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
+		mlBindAddr                    = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
+		mlBindPort                    = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
+		mlLabels                      = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
+		mlSecretKeyPath               = flag.String("ml-secret-key-path", os.Getenv("METALLB_ML_SECRET_KEY_PATH"), "Path to where the MemberList's secret key is mounted")
+		mlWANConfig                   = flag.Bool("ml-wan-config", false, "WAN network type for MemberList default config, bool")
+		myNode                        = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
+		myPod                         = flag.String("pod-name", os.Getenv("METALLB_POD_NAME"), "name of this MetalLB speaker pod")
+		port                          = flag.Int("port", 7472, "HTTP listening port")
+		logLevel                      = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
+		enablePprof                   = flag.Bool("enable-pprof", false, "Enable pprof profiling")
+		loadBalancerClass             = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
+		watchLoadBalancerWithoutClass = flag.Bool("watch-lb-without-class", false, "when load balancer class is enabled, metallb will also handle services that do not specify any spec.loadBalancerClass")
+		ignoreLBExclude               = flag.Bool("ignore-exclude-lb", false, "ignore the exclude-from-external-load-balancers label")
+		frrK8sNamespace               = flag.String("frrk8s-namespace", os.Getenv("FRRK8S_NAMESPACE"), "the namespace frr-k8s is being deployed on")
 	)
 	flag.Parse()
 
@@ -205,10 +206,11 @@ func main() {
 			ConfigChanged:  ctrl.SetConfig,
 			NodeChanged:    ctrl.SetNode,
 		},
-		ValidateConfig:    validateConfig,
-		LoadBalancerClass: *loadBalancerClass,
-		WithFRRK8s:        listenFRRK8s,
-		FRRK8sNamespace:   *frrK8sNamespace,
+		ValidateConfig:                validateConfig,
+		LoadBalancerClass:             *loadBalancerClass,
+		WatchLoadBalancerWithoutClass: *watchLoadBalancerWithoutClass,
+		WithFRRK8s:                    listenFRRK8s,
+		FRRK8sNamespace:               *frrK8sNamespace,
 
 		Layer2StatusChan:    statusNotifyChan,
 		Layer2StatusFetcher: ctrl.layer2StatusFetchFunc,


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

PR https://github.com/metallb/metallb/pull/1417 introduced support for LoadBalancer Class. However, with the current design, metallb can either look at every LoadBalancer service in the cluster (irrespectively of their LoadBalancer Class) or only the ones that specify the right LoadBalancer class. There is no way to have metallb "ignore" services that specify a given LoadBalancer Class that is not the one managed by metallb while also remaining the "default" load balancer implementation for services not specifying a LoadBalancer class at all.

This feature is very useful in big clusters with thousands of services where only a couple might need to be dealt with differently through a different load balancer implementation. Today there is no way to achieve this without refactoring every other service to also specify the load balancer class.

This PR introduces an extra flag `watch-lb-without-class` (being meaningful only if the `lb-class` flag is also passed and defaulting to `false` for backwards compatibility) which instructs metallb running in `lb-class` mode to still reconcile and manage also services which do not specify a load balancer class at all.

This is the same design that projects like ingress-nginx use for the same purpose (with ingress classes): https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.11.1/charts/ingress-nginx/values.yaml#L81

**Special notes for your reviewer**:

This PR should be fully backwards compatible such that users that do not wish to use this feature do not need to change anything at all in their current configuration and will observe the same behavior as they used to prior to this change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
A new flag `watch-lb-without-class` has been added. When used in conjunction with `lb-class` it instructs metallb to reconcile and manage also load balancer services which do not specify a load balancer class.
```
