### PR TITLE
Manifests: Add speaker delete FRRConfiguration rbac

### DIFF
--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -73,7 +73,7 @@ rules:
 {{- if or .Values.frrk8s.enabled .Values.frrk8s.external }}
 - apiGroups: ["frrk8s.metallb.io"]
   resources: ["frrconfigurations"]
-  verbs: ["get", "list", "watch","create","update"]
+  verbs: ["get", "list", "watch","create","update","delete"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/frr-k8s-external/clusterrole-patch.yaml
+++ b/config/frr-k8s-external/clusterrole-patch.yaml
@@ -11,3 +11,4 @@
       - watch
       - create
       - update
+      - delete

--- a/config/frr-k8s/clusterrole-patch.yaml
+++ b/config/frr-k8s/clusterrole-patch.yaml
@@ -11,3 +11,4 @@
       - watch
       - create
       - update
+      - delete

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -2257,6 +2257,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -2228,6 +2228,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - metallb.io
   resources:

--- a/config/prometheus-frr-k8s/clusterrole-patch.yaml
+++ b/config/prometheus-frr-k8s/clusterrole-patch.yaml
@@ -11,3 +11,4 @@
       - watch
       - create
       - update
+      - delete


### PR DESCRIPTION
We missed adding the rbac for deletion, needed for:
```
	if r.desiredConfiguration == nil {
		config := &frrv1beta1.FRRConfiguration{ObjectMeta: metav1.ObjectMeta{Name: frrk8s.ConfigName(r.NodeName), Namespace: r.FRRK8sNamespace}}
		err := r.Delete(ctx, config)
		return ctrl.Result{}, client.IgnoreNotFound(err)
	}
```
**Is this a BUG FIX or a FEATURE ?**:


/kind bug


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
