### PR TITLE
add readOnlyRootFilesystem securityContext to containers

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -369,6 +369,7 @@ spec:
       {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:
+          readOnlyRootFilesystem: true
           capabilities:
             add:
             - NET_ADMIN
@@ -431,6 +432,8 @@ spec:
           periodSeconds: {{ .Values.speaker.startupProbe.periodSeconds }}
         {{- end }}
       - name: reloader
+        securityContext:
+          readOnlyRootFilesystem: true
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}
         imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
@@ -448,6 +451,8 @@ spec:
           {{- toYaml . | nindent 12 }}
         {{- end }}
       - name: frr-metrics
+        securityContext:
+          readOnlyRootFilesystem: true
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         command: ["/etc/frr_metrics/frr-metrics"]
         args:

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: 'true'
+        prometheus.io/scrape: "true"
       labels:
         app: metallb
         component: speaker
@@ -39,20 +39,26 @@ spec:
         # Copies the reloader to the shared volume between the speaker and reloader.
         - name: cp-reloader
           image: quay.io/metallb/speaker:main
-          command: ["/cp-tool","/frr-reloader.sh","/etc/frr_reloader/frr-reloader.sh"]
+          command:
+            [
+              "/cp-tool",
+              "/frr-reloader.sh",
+              "/etc/frr_reloader/frr-reloader.sh",
+            ]
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
         # Copies the metrics exporter
         - name: cp-metrics
           image: quay.io/metallb/speaker:main
-          command: ["/cp-tool","/frr-metrics","/etc/frr_metrics/frr-metrics"]
+          command: ["/cp-tool", "/frr-metrics", "/etc/frr_metrics/frr-metrics"]
           volumeMounts:
             - name: metrics
               mountPath: /etc/frr_metrics
       containers:
         - name: frr
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
           image: quay.io/frrouting/frr:9.1.0
@@ -93,6 +99,8 @@ spec:
         - name: reloader
           image: quay.io/frrouting/frr:9.1.0
           command: ["/etc/frr_reloader/frr-reloader.sh"]
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: frr-sockets
               mountPath: /var/run/frr
@@ -111,6 +119,8 @@ spec:
           ports:
             - containerPort: 7473
               name: monitoring
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: frr-sockets
               mountPath: /var/run/frr


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:


/kind feature


**What this PR does / why we need it**:

This PR adds the securityContext.readOnlyRootFilesystem for the speaker Pod. 

Setting the readOnlyRootFilesystem flag to true reduces the attack surface of your containers since an attacker cannot manipulate the executables of your container, nor make any other changes to your root file system.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Sets readOnlyRootFilesystem for the Speaker Pods
```
