### PR TITLE
Added spaces for mermaid diagram subgraph titles to fix syntax error

### DIFF
--- a/website/content/configuration/_advanced_bgp_configuration.md
+++ b/website/content/configuration/_advanced_bgp_configuration.md
@@ -99,17 +99,17 @@ router, but not the routers in other racks.
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph " "
       metallbA("MetalLB<br>Speaker")
     end
-    subgraph ""
+    subgraph "  "
       metallbB("MetalLB<br>Speaker")
     end
 
-    subgraph ""
+    subgraph "   "
       metallbC("MetalLB<br>Speaker")
     end
-    subgraph ""
+    subgraph "    "
       metallbD("MetalLB<br>Speaker")
     end
 

--- a/website/content/configuration/calico.md
+++ b/website/content/configuration/calico.md
@@ -39,11 +39,11 @@ by BGP's conflict resolution algorithm.
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph "  "
       metallbA
       calicoA
     end
-    subgraph ""
+    subgraph " "
       metallbB
       calicoB
     end
@@ -72,20 +72,20 @@ MetalLB:
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph " "
       metallbA("MetalLB<br>Speaker")
       calicoA
     end
-    subgraph ""
+    subgraph "  "
       calicoB
       metallbB("MetalLB<br>Speaker")
     end
 
-    subgraph ""
+    subgraph "   "
       metallbC("MetalLB<br>Speaker")
       calicoC
     end
-    subgraph ""
+    subgraph "    "
       calicoD
       metallbD("MetalLB<br>Speaker")
     end
@@ -117,20 +117,20 @@ The alternative is to make MetalLB peer with the spine router(s):
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph " "
       metallbA("MetalLB<br>Speaker")
       calicoA
     end
-    subgraph ""
+    subgraph "  "
       calicoB
       metallbB("MetalLB<br>Speaker")
     end
 
-    subgraph ""
+    subgraph "   "
       metallbC("MetalLB<br>Speaker")
       calicoC
     end
-    subgraph ""
+    subgraph "    "
       calicoD
       metallbD("MetalLB<br>Speaker")
     end
@@ -169,12 +169,12 @@ externally facing services to run on those racks.
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph " "
       metallbA("MetalLB<br>Speaker")
       calicoA
     end
 
-    subgraph ""
+    subgraph "  "
       calicoB
     end
 
@@ -197,11 +197,11 @@ tables.
 
 {{<mermaid align="center">}}
 graph BT
-    subgraph ""
+    subgraph " "
       metallbA("MetalLB<br>Speaker")
       calicoA("Calico")
     end
-    subgraph ""
+    subgraph "  "
       calicoB("Calico")
       metallbB("MetalLB<br>Speaker")
     end


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
BUG FIX - on MetalLBs webpage - section "Issues with Calico" Fixed #2512 
> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind regression
/kind documentation

**What this PR does / why we need it**:
It fixes the Mermaid diagrams on "Issues with Calico" page of the MetalLb website.

**Special notes for your reviewer**:
Can be validated by running Hugo locally.
The original mermaid diagrams contain blank titles for the subgraphs, so I've simply added incremental spaces instead so they comply with correct Mermaid syntax.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->
```
NONE
```
