### PR TITLE
Deprecate bgppeerv1beta1

### DIFF
--- a/api/v1beta1/bgppeer_types.go
+++ b/api/v1beta1/bgppeer_types.go
@@ -100,6 +100,7 @@ type BGPPeerStatus struct {
 //+kubebuilder:printcolumn:name="ASN",type=string,JSONPath=`.spec.peerASN`
 //+kubebuilder:printcolumn:name="BFD Profile",type=string,JSONPath=`.spec.bfdProfile`
 //+kubebuilder:printcolumn:name="Multi Hops",type=string,JSONPath=`.spec.ebgpMultiHop`
+//+kubebuilder:deprecatedversion:warning="v1beta1 is deprecated, please use v1beta2"
 
 // BGPPeer is the Schema for the peers API.
 type BGPPeer struct {

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -365,6 +365,8 @@ spec:
         - jsonPath: .spec.ebgpMultiHop
           name: Multi Hops
           type: string
+      deprecated: true
+      deprecationWarning: v1beta1 is deprecated, please use v1beta2
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -27,6 +27,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -385,6 +385,8 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -119,6 +119,10 @@ or more external BGP routers.
 In order to do so, an instance of `BGPPeer` must be created for each
 router we want metallb to connect to.
 
+{{% notice note %}}
+The BGPPeer v1beta1 version is deprecated. Please consider using v1beta2.
+{{% /notice %}}
+
 For a basic configuration featuring one BGP router and one IP address
 range, you need 4 pieces of information:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:



> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

v1beta2 is around for a while now, deprecating v1beta1 would allow us to (one day!) get rid of the conversion webhooks.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Deprecation of BGPPeer v1beta1 in favor of v1beta2.
```
