### PR TITLE
Safeconvert: add arm specific code for int to uint32

### DIFF
--- a/internal/safeconvert/convert.go
+++ b/internal/safeconvert/convert.go
@@ -27,16 +27,6 @@ func IntToUInt16(toConvert int) (uint16, error) {
 	return uint16(toConvert), nil
 }
 
-func IntToUInt32(toConvert int) (uint32, error) {
-	if toConvert < 0 {
-		return 0, fmt.Errorf("trying to convert negative value to uint32: %d", toConvert)
-	}
-	if toConvert > math.MaxUint32 {
-		return 0, fmt.Errorf("trying to convert value to uint32: %d, would overflow", toConvert)
-	}
-	return uint32(toConvert), nil
-}
-
 func Uint32ToInt16(toConvert uint32) (uint16, error) {
 	if toConvert > math.MaxUint16 {
 		return 0, fmt.Errorf("trying to convert value to uint16: %d, too high", toConvert)

--- a/internal/safeconvert/convertuint32.go
+++ b/internal/safeconvert/convertuint32.go
@@ -1,0 +1,21 @@
+//go:build !arm
+// +build !arm
+
+// SPDX-License-Identifier:Apache-2.0
+
+package safeconvert
+
+import (
+	"fmt"
+	"math"
+)
+
+func IntToUInt32(toConvert int) (uint32, error) {
+	if toConvert < 0 {
+		return 0, fmt.Errorf("trying to convert negative value to uint32: %d", toConvert)
+	}
+	if toConvert > math.MaxUint32 {
+		return 0, fmt.Errorf("trying to convert value to uint32: %d, would overflow", toConvert)
+	}
+	return uint32(toConvert), nil
+}

--- a/internal/safeconvert/convertuint32_arm.go
+++ b/internal/safeconvert/convertuint32_arm.go
@@ -1,0 +1,18 @@
+//go:build arm
+// +build arm
+
+// SPDX-License-Identifier:Apache-2.0
+
+package safeconvert
+
+import (
+	"fmt"
+)
+
+func IntToUInt32(toConvert int) (uint32, error) {
+	if toConvert < 0 {
+		return 0, fmt.Errorf("trying to convert negative value to uint32: %d", toConvert)
+	}
+	// No need to check for upper limit on arm as maxInt is lower than maxuint32
+	return uint32(toConvert), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

On arm, there is no need to check if an int is bigger than uint32 as it
will never be the case. Additionally, leaving the check would cause
building on arm to fail.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
