### PR TITLE
Add task to bump frrk8s to latest release

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1119,7 +1119,7 @@ def get_frr_k8s_latest():
     return latest
 
 @task
-def checkfrr(ctx):
+def checkfrrk8s(ctx):
     latest = get_frr_k8s_latest().stdout
 
     res = run("go get github.com/metallb/frr-k8s@{}".format(latest))


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

 /kind cleanup

**What this PR does / why we need it**:

This PR adds a task to bump FRR to the latest available release (following changes seen in #2467) . This takes care of bumping the:
- go release
- helm release in chart.yaml
- updates helm deps
- updates frrk8s version path in `kustomization` files

begins to solve #2458 

**Special notes for your reviewer**:

Not quite sure this is exactly what you had in mind, but does seem to accomplish the goal. There will be some small initial changes due minor formatting changes and `yq` not being great at storing YAML comments (i.e. the default comments in `Chart.yaml` are tossed once this task is used

**Release note**:

```release-note
NONE
```
