### PR TITLE
Service annotations: change annotation prefix to metallb.io

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -382,7 +382,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			testservice.TestServicePort,
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
-				svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
+				svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
 				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort)
 			})
 		defer testservice.Delete(cs, svc)
@@ -390,7 +390,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			testservice.TestServicePort+1,
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
-				svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
+				svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
 				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort + 1)
 			})
 		defer testservice.Delete(cs, svc1)
@@ -810,7 +810,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 				ginkgo.By(fmt.Sprintf("configure service number %d", i+1))
 				svc, _ := testservice.CreateWithBackend(cs, testNamespace, fmt.Sprintf("svc%d", i+1), testservice.TrafficPolicyCluster, func(svc *corev1.Service) {
-					svc.Annotations = map[string]string{"metallb.universe.tf/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
+					svc.Annotations = map[string]string{"metallb.io/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
 				})
 				defer testservice.Delete(cs, svc)
 

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -483,7 +483,7 @@ var _ = ginkgo.Describe("L2", func() {
 		svc1, err := jig1.CreateLoadBalancerService(context.TODO(), func(svc *corev1.Service) {
 			svc.Spec.Ports[0].TargetPort = intstr.FromInt(service.TestServicePort)
 			svc.Spec.Ports[0].Port = int32(service.TestServicePort)
-			svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
+			svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
 			svc.Spec.LoadBalancerIP = ip
 		})
 
@@ -493,7 +493,7 @@ var _ = ginkgo.Describe("L2", func() {
 		svc2, err := jig2.CreateLoadBalancerService(context.TODO(), func(svc *corev1.Service) {
 			svc.Spec.Ports[0].TargetPort = intstr.FromInt(service.TestServicePort + 1)
 			svc.Spec.Ports[0].Port = int32(service.TestServicePort + 1)
-			svc.Annotations = map[string]string{"metallb.universe.tf/allow-shared-ip": "foo"}
+			svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
 			svc.Spec.LoadBalancerIP = ip
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -825,7 +825,7 @@ var _ = ginkgo.Describe("L2", func() {
 			svc, _ := service.CreateWithBackend(cs, namespace, fmt.Sprintf("test-service%d", i+1),
 				func(svc *corev1.Service) {
 					svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
-					svc.Annotations = map[string]string{"metallb.universe.tf/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
+					svc.Annotations = map[string]string{"metallb.io/address-pool": fmt.Sprintf("test-addresspool%d", i+1)}
 				})
 
 			defer func() {
@@ -839,7 +839,7 @@ var _ = ginkgo.Describe("L2", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ginkgo.By("validate annotating a service with the pool used to provide its IP")
-			Expect(svc.Annotations["metallb.universe.tf/ip-allocated-from-pool"]).To(Equal(pool.Name))
+			Expect(svc.Annotations["metallb.io/ip-allocated-from-pool"]).To(Equal(pool.Name))
 
 			services = append(services, svc)
 			servicesIngressIP = append(servicesIngressIP, ingressIP)

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -42,14 +42,14 @@ func WithSpecificIPs(svc *corev1.Service, ips ...string) {
 		return
 	}
 	svc.Annotations = map[string]string{
-		"metallb.universe.tf/loadBalancerIPs": strings.Join(ips, ","),
+		"metallb.io/loadBalancerIPs": strings.Join(ips, ","),
 	}
 }
 
 func WithSpecificPool(poolName string) func(*corev1.Service) {
 	return func(svc *corev1.Service) {
 		svc.Annotations = map[string]string{
-			"metallb.universe.tf/address-pool": poolName,
+			"metallb.io/address-pool": poolName,
 		}
 	}
 }

--- a/e2etest/pkg/service/validate.go
+++ b/e2etest/pkg/service/validate.go
@@ -30,7 +30,7 @@ func ValidateL2(svc *corev1.Service) error {
 }
 
 func ValidateDesiredLB(svc *corev1.Service) {
-	desiredLbIPs := svc.Annotations["metallb.universe.tf/loadBalancerIPs"]
+	desiredLbIPs := svc.Annotations["metallb.io/loadBalancerIPs"]
 	if desiredLbIPs == "" {
 		return
 	}

--- a/internal/allocator/k8salloc/k8salloc.go
+++ b/internal/allocator/k8salloc/k8salloc.go
@@ -20,11 +20,6 @@ func Ports(svc *v1.Service) []allocator.Port {
 	return ret
 }
 
-// SharingKey extracts the sharing key for a service.
-func SharingKey(svc *v1.Service) string {
-	return svc.Annotations["metallb.universe.tf/allow-shared-ip"]
-}
-
 // BackendKey extracts the backend key for a service.
 func BackendKey(svc *v1.Service) string {
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {


### PR DESCRIPTION
This commit deprecates the old annotation prefix metallb.universe.tf in favor of metallb.io.

The introduced change is backwards compatible. E.g., if a services specifies a address-pool using the old prefix, it will still be accepted by the controller. However, if two address-pool annotations are specified the one with the newer prefix (metallb.io/address-pool) has precedence.

If a services uses the old prefix a deprecation warning is generated. The corresponding message will look similar to this one: "Warning: service object contains deprecated metallb annotation metallb.universe.tf/address-pool".

Fixed #2392

**Is this a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Migrate from "metallb.universe.tf" annotation prefix to "metallb.io"

**Special notes for your reviewer**:

This pull request currently lacks e2e tests to check the usage of deprecated annotations. Moreover, it lacks documentation Adjustments. Therefore, this PR must be considered WIP.

**Release note**:

```release-note
Action Required: The annotation prefix "metallb.universe.tf" is deprecated by now. Please use the new prefix "metallb.io". E.g.  "metallb.io/address-pool" instead of "metallb.universe.tf/address-pool". The old prefix is still supported. However, migrating to the new prefix is highly recommend. Future versions might remove this backwards compatibility. 
```
