### PR TITLE
:sparkles: Add PreferDualStack IP family and related tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,10 +232,10 @@ jobs:
           SKIP="L2ServiceStatus"
           WITH_VRF="--with-vrf"
           FOCUS=""
-          if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|REQUIRE-DUALSTACK"; WITH_VRF=""; fi
-          if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|REQUIRE-DUALSTACK"; fi
+          if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|REQUIRE-DUALSTACK|PREFER-DUALSTACK"; WITH_VRF=""; fi
+          if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|REQUIRE-DUALSTACK|PREFER-DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "dual" ]; then SKIP="$SKIP|IPV6"; fi
-          if [ "${{ matrix.ip-family }}" == "ipv6" ]; then SKIP="$SKIP|IPV4|REQUIRE-DUALSTACK"; fi
+          if [ "${{ matrix.ip-family }}" == "ipv6" ]; then SKIP="$SKIP|IPV4|REQUIRE-DUALSTACK|PREFER-DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "ipv6" ] && [ ${{ matrix.bgp-type }} == "native" ]; then SKIP="$SKIP|BGP"; fi
           if [ "${{ matrix.bgp-type }}" == "frr" ]; then SKIP="$SKIP|FRRK8S-MODE"; fi
           if [ "${{ matrix.bgp-type }}" == "frr-k8s" ]; then SKIP="$SKIP|FRR-MODE"; fi
@@ -340,7 +340,7 @@ jobs:
             logLevel: debug
           EOF
           # TOOD remove skipping L2ServiceStatus once https://github.com/metallb/metallb/issues/2311 is fixed
-          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|REQUIRE-DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|REQUIRE-DUALSTACK|PREFER-DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,10 +232,10 @@ jobs:
           SKIP="L2ServiceStatus"
           WITH_VRF="--with-vrf"
           FOCUS=""
-          if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|DUALSTACK"; WITH_VRF=""; fi
-          if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|DUALSTACK"; fi
+          if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|REQUIRE-DUALSTACK"; WITH_VRF=""; fi
+          if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|REQUIRE-DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "dual" ]; then SKIP="$SKIP|IPV6"; fi
-          if [ "${{ matrix.ip-family }}" == "ipv6" ]; then SKIP="$SKIP|IPV4|DUALSTACK"; fi
+          if [ "${{ matrix.ip-family }}" == "ipv6" ]; then SKIP="$SKIP|IPV4|REQUIRE-DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "ipv6" ] && [ ${{ matrix.bgp-type }} == "native" ]; then SKIP="$SKIP|BGP"; fi
           if [ "${{ matrix.bgp-type }}" == "frr" ]; then SKIP="$SKIP|FRRK8S-MODE"; fi
           if [ "${{ matrix.bgp-type }}" == "frr-k8s" ]; then SKIP="$SKIP|FRR-MODE"; fi
@@ -340,7 +340,7 @@ jobs:
             logLevel: debug
           EOF
           # TOOD remove skipping L2ServiceStatus once https://github.com/metallb/metallb/issues/2311 is fixed
-          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest --bgp-mode frr --skip "IPV6|REQUIRE-DUALSTACK|metrics|L2-interface selector|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -195,6 +195,7 @@ func TestControllerMutation(t *testing.T) {
 	}, ByNamespace: map[string][]string{"test-ns1": {"pool6", "pool7", "pool11", "pool12"}, "test-ns2": {"pool9"}},
 		ByServiceSelector: []string{"pool8", "pool10", "pool11", "pool12"},
 	}
+	IPFamilyPolicyRequireDualStack := v1.IPFamilyPolicyRequireDualStack
 
 	l := log.NewNopLogger()
 
@@ -673,14 +674,16 @@ func TestControllerMutation(t *testing.T) {
 			desc: "simple dual-stack LoadBalancer",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
-					Type:       "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
 			},
@@ -694,8 +697,9 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 			},
 			want: &v1.Service{
@@ -705,8 +709,9 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
 			},
@@ -746,8 +751,9 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
-					Type:       "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 			},
 			want: &v1.Service{
@@ -757,8 +763,9 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"1.2.3.4", "3000::1"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
 			},
@@ -767,8 +774,9 @@ func TestControllerMutation(t *testing.T) {
 			desc: "request dual-stack loadbalancer with invalid ingress",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"3000::1", "5.6.7.8"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"3000::1", "5.6.7.8"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 				Status: v1.ServiceStatus{
 					LoadBalancer: v1.LoadBalancerStatus{
@@ -777,7 +785,7 @@ func TestControllerMutation(t *testing.T) {
 								Hostname: "foo.bar.local",
 							},
 							{
-								IP: "1000::",
+								IP: "1000:::",
 							},
 						},
 					},
@@ -785,8 +793,9 @@ func TestControllerMutation(t *testing.T) {
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type:       "LoadBalancer",
-					ClusterIPs: []string{"3000::1", "5.6.7.8"},
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"3000::1", "5.6.7.8"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
 				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
 			},
@@ -1132,6 +1141,7 @@ func TestDeleteRecyclesIP(t *testing.T) {
 		t.Fatal("svc2 didn't get an IP")
 	}
 }
+
 func TestControllerReassign(t *testing.T) {
 	k := &testK8S{t: t}
 	c := &controller{
@@ -1236,10 +1246,12 @@ func TestControllerDualStackConfig(t *testing.T) {
 	}
 
 	l := log.NewNopLogger()
+	IPFamilyPolicyRequireDualStack := v1.IPFamilyPolicyRequireDualStack
 	svc := &v1.Service{
 		Spec: v1.ServiceSpec{
-			Type:       "LoadBalancer",
-			ClusterIPs: []string{"1.2.3.4", "1000::"},
+			Type:           "LoadBalancer",
+			ClusterIPs:     []string{"1.2.3.4", "1000::"},
+			IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 		},
 	}
 	if c.SetBalancer(l, "test", svc, []discovery.EndpointSlice{}) == controllers.SyncStateError {

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -118,7 +118,6 @@ var _ = ginkgo.Describe("BGP", func() {
 	})
 
 	ginkgo.DescribeTable("A service of protocol load balancer should work with ETP=cluster", func(pairingIPFamily ipfamily.Family, poolAddresses []string, tweak testservice.Tweak) {
-
 		_, svc := setupBGPService(cs, testNamespace, pairingIPFamily, poolAddresses, FRRContainers, func(svc *corev1.Service) {
 			testservice.TrafficPolicyCluster(svc)
 			tweak(svc)
@@ -135,23 +134,22 @@ var _ = ginkgo.Describe("BGP", func() {
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
 		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}, func(_ *corev1.Service) {}),
-		ginkgo.Entry("DUALSTACK", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
+		ginkgo.Entry("REQUIRE-DUALSTACK", ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses},
 			func(svc *corev1.Service) {
-				testservice.DualStack(svc)
+				testservice.RequireDualStack(svc)
 			}),
 		ginkgo.Entry("IPV4 - request IPv4 via custom annotation", ipfamily.IPv4, []string{v4PoolAddresses},
 			func(svc *corev1.Service) {
 				testservice.WithSpecificIPs(svc, "192.168.10.100")
 			}),
-		ginkgo.Entry("DUALSTACK - request Dual Stack via custom annotation", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
+		ginkgo.Entry("REQUIRE-DUALSTACK - request Dual Stack via custom annotation", ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses},
 			func(svc *corev1.Service) {
-				testservice.DualStack(svc)
+				testservice.RequireDualStack(svc)
 				testservice.WithSpecificIPs(svc, "192.168.10.100", "fc00:f853:ccd:e799::")
 			}),
 	)
 
 	ginkgo.Describe("GracefulRestart, when speakers restart", func() {
-
 		ginkgo.AfterEach(func() {
 			for _, c := range FRRContainers {
 				c.NeighborConfig.GracefulRestart = false
@@ -222,7 +220,6 @@ var _ = ginkgo.Describe("BGP", func() {
 		}
 
 		ginkgo.Context("and when GR enabled", func() {
-
 			assertDuringSpeakerRestartWithGR := func(pairingIPFamily ipfamily.Family, poolAddresses []string, tweak testservice.Tweak) {
 				assertDuringSpeakerRestart(GracefulRestartEnabled, pairingIPFamily, poolAddresses, tweak)
 			}
@@ -236,8 +233,8 @@ var _ = ginkgo.Describe("BGP", func() {
 			ginkgo.DescribeTable("dataplane should keep working", assertDuringSpeakerRestartWithGR,
 				ginkgo.Entry("FRR-MODE IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
 				ginkgo.Entry("FRR-MODE IPV6", ipfamily.IPv6, []string{v6PoolAddresses}, func(_ *corev1.Service) {}),
-				ginkgo.Entry("FRR-MODE DUALSTACK", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
-					func(svc *corev1.Service) { testservice.DualStack(svc) }),
+				ginkgo.Entry("FRR-MODE REQUIRE-DUALSTACK", ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses},
+					func(svc *corev1.Service) { testservice.RequireDualStack(svc) }),
 			)
 		})
 
@@ -255,8 +252,8 @@ var _ = ginkgo.Describe("BGP", func() {
 			ginkgo.DescribeTable("dataplane should have a downtime", assertDuringSpeakerRestartWithoutGR,
 				ginkgo.Entry("FRR-MODE IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
 				ginkgo.Entry("FRR-MODE IPV6", ipfamily.IPv6, []string{v6PoolAddresses}, func(_ *corev1.Service) {}),
-				ginkgo.Entry("FRR-MODE DUALSTACK", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
-					func(svc *corev1.Service) { testservice.DualStack(svc) }),
+				ginkgo.Entry("FRR-MODE REQUIRE-DUALSTACK", ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses},
+					func(svc *corev1.Service) { testservice.RequireDualStack(svc) }),
 			)
 		})
 	})
@@ -301,7 +298,6 @@ var _ = ginkgo.Describe("BGP", func() {
 	})
 
 	ginkgo.DescribeTable("A service of protocol load balancer should work with ETP=local", func(pairingIPFamily ipfamily.Family, poolAddresses []string, tweak testservice.Tweak) {
-
 		jig, svc := setupBGPService(cs, testNamespace, pairingIPFamily, poolAddresses, FRRContainers, func(svc *corev1.Service) {
 			testservice.TrafficPolicyLocal(svc)
 			tweak(svc)
@@ -322,14 +318,13 @@ var _ = ginkgo.Describe("BGP", func() {
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, func(_ *corev1.Service) {}),
 		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}, func(_ *corev1.Service) {}),
-		ginkgo.Entry("DUALSTACK", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
+		ginkgo.Entry("REQUIRE-DUALSTACK", ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses},
 			func(svc *corev1.Service) {
-				testservice.DualStack(svc)
+				testservice.RequireDualStack(svc)
 			}),
 	)
 
 	ginkgo.DescribeTable("FRR must be deployed when enabled", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {
-
 		_, svc := setupBGPService(cs, testNamespace, pairingIPFamily, poolAddresses, FRRContainers, func(svc *corev1.Service) {
 			testservice.TrafficPolicyCluster(svc)
 		})
@@ -337,7 +332,6 @@ var _ = ginkgo.Describe("BGP", func() {
 		for _, c := range FRRContainers {
 			frrIsPairedOnPods(cs, c, pairingIPFamily)
 		}
-
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}),
 		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}),
@@ -458,7 +452,8 @@ var _ = ginkgo.Describe("BGP", func() {
 							"192.168.10.0-192.168.10.18",
 						},
 					},
-				}}, ipfamily.IPv4, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.IPv4, testservice.TrafficPolicyCluster,
 			),
 			ginkgo.Entry("IPV4 - test AddressPool defined by network prefix", []metallbv1beta1.IPAddressPool{
 				{
@@ -468,7 +463,8 @@ var _ = ginkgo.Describe("BGP", func() {
 							"192.168.10.0/24",
 						},
 					},
-				}}, ipfamily.IPv4, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.IPv4, testservice.TrafficPolicyCluster,
 			),
 			ginkgo.Entry("IPV6 - test AddressPool defined by address range", []metallbv1beta1.IPAddressPool{
 				{
@@ -478,7 +474,8 @@ var _ = ginkgo.Describe("BGP", func() {
 							"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18",
 						},
 					},
-				}}, ipfamily.IPv6, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.IPv6, testservice.TrafficPolicyCluster,
 			),
 			ginkgo.Entry("IPV6 - test AddressPool defined by network prefix", []metallbv1beta1.IPAddressPool{
 				{
@@ -488,9 +485,10 @@ var _ = ginkgo.Describe("BGP", func() {
 							"fc00:f853:0ccd:e799::/124",
 						},
 					},
-				}}, ipfamily.IPv6, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.IPv6, testservice.TrafficPolicyCluster,
 			),
-			ginkgo.Entry("DUALSTACK - test AddressPool defined by address range", []metallbv1beta1.IPAddressPool{
+			ginkgo.Entry("REQUIRE-DUALSTACK - test AddressPool defined by address range", []metallbv1beta1.IPAddressPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "bgp-test"},
 					Spec: metallbv1beta1.IPAddressPoolSpec{
@@ -499,9 +497,10 @@ var _ = ginkgo.Describe("BGP", func() {
 							"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18",
 						},
 					},
-				}}, ipfamily.DualStack, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.RequireDualStack, testservice.TrafficPolicyCluster,
 			),
-			ginkgo.Entry("DUALSTACK - test AddressPool defined by network prefix", []metallbv1beta1.IPAddressPool{
+			ginkgo.Entry("REQUIRE-DUALSTACK - test AddressPool defined by network prefix", []metallbv1beta1.IPAddressPool{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "bgp-test"},
 					Spec: metallbv1beta1.IPAddressPoolSpec{
@@ -510,7 +509,8 @@ var _ = ginkgo.Describe("BGP", func() {
 							"fc00:f853:0ccd:e799::/124",
 						},
 					},
-				}}, ipfamily.DualStack, testservice.TrafficPolicyCluster,
+				},
+			}, ipfamily.RequireDualStack, testservice.TrafficPolicyCluster,
 			),
 		)
 	})
@@ -744,7 +744,7 @@ var _ = ginkgo.Describe("BGP", func() {
 						MinimumTTL:       ptr.To(uint32(254)),
 					},
 				}, ipfamily.IPv6, []string{v6PoolAddresses}, testservice.TrafficPolicyCluster),
-			ginkgo.Entry("DUALSTACK - full params",
+			ginkgo.Entry("REQUIRE-DUALSTACK - full params",
 				metallbv1beta1.BFDProfile{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "full1",
@@ -757,9 +757,9 @@ var _ = ginkgo.Describe("BGP", func() {
 						PassiveMode:      ptr.To(false),
 						MinimumTTL:       ptr.To(uint32(254)),
 					},
-				}, ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+				}, ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
 					testservice.TrafficPolicyCluster(svc)
-					testservice.DualStack(svc)
+					testservice.RequireDualStack(svc)
 				}),
 		)
 	})
@@ -860,7 +860,8 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		ginkgo.DescribeTable("configure bgp advertisement and verify it gets propagated",
 			func(rangeWithAdvertisement string, rangeWithoutAdvertisement string, advertisement metallbv1beta1.BGPAdvertisement,
-				ipFamily ipfamily.Family, communities []metallbv1beta1.Community) {
+				ipFamily ipfamily.Family, communities []metallbv1beta1.Community,
+			) {
 				emptyAdvertisement := metallbv1beta1.BGPAdvertisement{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "empty",
@@ -990,7 +991,6 @@ var _ = ginkgo.Describe("BGP", func() {
 						return nil
 					}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 				}
-
 			},
 			ginkgo.Entry("IPV4 - community and localpref",
 				"192.168.10.0/24",
@@ -1550,7 +1550,6 @@ var _ = ginkgo.Describe("BGP", func() {
 					return nil
 				}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 			}
-
 		})
 	})
 	ginkgo.DescribeTable("A service of protocol load balancer should work with two protocols", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -125,6 +125,27 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 					testservice.RequireDualStack(svc)
 					testservice.ForceV4(svc)
 				}),
+			ginkgo.Entry("PREFER-DUALSTACK - via both, advertising ipv4 only",
+				ipfamily.PreferDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.PreferDualStackV4First(svc)
+					testservice.ForceV4(svc)
+				}),
+			ginkgo.Entry("PREFER-DUALSTACK - ipv4 first, ipv4 Preferred",
+				ipfamily.PreferDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.PreferDualStackV4First(svc)
+				}),
+			ginkgo.Entry("PREFER-DUALSTACK - ipv4 first, ipv6 Preferred",
+				ipfamily.PreferDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.PreferDualStackV6First(svc)
+				}),
+			ginkgo.Entry("PREFER-DUALSTACK - ipv6 first",
+				ipfamily.PreferDualStack, []string{v6PoolAddresses, v4PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.PreferDualStackV6First(svc)
+				}),
 		)
 
 		ginkgo.DescribeTable("should propagate the localpreference and the communities to both ipv4 and ipv6 addresses",

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -103,26 +103,26 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 				validateService(svc, allNodes.Items, c)
 			}
 		},
-			ginkgo.Entry("DUALSTACK - via ipv4",
+			ginkgo.Entry("REQUIRE-DUALSTACK - via ipv4",
 				ipfamily.IPv4, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
 					testservice.TrafficPolicyCluster(svc)
-					testservice.DualStack(svc)
+					testservice.RequireDualStack(svc)
 				}),
-			ginkgo.Entry("DUALSTACK - via ipv6",
+			ginkgo.Entry("REQUIRE-DUALSTACK - via ipv6",
 				ipfamily.IPv6, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
 					testservice.TrafficPolicyCluster(svc)
-					testservice.DualStack(svc)
+					testservice.RequireDualStack(svc)
 				}),
-			ginkgo.Entry("DUALSTACK - via both, advertising ipv6 only",
-				ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+			ginkgo.Entry("REQUIRE-DUALSTACK - via both, advertising ipv6 only",
+				ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
 					testservice.TrafficPolicyCluster(svc)
-					testservice.DualStack(svc)
+					testservice.RequireDualStack(svc)
 					testservice.ForceV6(svc)
 				}),
-			ginkgo.Entry("DUALSTACK - via both, advertising ipv4 only",
-				ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+			ginkgo.Entry("REQUIRE-DUALSTACK - via both, advertising ipv4 only",
+				ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
 					testservice.TrafficPolicyCluster(svc)
-					testservice.DualStack(svc)
+					testservice.RequireDualStack(svc)
 					testservice.ForceV4(svc)
 				}),
 		)
@@ -144,8 +144,10 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 						Labels: map[string]string{"test": "bgp-with-advertisement"},
 					},
 					Spec: metallbv1beta1.IPAddressPoolSpec{
-						Addresses: []string{"192.168.10.0/24",
-							"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
+						Addresses: []string{
+							"192.168.10.0/24",
+							"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18",
+						},
 					},
 				}
 
@@ -181,7 +183,7 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 
 				svc, _ := testservice.CreateWithBackend(cs, testNamespace, "service-with-adv",
 					testservice.TrafficPolicyCluster,
-					testservice.DualStack)
+					testservice.RequireDualStack)
 
 				defer testservice.Delete(cs, svc)
 
@@ -216,9 +218,9 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 					}
 				}
 			},
-			ginkgo.Entry("with DUALSTACK via ipv4",
+			ginkgo.Entry("with REQUIRE-DUALSTACK via ipv4",
 				ipfamily.IPv4),
-			ginkgo.Entry("with DUALSTACK via ipv6",
+			ginkgo.Entry("with REQUIRE-DUALSTACK via ipv6",
 				ipfamily.IPv6),
 		)
 	})

--- a/e2etest/bgptests/bgppeer_selector.go
+++ b/e2etest/bgptests/bgppeer_selector.go
@@ -4,7 +4,6 @@ package bgptests
 
 import (
 	"context"
-
 	"fmt"
 	"strings"
 
@@ -175,13 +174,13 @@ var _ = ginkgo.Describe("BGP Peer Selector", func() {
 			[]string{"192.168.16.0/24"}, ipfamily.IPv4, func(_ *corev1.Service) {}),
 		ginkgo.Entry("IPV6", []string{"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
 			[]string{"fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26"}, ipfamily.IPv6, func(_ *corev1.Service) {}),
-		ginkgo.Entry("DUALSTACK", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
-			[]string{"192.168.16.0/24", "fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26"}, ipfamily.DualStack,
+		ginkgo.Entry("REQUIRE-DUALSTACK", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
+			[]string{"192.168.16.0/24", "fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26"}, ipfamily.RequireDualStack,
 			func(svc *corev1.Service) {
-				testservice.DualStack(svc)
+				testservice.RequireDualStack(svc)
 			}),
-		ginkgo.Entry("DUALSTACK - force V6 only", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
-			[]string{"192.168.16.0/24", "fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26"}, ipfamily.DualStack,
+		ginkgo.Entry("REQUIRE-DUALSTACK - force V6 only", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
+			[]string{"192.168.16.0/24", "fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26"}, ipfamily.RequireDualStack,
 			func(svc *corev1.Service) {
 				testservice.ForceV6(svc)
 			}))
@@ -265,13 +264,13 @@ var _ = ginkgo.Describe("BGP Peer Selector", func() {
 		},
 		ginkgo.Entry("IPV4", []string{"192.168.10.0/24"}, ipfamily.IPv4, func(_ *corev1.Service) {}),
 		ginkgo.Entry("IPV6", []string{"fc00:f853:0ccd:e799::/116"}, ipfamily.IPv6, func(_ *corev1.Service) {}),
-		ginkgo.Entry("DUALSTACK", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::/116"},
-			ipfamily.DualStack,
+		ginkgo.Entry("REQUIRE-DUALSTACK", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::/116"},
+			ipfamily.RequireDualStack,
 			func(svc *corev1.Service) {
-				testservice.DualStack(svc)
+				testservice.RequireDualStack(svc)
 			}),
-		ginkgo.Entry("DUALSTACK - force V6 only", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::/116"},
-			ipfamily.DualStack,
+		ginkgo.Entry("REQUIRE-DUALSTACK - force V6 only", []string{"192.168.10.0/24", "fc00:f853:0ccd:e799::/116"},
+			ipfamily.RequireDualStack,
 			func(svc *corev1.Service) {
 				testservice.ForceV6(svc)
 			}))

--- a/e2etest/bgptests/metrics.go
+++ b/e2etest/bgptests/metrics.go
@@ -630,7 +630,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					Name: "bar",
 				},
 			}, ipfamily.IPv6, []string{v6PoolAddresses}),
-		ginkgo.Entry("DUALSTACK - full params",
+		ginkgo.Entry("REQUIRE-DUALSTACK - full params",
 			metallbv1beta1.BFDProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "full1",
@@ -643,7 +643,7 @@ var _ = ginkgo.Describe("BGP metrics", func() {
 					PassiveMode:      ptr.To(false),
 					MinimumTTL:       ptr.To(uint32(254)),
 				},
-			}, ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}),
+			}, ipfamily.RequireDualStack, []string{v4PoolAddresses, v6PoolAddresses}),
 	)
 
 	ginkgo.It("FRR metrics related to config should be exposed", func() {

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -3,10 +3,9 @@
 package frr
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"errors"
 
 	"go.universe.tf/e2etest/pkg/executor"
 
@@ -21,7 +20,6 @@ import (
 // executor.
 func NeighborInfo(neighborName string, exec executor.Executor) (*Neighbor, error) {
 	res, err := exec.Exec("vtysh", "-c", fmt.Sprintf("show bgp neighbor %s json", neighborName))
-
 	if err != nil {
 		return nil, errors.Join(err, fmt.Errorf("Failed to query neighbour %s", neighborName))
 	}
@@ -114,7 +112,7 @@ func RoutesForCommunity(exec executor.Executor, communityString string, family i
 	}
 
 	families := []string{family.String()}
-	if family == ipfamily.DualStack {
+	if family == ipfamily.RequireDualStack {
 		families = []string{ipfamily.IPv4.String(), ipfamily.IPv6.String()}
 	}
 

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -112,7 +112,7 @@ func RoutesForCommunity(exec executor.Executor, communityString string, family i
 	}
 
 	families := []string{family.String()}
-	if family == ipfamily.RequireDualStack {
+	if family == ipfamily.RequireDualStack || family == ipfamily.PreferDualStack {
 		families = []string{ipfamily.IPv4.String(), ipfamily.IPv6.String()}
 	}
 

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -290,6 +290,8 @@ func (c *FRR) AddressesForFamily(ipFamily ipfamily.Family) []string {
 		addresses = []string{c.Ipv6}
 	case ipfamily.RequireDualStack:
 		addresses = []string{c.Ipv4, c.Ipv6}
+	case ipfamily.PreferDualStack:
+		addresses = []string{c.Ipv4, c.Ipv6}
 	}
 	return addresses
 }

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -3,6 +3,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -10,8 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.universe.tf/e2etest/pkg/executor"
 	"go.universe.tf/e2etest/pkg/frr"
@@ -263,7 +262,6 @@ func (c *FRR) UpdateBGPConfigFile(bgpConfig string) error {
 	err = reloadFRRConfig(consts.BGPConfigFile, c)
 	if err != nil {
 		return errors.Join(err, errors.New("failed to update BGP config file"))
-
 	}
 
 	return nil
@@ -290,7 +288,7 @@ func (c *FRR) AddressesForFamily(ipFamily ipfamily.Family) []string {
 	switch ipFamily {
 	case ipfamily.IPv6:
 		addresses = []string{c.Ipv6}
-	case ipfamily.DualStack:
+	case ipfamily.RequireDualStack:
 		addresses = []string{c.Ipv4, c.Ipv6}
 	}
 	return addresses

--- a/e2etest/pkg/ipfamily/ipfamily.go
+++ b/e2etest/pkg/ipfamily/ipfamily.go
@@ -20,41 +20,72 @@ const (
 	IPv4             Family = "ipv4"
 	IPv6             Family = "ipv6"
 	RequireDualStack Family = "require-dual"
+	PreferDualStack  Family = "prefer-dual"
 	Unknown          Family = "unknown"
 )
 
-// ForAddresses returns the address family given list of addresses strings.
-func ForAddresses(ips []string) (Family, error) {
+// determineIPFamily returns the address family for a given ip string.
+func determineIPFamily(ipString string) Family {
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return Unknown
+	}
+	return ForAddress(ip)
+}
+
+// ForAddresses returns the address family given list of addresses strings and the
+// ipFamilyPolicy of the service.
+func ForAddresses(ips []string, familyPolicy v1.IPFamilyPolicy) (Family, error) {
 	switch len(ips) {
 	case 1:
-		ip := net.ParseIP(ips[0])
-		if ip.To4() != nil {
-			return IPv4, nil
+		ipType := determineIPFamily(ips[0])
+		if ipType == Unknown {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips[0])
 		}
-		return IPv6, nil
+		switch familyPolicy {
+		case v1.IPFamilyPolicySingleStack:
+			return ipType, nil
+		case v1.IPFamilyPolicyPreferDualStack:
+			return PreferDualStack, nil
+		default:
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips[0])
+		}
 	case 2:
-		ip1 := net.ParseIP(ips[0])
-		ip2 := net.ParseIP(ips[1])
-		if ip1 == nil || ip2 == nil {
+		ipType1 := determineIPFamily(ips[0])
+		ipType2 := determineIPFamily(ips[1])
+		if ipType1 == Unknown || ipType2 == Unknown {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: At least 1 of %q is invalid", ips)
+		}
+		switch familyPolicy {
+		case v1.IPFamilyPolicySingleStack:
+			if ipType1 != ipType2 {
+				return Unknown, fmt.Errorf("IPFamilyForAddresses: Two addresses on single stack: %q", ips)
+			}
+			return ipType1, nil
+		case v1.IPFamilyPolicyPreferDualStack:
+			return PreferDualStack, nil
+		case v1.IPFamilyPolicyRequireDualStack:
+			if ipType1 == ipType2 {
+				return Unknown, fmt.Errorf("IPFamilyForAddresses: Addresses from same family %q", ips)
+			}
+			return RequireDualStack, nil
+		default:
 			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips)
 		}
-		if (ip1.To4() == nil) == (ip2.To4() == nil) {
-			return Unknown, fmt.Errorf("IPFamilyForAddresses: same address family %q", ips)
-		}
-		return RequireDualStack, nil
 	default:
 		return Unknown, fmt.Errorf("IPFamilyForAddresses: invalid ips length %d %q", len(ips), ips)
 	}
 }
 
-// ForAddressesIPs returns the address family from a given list of addresses IPs.
-func ForAddressesIPs(ips []net.IP) (Family, error) {
+// ForAddressesIPs returns the address family from a given list of addresses ips
+// and the ipFamilyPolicy of the service.
+func ForAddressesIPs(ips []net.IP, familyPolicy v1.IPFamilyPolicy) (Family, error) {
 	ipsStrings := []string{}
 
 	for _, ip := range ips {
 		ipsStrings = append(ipsStrings, ip.String())
 	}
-	return ForAddresses(ipsStrings)
+	return ForAddresses(ipsStrings, familyPolicy)
 }
 
 // ForCIDR returns the address family from a given CIDR.
@@ -75,10 +106,14 @@ func ForAddress(ip net.IP) Family {
 
 // ForService returns the address family of a given service.
 func ForService(svc *v1.Service) (Family, error) {
+	familyPolicy := v1.IPFamilyPolicySingleStack
+	if svc.Spec.IPFamilyPolicy != nil {
+		familyPolicy = *(svc.Spec.IPFamilyPolicy)
+	}
 	if len(svc.Spec.ClusterIPs) > 0 {
-		return ForAddresses(svc.Spec.ClusterIPs)
+		return ForAddresses(svc.Spec.ClusterIPs, familyPolicy)
 	}
 	// fallback to clusterip if clusterips are not set
 	addresses := []string{svc.Spec.ClusterIP}
-	return ForAddresses(addresses)
+	return ForAddresses(addresses, familyPolicy)
 }

--- a/e2etest/pkg/ipfamily/ipfamily.go
+++ b/e2etest/pkg/ipfamily/ipfamily.go
@@ -17,10 +17,10 @@ func (f Family) String() string {
 }
 
 const (
-	IPv4      Family = "ipv4"
-	IPv6      Family = "ipv6"
-	DualStack Family = "dual"
-	Unknown   Family = "unknown"
+	IPv4             Family = "ipv4"
+	IPv6             Family = "ipv6"
+	RequireDualStack Family = "require-dual"
+	Unknown          Family = "unknown"
 )
 
 // ForAddresses returns the address family given list of addresses strings.
@@ -41,7 +41,7 @@ func ForAddresses(ips []string) (Family, error) {
 		if (ip1.To4() == nil) == (ip2.To4() == nil) {
 			return Unknown, fmt.Errorf("IPFamilyForAddresses: same address family %q", ips)
 		}
-		return DualStack, nil
+		return RequireDualStack, nil
 	default:
 		return Unknown, fmt.Errorf("IPFamilyForAddresses: invalid ips length %d %q", len(ips), ips)
 	}

--- a/e2etest/pkg/ipfamily/ipfamily_test.go
+++ b/e2etest/pkg/ipfamily/ipfamily_test.go
@@ -27,7 +27,7 @@ func TestIPFamilyForAddresses(t *testing.T) {
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []string{"1.2.3.4", "100::1"},
-			family: DualStack,
+			family: RequireDualStack,
 		},
 		{
 			desc:    "dual stack with same address family",
@@ -85,7 +85,7 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("100::1")},
-			family: DualStack,
+			family: RequireDualStack,
 		},
 		{
 			desc:    "dual stack with same address family",

--- a/e2etest/pkg/ipfamily/ipfamily_test.go
+++ b/e2etest/pkg/ipfamily/ipfamily_test.go
@@ -5,44 +5,78 @@ package ipfamily
 import (
 	"net"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestIPFamilyForAddresses(t *testing.T) {
 	tests := []struct {
 		desc    string
 		ips     []string
+		policy  v1.IPFamilyPolicy
 		family  Family
 		wantErr bool
 	}{
 		{
 			desc:   "ipv4 address",
 			ips:    []string{"1.1.1.1"},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv4,
 		},
 		{
 			desc:   "ipv6 address",
 			ips:    []string{"100::1"},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv6,
 		},
 		{
-			desc:   "ipv4 and ipv6 addresse",
-			ips:    []string{"1.2.3.4", "100::1"},
-			family: RequireDualStack,
-		},
-		{
-			desc:    "dual stack with same address family",
-			ips:     []string{"1.2.3.4", "5.6.7.8"},
+			desc:    "one invalid address",
+			ips:     []string{"!.1.1.1"},
+			policy:  v1.IPFamilyPolicySingleStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
-			desc:    "dual stack with empty address",
+			desc:   "require dualstack with ipv4 and ipv6 addresses",
+			ips:    []string{"1.2.3.4", "100::1"},
+			policy: v1.IPFamilyPolicyRequireDualStack,
+			family: RequireDualStack,
+		},
+		{
+			desc:   "prefer dualstack with ipv4 and ipv6 addresses",
+			ips:    []string{"1.2.3.4", "100::1"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
+		},
+		{
+			desc:   "prefer dualstack with both ipv4",
+			ips:    []string{"1.2.3.4", "5.6.7.8"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
+		},
+		{
+			desc:   "prefer dualstack with both ipv6",
+			ips:    []string{"100::1", "100::2"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
+		},
+		{
+			desc:    "prefer dualstack with empty address",
 			ips:     []string{"", ""},
+			policy:  v1.IPFamilyPolicyPreferDualStack,
+			family:  Unknown,
+			wantErr: true,
+		},
+		{
+			desc:    "require dualstack with one invalid address",
+			ips:     []string{"!.1.1.1", "100::1"},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
 			desc:    "more than 2 addresses",
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			ips:     []string{"1.1.1.1", "100::1", "2.2.2.2"},
 			family:  Unknown,
 			wantErr: true,
@@ -51,7 +85,7 @@ func TestIPFamilyForAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			family, err := ForAddresses(test.ips)
+			family, err := ForAddresses(test.ips, test.policy)
 			if test.wantErr && err == nil {
 				t.Fatalf("Expected error for %s", test.desc)
 			}
@@ -69,39 +103,45 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 	tests := []struct {
 		desc    string
 		ips     []net.IP
+		policy  v1.IPFamilyPolicy
 		family  Family
 		wantErr bool
 	}{
 		{
 			desc:   "ipv4 address",
 			ips:    []net.IP{net.ParseIP("1.2.4.0")},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv4,
 		},
 		{
 			desc:   "ipv6 address",
 			ips:    []net.IP{net.ParseIP("100::1")},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv6,
 		},
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("100::1")},
+			policy: v1.IPFamilyPolicyRequireDualStack,
 			family: RequireDualStack,
 		},
 		{
-			desc:    "dual stack with same address family",
-			ips:     []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
-			family:  Unknown,
-			wantErr: true,
+			desc:   "dual stack with same address family",
+			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
 		},
 		{
 			desc:    "dual stack with empty address",
 			ips:     []net.IP{net.ParseIP(""), net.ParseIP("")},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
 			desc:    "more than 2 addresses",
 			ips:     []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("100::1"), net.ParseIP("2.2.2.2")},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
@@ -109,7 +149,7 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			family, err := ForAddressesIPs(test.ips)
+			family, err := ForAddressesIPs(test.ips, test.policy)
 			if test.wantErr && err == nil {
 				t.Fatalf("Expected error for %s", test.desc)
 			}

--- a/e2etest/pkg/k8s/nodes.go
+++ b/e2etest/pkg/k8s/nodes.go
@@ -46,15 +46,17 @@ func NodeIPsForFamily(nodes []v1.Node, family ipfamily.Family, vrfName string) (
 			case ipfamily.RequireDualStack:
 				res = append(res, addr.IPV4Address)
 				res = append(res, addr.IPV6Address)
+			case ipfamily.PreferDualStack:
+				res = append(res, addr.IPV4Address)
+				res = append(res, addr.IPV6Address)
 			}
 			continue
 		}
 		for _, a := range n.Status.Addresses {
 			if a.Type == v1.NodeInternalIP {
-				if family != ipfamily.RequireDualStack && ipfamily.ForAddress(net.ParseIP(a.Address)) != family {
-					continue
+				if family == ipfamily.RequireDualStack || family == ipfamily.PreferDualStack || ipfamily.ForAddress(net.ParseIP(a.Address)) == family {
+					res = append(res, a.Address)
 				}
-				res = append(res, a.Address)
 			}
 		}
 	}

--- a/e2etest/pkg/k8s/nodes.go
+++ b/e2etest/pkg/k8s/nodes.go
@@ -43,7 +43,7 @@ func NodeIPsForFamily(nodes []v1.Node, family ipfamily.Family, vrfName string) (
 				res = append(res, addr.IPV4Address)
 			case ipfamily.IPv6:
 				res = append(res, addr.IPV6Address)
-			case ipfamily.DualStack:
+			case ipfamily.RequireDualStack:
 				res = append(res, addr.IPV4Address)
 				res = append(res, addr.IPV6Address)
 			}
@@ -51,7 +51,7 @@ func NodeIPsForFamily(nodes []v1.Node, family ipfamily.Family, vrfName string) (
 		}
 		for _, a := range n.Status.Addresses {
 			if a.Type == v1.NodeInternalIP {
-				if family != ipfamily.DualStack && ipfamily.ForAddress(net.ParseIP(a.Address)) != family {
+				if family != ipfamily.RequireDualStack && ipfamily.ForAddress(net.ParseIP(a.Address)) != family {
 					continue
 				}
 				res = append(res, a.Address)
@@ -156,7 +156,6 @@ func conditionStatus(n *corev1.Node, ct corev1.NodeConditionType) corev1.Conditi
 }
 
 func CordonNode(cs kubernetes.Interface, node *corev1.Node) error {
-
 	helper := &drain.Helper{
 		Client:              cs,
 		Ctx:                 context.TODO(),
@@ -175,7 +174,6 @@ func CordonNode(cs kubernetes.Interface, node *corev1.Node) error {
 }
 
 func UnCordonNode(cs kubernetes.Interface, node *corev1.Node) error {
-
 	helper := &drain.Helper{
 		Client:              cs,
 		Ctx:                 context.TODO(),

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -27,7 +27,7 @@ func ForceV6(svc *corev1.Service) {
 	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
 }
 
-func DualStack(svc *corev1.Service) {
+func RequireDualStack(svc *corev1.Service) {
 	f := corev1.IPFamilyPolicyRequireDualStack
 	svc.Spec.IPFamilyPolicy = &f
 	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -33,6 +33,18 @@ func RequireDualStack(svc *corev1.Service) {
 	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 }
 
+func PreferDualStackV4First(svc *corev1.Service) {
+	f := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &f
+	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+}
+
+func PreferDualStackV6First(svc *corev1.Service) {
+	f := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &f
+	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+}
+
 func TrafficPolicyCluster(svc *corev1.Service) {
 	svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
 }

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -272,7 +272,7 @@ func (a *Allocator) AllocateFromPool(svcKey string, svc *v1.Service, serviceIPFa
 	ipfamilySel := make(map[ipfamily.Family]bool)
 
 	switch serviceIPFamily {
-	case ipfamily.DualStack:
+	case ipfamily.RequireDualStack:
 		ipfamilySel[ipfamily.IPv4], ipfamilySel[ipfamily.IPv6] = true, true
 	default:
 		ipfamilySel[serviceIPFamily] = true

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -87,8 +87,10 @@ func TestAssignment(t *testing.T) {
 			Name:          "test5",
 			AvoidBuggyIPs: true,
 			AutoAssign:    true,
-			ServiceAllocations: &config.ServiceAllocation{Priority: 20, Namespaces: sets.New("test-ns1"),
-				ServiceSelectors: []labels.Selector{selector("team=metallb")}},
+			ServiceAllocations: &config.ServiceAllocation{
+				Priority: 20, Namespaces: sets.New("test-ns1"),
+				ServiceSelectors: []labels.Selector{selector("team=metallb")},
+			},
 			CIDR: []*net.IPNet{
 				ipnet("1.2.7.0/24"),
 				ipnet("1000::7:0/120"),
@@ -98,8 +100,10 @@ func TestAssignment(t *testing.T) {
 			Name:          "test6",
 			AvoidBuggyIPs: true,
 			AutoAssign:    true,
-			ServiceAllocations: &config.ServiceAllocation{Priority: 20, Namespaces: sets.New("test-ns2"),
-				ServiceSelectors: []labels.Selector{selector("foo=bar")}},
+			ServiceAllocations: &config.ServiceAllocation{
+				Priority: 20, Namespaces: sets.New("test-ns2"),
+				ServiceSelectors: []labels.Selector{selector("foo=bar")},
+			},
 			CIDR: []*net.IPNet{
 				ipnet("1.2.8.0/24"),
 				ipnet("1000::9:0/120"),
@@ -984,38 +988,38 @@ func TestPoolAllocation(t *testing.T) {
 			desc:     "s1 gets dual-stack IPs",
 			svcKey:   "s1",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s2 gets dual-stack IPs",
 			svcKey:   "s2",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s3 gets dual-stack IPs",
 			svcKey:   "s3",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s4 gets dual-stack IPs",
 			svcKey:   "s4",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s5 can't get dual-stack IPs",
 			svcKey:   "s5",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
 			desc:     "s6 can't get dual-stack IPs",
 			svcKey:   "s6",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
@@ -1023,19 +1027,19 @@ func TestPoolAllocation(t *testing.T) {
 			svcKey:   "s1",
 			svc:      svc,
 			unassign: true,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s5 can now grab s1's former dual-stack IPs",
 			svcKey:   "s5",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s6 still can't get dual-stack IPs",
 			svcKey:   "s6",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
@@ -1043,7 +1047,7 @@ func TestPoolAllocation(t *testing.T) {
 			svcKey:   "s5",
 			svc:      svc,
 			unassign: true,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:       "s5 enables dual-stack IP sharing",
@@ -1051,7 +1055,7 @@ func TestPoolAllocation(t *testing.T) {
 			svc:        svc,
 			ports:      ports("tcp/80"),
 			sharingKey: "share",
-			ipFamily:   ipfamily.DualStack,
+			ipFamily:   ipfamily.RequireDualStack,
 		},
 		{
 			desc:       "s6 can get an dual-stack IPs now, with sharing",
@@ -1059,7 +1063,7 @@ func TestPoolAllocation(t *testing.T) {
 			svc:        svc,
 			ports:      ports("tcp/443"),
 			sharingKey: "share",
-			ipFamily:   ipfamily.DualStack,
+			ipFamily:   ipfamily.RequireDualStack,
 		},
 	}
 
@@ -1081,7 +1085,7 @@ func TestPoolAllocation(t *testing.T) {
 		validIPs := validIP4s
 		if test.ipFamily == ipfamily.IPv6 {
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		} else if test.ipFamily == ipfamily.RequireDualStack {
 			validIPs = validIPDualStacks
 		}
 		for _, ip := range ips {
@@ -1373,38 +1377,38 @@ func TestAllocation(t *testing.T) {
 			desc:     "s1 gets dual-stack IPs",
 			svcKey:   "s1",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s2 gets dual-stack IPs",
 			svcKey:   "s2",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s3 gets dual-stack IPs",
 			svcKey:   "s3",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s4 gets dual-stack IPs",
 			svcKey:   "s4",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s5 can't get dual-stack IPs",
 			svcKey:   "s5",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
 			desc:     "s6 can't get dual-stack IPs",
 			svcKey:   "s6",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
@@ -1419,13 +1423,13 @@ func TestAllocation(t *testing.T) {
 			svc:        svc,
 			ports:      ports("tcp/80"),
 			sharingKey: "share",
-			ipFamily:   ipfamily.DualStack,
+			ipFamily:   ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s6 still can't get dual-stack IPs",
 			svcKey:   "s6",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
@@ -1434,7 +1438,7 @@ func TestAllocation(t *testing.T) {
 			svc:        svc,
 			ports:      ports("tcp/443"),
 			sharingKey: "share",
-			ipFamily:   ipfamily.DualStack,
+			ipFamily:   ipfamily.RequireDualStack,
 		},
 	}
 
@@ -1457,7 +1461,7 @@ func TestAllocation(t *testing.T) {
 		validIPs := validIP4s
 		if test.ipFamily == ipfamily.IPv6 {
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		} else if test.ipFamily == ipfamily.RequireDualStack {
 			validIPs = validIPDualStacks
 		}
 		for _, ip := range ips {
@@ -1829,30 +1833,30 @@ func TestAutoAssign(t *testing.T) {
 		{
 			svcKey:   "s1",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			svcKey:   "s2",
 			svc:      svc,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			svcKey:   "s3",
 			svc:      svc,
 			wantErr:  true,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			svcKey:   "s4",
 			svc:      svc,
 			wantErr:  true,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			svcKey:   "s5",
 			svc:      svc,
 			wantErr:  true,
-			ipFamily: ipfamily.DualStack,
+			ipFamily: ipfamily.RequireDualStack,
 		},
 	}
 
@@ -1874,7 +1878,7 @@ func TestAutoAssign(t *testing.T) {
 		validIPs := validIP4s
 		if test.ipFamily == ipfamily.IPv6 {
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		} else if test.ipFamily == ipfamily.RequireDualStack {
 			validIPs = validIPDualStacks
 		}
 		for _, ip := range ips {

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -20,20 +20,39 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var svc = &v1.Service{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "test-lb-service",
-	},
-	Spec: v1.ServiceSpec{
-		Type: v1.ServiceTypeLoadBalancer,
-		Ports: []v1.ServicePort{
-			{
-				Protocol: v1.ProtocolTCP,
-				Port:     8080,
+var (
+	ipFamilyPolicyRequireDualStack = v1.IPFamilyPolicyRequireDualStack
+	svc                            = &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-lb-service",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     8080,
+				},
 			},
 		},
-	},
-}
+	}
+
+	svcRequireDualStack = &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-lb-service-require-dualstack",
+		},
+		Spec: v1.ServiceSpec{
+			IPFamilyPolicy: &ipFamilyPolicyRequireDualStack,
+			Type:           v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     8080,
+				},
+			},
+		},
+	}
+)
 
 func selector(s string) labels.Selector {
 	ret, err := labels.Parse(s)
@@ -987,72 +1006,72 @@ func TestPoolAllocation(t *testing.T) {
 		{
 			desc:     "s1 gets dual-stack IPs",
 			svcKey:   "s1",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s2 gets dual-stack IPs",
 			svcKey:   "s2",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s3 gets dual-stack IPs",
 			svcKey:   "s3",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s4 gets dual-stack IPs",
 			svcKey:   "s4",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s5 can't get dual-stack IPs",
 			svcKey:   "s5",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
 			desc:     "s6 can't get dual-stack IPs",
 			svcKey:   "s6",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
 			desc:     "s1 releases its dual-stack IPs",
 			svcKey:   "s1",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			unassign: true,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s5 can now grab s1's former dual-stack IPs",
 			svcKey:   "s5",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:     "s6 still can't get dual-stack IPs",
 			svcKey:   "s6",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			ipFamily: ipfamily.RequireDualStack,
 			wantErr:  true,
 		},
 		{
 			desc:     "s5 unassigns in prep for enabling dual-stack IPs sharing",
 			svcKey:   "s5",
-			svc:      svc,
+			svc:      svcRequireDualStack,
 			unassign: true,
 			ipFamily: ipfamily.RequireDualStack,
 		},
 		{
 			desc:       "s5 enables dual-stack IP sharing",
 			svcKey:     "s5",
-			svc:        svc,
+			svc:        svcRequireDualStack,
 			ports:      ports("tcp/80"),
 			sharingKey: "share",
 			ipFamily:   ipfamily.RequireDualStack,
@@ -1060,7 +1079,7 @@ func TestPoolAllocation(t *testing.T) {
 		{
 			desc:       "s6 can get an dual-stack IPs now, with sharing",
 			svcKey:     "s6",
-			svc:        svc,
+			svc:        svcRequireDualStack,
 			ports:      ports("tcp/443"),
 			sharingKey: "share",
 			ipFamily:   ipfamily.RequireDualStack,

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -17,10 +17,10 @@ func (f Family) String() string {
 }
 
 const (
-	IPv4      Family = "ipv4"
-	IPv6      Family = "ipv6"
-	DualStack Family = "dual"
-	Unknown   Family = "unknown"
+	IPv4             Family = "ipv4"
+	IPv6             Family = "ipv6"
+	RequireDualStack Family = "require-dual"
+	Unknown          Family = "unknown"
 )
 
 // ForAddresses returns the address family given list of addresses strings.
@@ -44,7 +44,7 @@ func ForAddresses(ips []string) (Family, error) {
 		if (ip1.To4() == nil) == (ip2.To4() == nil) {
 			return Unknown, fmt.Errorf("IPFamilyForAddresses: same address family %q", ips)
 		}
-		return DualStack, nil
+		return RequireDualStack, nil
 	default:
 		return Unknown, fmt.Errorf("IPFamilyForAddresses: invalid ips length %d %q", len(ips), ips)
 	}

--- a/internal/ipfamily/ipfamily.go
+++ b/internal/ipfamily/ipfamily.go
@@ -20,44 +20,72 @@ const (
 	IPv4             Family = "ipv4"
 	IPv6             Family = "ipv6"
 	RequireDualStack Family = "require-dual"
+	PreferDualStack  Family = "prefer-dual"
 	Unknown          Family = "unknown"
 )
 
-// ForAddresses returns the address family given list of addresses strings.
-func ForAddresses(ips []string) (Family, error) {
+// determineIPFamily returns the address family for a given ip string.
+func determineIPFamily(ipString string) Family {
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return Unknown
+	}
+	return ForAddress(ip)
+}
+
+// ForAddresses returns the address family given list of addresses strings and the
+// ipFamilyPolicy of the service.
+func ForAddresses(ips []string, familyPolicy v1.IPFamilyPolicy) (Family, error) {
 	switch len(ips) {
 	case 1:
-		ip := net.ParseIP(ips[0])
-		if ip == nil {
-			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips)
+		ipType := determineIPFamily(ips[0])
+		if ipType == Unknown {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips[0])
 		}
-		if ip.To4() != nil {
-			return IPv4, nil
+		switch familyPolicy {
+		case v1.IPFamilyPolicySingleStack:
+			return ipType, nil
+		case v1.IPFamilyPolicyPreferDualStack:
+			return PreferDualStack, nil
+		default:
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips[0])
 		}
-		return IPv6, nil
 	case 2:
-		ip1 := net.ParseIP(ips[0])
-		ip2 := net.ParseIP(ips[1])
-		if ip1 == nil || ip2 == nil {
+		ipType1 := determineIPFamily(ips[0])
+		ipType2 := determineIPFamily(ips[1])
+		if ipType1 == Unknown || ipType2 == Unknown {
+			return Unknown, fmt.Errorf("IPFamilyForAddresses: At least 1 of %q is invalid", ips)
+		}
+		switch familyPolicy {
+		case v1.IPFamilyPolicySingleStack:
+			if ipType1 != ipType2 {
+				return Unknown, fmt.Errorf("IPFamilyForAddresses: Two addresses on single stack: %q", ips)
+			}
+			return ipType1, nil
+		case v1.IPFamilyPolicyPreferDualStack:
+			return PreferDualStack, nil
+		case v1.IPFamilyPolicyRequireDualStack:
+			if ipType1 == ipType2 {
+				return Unknown, fmt.Errorf("IPFamilyForAddresses: Addresses from same family %q", ips)
+			}
+			return RequireDualStack, nil
+		default:
 			return Unknown, fmt.Errorf("IPFamilyForAddresses: Invalid address %q", ips)
 		}
-		if (ip1.To4() == nil) == (ip2.To4() == nil) {
-			return Unknown, fmt.Errorf("IPFamilyForAddresses: same address family %q", ips)
-		}
-		return RequireDualStack, nil
 	default:
 		return Unknown, fmt.Errorf("IPFamilyForAddresses: invalid ips length %d %q", len(ips), ips)
 	}
 }
 
-// ForAddressesIPs returns the address family from a given list of addresses IPs.
-func ForAddressesIPs(ips []net.IP) (Family, error) {
+// ForAddressesIPs returns the address family from a given list of addresses ips
+// and the ipFamilyPolicy of the service.
+func ForAddressesIPs(ips []net.IP, familyPolicy v1.IPFamilyPolicy) (Family, error) {
 	ipsStrings := []string{}
 
 	for _, ip := range ips {
 		ipsStrings = append(ipsStrings, ip.String())
 	}
-	return ForAddresses(ipsStrings)
+	return ForAddresses(ipsStrings, familyPolicy)
 }
 
 // ForCIDR returns the address family from a given CIDR.
@@ -78,10 +106,14 @@ func ForAddress(ip net.IP) Family {
 
 // ForService returns the address family of a given service.
 func ForService(svc *v1.Service) (Family, error) {
+	familyPolicy := v1.IPFamilyPolicySingleStack
+	if svc.Spec.IPFamilyPolicy != nil {
+		familyPolicy = *(svc.Spec.IPFamilyPolicy)
+	}
 	if len(svc.Spec.ClusterIPs) > 0 {
-		return ForAddresses(svc.Spec.ClusterIPs)
+		return ForAddresses(svc.Spec.ClusterIPs, familyPolicy)
 	}
 	// fallback to clusterip if clusterips are not set
 	addresses := []string{svc.Spec.ClusterIP}
-	return ForAddresses(addresses)
+	return ForAddresses(addresses, familyPolicy)
 }

--- a/internal/ipfamily/ipfamily_test.go
+++ b/internal/ipfamily/ipfamily_test.go
@@ -5,56 +5,78 @@ package ipfamily
 import (
 	"net"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestIPFamilyForAddresses(t *testing.T) {
 	tests := []struct {
 		desc    string
 		ips     []string
+		policy  v1.IPFamilyPolicy
 		family  Family
 		wantErr bool
 	}{
 		{
 			desc:   "ipv4 address",
 			ips:    []string{"1.1.1.1"},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv4,
 		},
 		{
 			desc:   "ipv6 address",
 			ips:    []string{"100::1"},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv6,
 		},
 		{
 			desc:    "one invalid address",
 			ips:     []string{"!.1.1.1"},
+			policy:  v1.IPFamilyPolicySingleStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
-			desc:   "ipv4 and ipv6 addresse",
+			desc:   "require dualstack with ipv4 and ipv6 addresses",
 			ips:    []string{"1.2.3.4", "100::1"},
+			policy: v1.IPFamilyPolicyRequireDualStack,
 			family: RequireDualStack,
 		},
 		{
-			desc:    "dual stack with same address family",
-			ips:     []string{"1.2.3.4", "5.6.7.8"},
-			family:  Unknown,
-			wantErr: true,
+			desc:   "prefer dualstack with ipv4 and ipv6 addresses",
+			ips:    []string{"1.2.3.4", "100::1"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
 		},
 		{
-			desc:    "dual stack with empty address",
+			desc:   "prefer dualstack with both ipv4",
+			ips:    []string{"1.2.3.4", "5.6.7.8"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
+		},
+		{
+			desc:   "prefer dualstack with both ipv6",
+			ips:    []string{"100::1", "100::2"},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
+		},
+		{
+			desc:    "prefer dualstack with empty address",
 			ips:     []string{"", ""},
+			policy:  v1.IPFamilyPolicyPreferDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
-			desc:    "dual stack with one invalid address",
+			desc:    "require dualstack with one invalid address",
 			ips:     []string{"!.1.1.1", "100::1"},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
 			desc:    "more than 2 addresses",
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			ips:     []string{"1.1.1.1", "100::1", "2.2.2.2"},
 			family:  Unknown,
 			wantErr: true,
@@ -63,7 +85,7 @@ func TestIPFamilyForAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			family, err := ForAddresses(test.ips)
+			family, err := ForAddresses(test.ips, test.policy)
 			if test.wantErr && err == nil {
 				t.Fatalf("Expected error for %s", test.desc)
 			}
@@ -81,39 +103,45 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 	tests := []struct {
 		desc    string
 		ips     []net.IP
+		policy  v1.IPFamilyPolicy
 		family  Family
 		wantErr bool
 	}{
 		{
 			desc:   "ipv4 address",
 			ips:    []net.IP{net.ParseIP("1.2.4.0")},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv4,
 		},
 		{
 			desc:   "ipv6 address",
 			ips:    []net.IP{net.ParseIP("100::1")},
+			policy: v1.IPFamilyPolicySingleStack,
 			family: IPv6,
 		},
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("100::1")},
+			policy: v1.IPFamilyPolicyRequireDualStack,
 			family: RequireDualStack,
 		},
 		{
-			desc:    "dual stack with same address family",
-			ips:     []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
-			family:  Unknown,
-			wantErr: true,
+			desc:   "dual stack with same address family",
+			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
+			policy: v1.IPFamilyPolicyPreferDualStack,
+			family: PreferDualStack,
 		},
 		{
 			desc:    "dual stack with empty address",
 			ips:     []net.IP{net.ParseIP(""), net.ParseIP("")},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
 		{
 			desc:    "more than 2 addresses",
 			ips:     []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("100::1"), net.ParseIP("2.2.2.2")},
+			policy:  v1.IPFamilyPolicyRequireDualStack,
 			family:  Unknown,
 			wantErr: true,
 		},
@@ -121,7 +149,7 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			family, err := ForAddressesIPs(test.ips)
+			family, err := ForAddressesIPs(test.ips, test.policy)
 			if test.wantErr && err == nil {
 				t.Fatalf("Expected error for %s", test.desc)
 			}

--- a/internal/ipfamily/ipfamily_test.go
+++ b/internal/ipfamily/ipfamily_test.go
@@ -33,7 +33,7 @@ func TestIPFamilyForAddresses(t *testing.T) {
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []string{"1.2.3.4", "100::1"},
-			family: DualStack,
+			family: RequireDualStack,
 		},
 		{
 			desc:    "dual stack with same address family",
@@ -97,7 +97,7 @@ func TestIPFamilyForAddressesIPs(t *testing.T) {
 		{
 			desc:   "ipv4 and ipv6 addresse",
 			ips:    []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("100::1")},
-			family: DualStack,
+			family: RequireDualStack,
 		},
 		{
 			desc:    "dual stack with same address family",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
Fixes #2482

**Special notes for your reviewer**:

Changes:
1. Rename DualStack to RequireDualStack
In preparation for the new IP family, this commit renames the existing ipfamily.DualStack to ipfamily.RequireDualStack. The renaming aligns the naming convention with Kubernetes' IP family types (k8s.io/api/core/v1) and clarifies that dual-stack is a required configuration when using this option.

2. Add PreferDualStack IP family
The new PreferDualStack IP family type is introduced, allowing dual-stack networking when available but falling back to single-stack if necessary. This provides a more flexible approach to networking in clusters that may not fully support dual-stack.

3. Add e2e tests for PreferDualStack assignments
End-to-end tests are added to verify the behavior of the PreferDualStack type. These tests cover various scenarios:

Ensuring dual-stack is assigned when available.
Falling back to single-stack when dual-stack isn't supported.
Verifying correct behavior in mixed or transitioning networking environments.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
--> 

```release-note
- Added new `PreferDualStack` IP family type to support environments where dual-stack networking is preferred but not strictly required.
- Renamed `ipfamily.DualStack` to `ipfamily.RequireDualStack` to align with Kubernetes API terminology.
- Added e2e tests for `PreferDualStack` behavior to validate network assignment scenarios.
```
