### PR TITLE
Fix the cordon test names to include L2 or BGP context

### DIFF
--- a/e2etest/bgptests/cordon_node.go
+++ b/e2etest/bgptests/cordon_node.go
@@ -19,7 +19,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-var _ = ginkgo.Describe("Cordon Node", func() {
+var _ = ginkgo.Describe("BGP Cordon Node", func() {
 	var (
 		cs            clientset.Interface
 		testNamespace string

--- a/e2etest/l2tests/cordon_node.go
+++ b/e2etest/l2tests/cordon_node.go
@@ -20,7 +20,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-var _ = ginkgo.Describe("Cordon Node", func() {
+var _ = ginkgo.Describe("L2 Cordon Node", func() {
 	emptyL2Advertisement := metallbv1beta1.L2Advertisement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "empty",


### PR DESCRIPTION

/kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:
this is need to be able to skip test in ginkgo e.g. --skip"L2 Cordon" 

**Release note**:

-->

```release-note
NONE
```
