### PR TITLE
Add support for "Dynamic ASN"

### DIFF
--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -29,9 +29,20 @@ type BGPPeerSpec struct {
 	MyASN uint32 `json:"myASN"`
 
 	// AS number to expect from the remote end of the session.
+	// ASN and DynamicASN are mutually exclusive and one of them must be specified.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
-	ASN uint32 `json:"peerASN"`
+	// +optional
+	ASN uint32 `json:"peerASN,omitempty"`
+
+	// DynamicASN detects the AS number to use for the remote end of the session
+	// without explicitly setting it via the ASN field. Limited to:
+	// internal - if the neighbor's ASN is different than MyASN connection is denied.
+	// external - if the neighbor's ASN is the same as MyASN the connection is denied.
+	// ASN and DynamicASN are mutually exclusive and one of them must be specified.
+	// +kubebuilder:validation:Enum=internal;external
+	// +optional
+	DynamicASN DynamicASNMode `json:"dynamicASN,omitempty"`
 
 	// Address to dial when establishing the session.
 	Address string `json:"peerAddress"`
@@ -144,3 +155,10 @@ type BGPPeerList struct {
 func init() {
 	SchemeBuilder.Register(&BGPPeer{}, &BGPPeerList{})
 }
+
+type DynamicASNMode string
+
+const (
+	InternalASNMode DynamicASNMode = "internal"
+	ExternalASNMode DynamicASNMode = "external"
+)

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -528,6 +528,17 @@ spec:
                   default: false
                   description: To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
                   type: boolean
+                dynamicASN:
+                  description: |-
+                    DynamicASN detects the AS number to use for the remote end of the session
+                    without explicitly setting it via the ASN field. Limited to:
+                    internal - if the neighbor's ASN is different than MyASN connection is denied.
+                    external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                  enum:
+                    - internal
+                    - external
+                  type: string
                 ebgpMultiHop:
                   description: To set if the BGPPeer is multi-hops away. Needed for FRR mode only.
                   type: boolean
@@ -624,7 +635,9 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 peerASN:
-                  description: AS number to expect from the remote end of the session.
+                  description: |-
+                    AS number to expect from the remote end of the session.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
                   format: int32
                   maximum: 4294967295
                   minimum: 0
@@ -651,7 +664,6 @@ spec:
                   type: string
               required:
                 - myASN
-                - peerASN
                 - peerAddress
               type: object
             status:

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -196,6 +196,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -298,7 +309,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -325,7 +338,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -554,6 +554,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -656,7 +667,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -683,7 +696,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -68,6 +68,7 @@ type SessionParameters struct {
 	MyASN           uint32
 	RouterID        net.IP
 	PeerASN         uint32
+	DynamicASN      string
 	HoldTime        *time.Duration
 	KeepAliveTime   *time.Duration
 	ConnectTime     *time.Duration

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -252,7 +252,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			routers[routerName] = rout
 		}
 
-		neighborName := NeighborName(s.PeerAddress, s.PeerASN, s.VRFName)
+		neighborName := NeighborName(s.PeerAddress, s.PeerASN, s.DynamicASN, s.VRFName)
 		if neighbor, exist = rout.neighbors[neighborName]; !exist {
 			host, port, err := net.SplitHostPort(s.PeerAddress)
 			if err != nil {
@@ -285,7 +285,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			neighbor = &neighborConfig{
 				Name:            neighborName,
 				IPFamily:        family,
-				ASN:             s.PeerASN,
+				ASN:             asnFor(s.PeerASN, s.DynamicASN),
 				Addr:            host,
 				Port:            uint16(portUint),
 				HoldTime:        holdTime,

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -1357,3 +1357,51 @@ func TestAddToAdvertisements(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleSessionWithInternalASN(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:     "10.2.2.254:179",
+			SourceAddress:   net.ParseIP("10.1.1.254"),
+			MyASN:           102,
+			RouterID:        net.ParseIP("10.1.1.254"),
+			DynamicASN:      "internal",
+			GracefulRestart: true,
+			SessionName:     "test-peer"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithExternalASN(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := mockNewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:     "10.2.2.254:179",
+			SourceAddress:   net.ParseIP("10.1.1.254"),
+			MyASN:           102,
+			RouterID:        net.ParseIP("10.1.1.254"),
+			DynamicASN:      "external",
+			GracefulRestart: true,
+			SessionName:     "test-peer"})
+
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}

--- a/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,0 +1,42 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+router bgp 102
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as external
+  neighbor 10.2.2.254 port 179
+  
+  neighbor 10.2.2.254 update-source 10.1.1.254
+  neighbor 10.2.2.254 graceful-restart
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+

--- a/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,0 +1,42 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+router bgp 102
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as internal
+  neighbor 10.2.2.254 port 179
+  
+  neighbor 10.2.2.254 update-source 10.1.1.254
+  neighbor 10.2.2.254 graceful-restart
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+

--- a/internal/bgp/frrk8s/frrk8s.go
+++ b/internal/bgp/frrk8s/frrk8s.go
@@ -227,7 +227,7 @@ func (sm *sessionManager) updateConfig() error {
 			routers[routerName] = rout
 		}
 
-		neighborName := frr.NeighborName(s.PeerAddress, s.PeerASN, s.VRFName)
+		neighborName := frr.NeighborName(s.PeerAddress, s.PeerASN, s.DynamicASN, s.VRFName)
 		if neighbor, exist = rout.neighbors[neighborName]; !exist {
 			host, port, err := net.SplitHostPort(s.PeerAddress)
 			if err != nil {
@@ -260,6 +260,7 @@ func (sm *sessionManager) updateConfig() error {
 
 			neighbor = frrv1beta1.Neighbor{
 				ASN:                   s.PeerASN,
+				DynamicASN:            frrv1beta1.DynamicASNMode(s.DynamicASN),
 				Address:               host,
 				Port:                  &portUint16,
 				HoldTime:              holdTime,

--- a/internal/bgp/frrk8s/frrk8s_test.go
+++ b/internal/bgp/frrk8s/frrk8s_test.go
@@ -901,3 +901,43 @@ func TestSingleSessionWithZeroTimers(t *testing.T) {
 
 	testCheckConfigFile(t)
 }
+
+func TestSingleSessionWithInternalASN(t *testing.T) {
+	sessionManager := newTestSessionManager(t)
+	l := log.NewNopLogger()
+
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress: "10.2.2.254:179",
+			MyASN:       100,
+			RouterID:    net.ParseIP("10.1.1.254"),
+			DynamicASN:  "internal",
+			CurrentNode: "hostname",
+			SessionName: "test-peer"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithExternalASN(t *testing.T) {
+	sessionManager := newTestSessionManager(t)
+	l := log.NewNopLogger()
+
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress: "10.2.2.254:179",
+			MyASN:       100,
+			RouterID:    net.ParseIP("10.1.1.254"),
+			DynamicASN:  "external",
+			CurrentNode: "hostname",
+			SessionName: "test-peer"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	testCheckConfigFile(t)
+}

--- a/internal/bgp/frrk8s/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/bgp/frrk8s/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,0 +1,38 @@
+{
+    "metadata": {
+        "name": "metallb-testnodename",
+        "namespace": "testnamespace",
+        "creationTimestamp": null
+    },
+    "spec": {
+        "bgp": {
+            "routers": [
+                {
+                    "asn": 100,
+                    "id": "10.1.1.254",
+                    "neighbors": [
+                        {
+                            "dynamicASN": "external",
+                            "address": "10.2.2.254",
+                            "port": 179,
+                            "passwordSecret": {},
+                            "toAdvertise": {
+                                "allowed": {}
+                            },
+                            "toReceive": {
+                                "allowed": {}
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "raw": {},
+        "nodeSelector": {
+            "matchLabels": {
+                "kubernetes.io/hostname": "testnodename"
+            }
+        }
+    },
+    "status": {}
+}

--- a/internal/bgp/frrk8s/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/bgp/frrk8s/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,0 +1,38 @@
+{
+    "metadata": {
+        "name": "metallb-testnodename",
+        "namespace": "testnamespace",
+        "creationTimestamp": null
+    },
+    "spec": {
+        "bgp": {
+            "routers": [
+                {
+                    "asn": 100,
+                    "id": "10.1.1.254",
+                    "neighbors": [
+                        {
+                            "dynamicASN": "internal",
+                            "address": "10.2.2.254",
+                            "port": 179,
+                            "passwordSecret": {},
+                            "toAdvertise": {
+                                "allowed": {}
+                            },
+                            "toReceive": {
+                                "allowed": {}
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "raw": {},
+        "nodeSelector": {
+            "matchLabels": {
+                "kubernetes.io/hostname": "testnodename"
+            }
+        }
+    },
+    "status": {}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3439,6 +3439,66 @@ func TestParse(t *testing.T) {
 				BFDProfiles: map[string]*BFDProfile{},
 			},
 		},
+		{
+			desc: "peer with dynamic asn",
+			crs: ClusterResources{
+
+				Peers: []v1beta2.BGPPeer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "peer1",
+						},
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:      42,
+							DynamicASN: v1beta2.InternalASNMode,
+							Address:    "1.2.3.4",
+						},
+					},
+				},
+			},
+			want: &Config{
+				Peers: map[string]*Peer{
+					"peer1": {
+						Name:          "peer1",
+						MyASN:         42,
+						DynamicASN:    "internal",
+						Addr:          net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+						EBGPMultiHop:  false,
+					},
+				},
+				Pools:       &Pools{ByName: map[string]*Pool{}},
+				BFDProfiles: map[string]*BFDProfile{},
+			},
+		},
+		{
+			desc: "peer without asn or dynamic asn",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:      42,
+							ASN:        0,
+							DynamicASN: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "peer with both asn and dynamic asn",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:      42,
+							ASN:        42,
+							DynamicASN: v1beta2.InternalASNMode,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -48,6 +48,9 @@ func DiscardFRROnly(c ClusterResources) error {
 		if p.Spec.DisableMP {
 			return fmt.Errorf("peer %s has disable MP flag set on native bgp mode", p.Spec.Address)
 		}
+		if p.Spec.DynamicASN != "" {
+			return fmt.Errorf("peer %s has dynamicASN set on native bgp mode", p.Spec.Address)
+		}
 	}
 	if len(c.BFDProfiles) > 0 {
 		return errors.New("bfd profiles section set")

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -97,6 +97,19 @@ func TestValidate(t *testing.T) {
 			mustFail: true,
 		},
 		{
+			desc: "dynamic ASN",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							DynamicASN: "internal",
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
 			desc: "keepalive time",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -238,6 +238,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				MyASN:           p.cfg.MyASN,
 				RouterID:        routerID,
 				PeerASN:         p.cfg.ASN,
+				DynamicASN:      p.cfg.DynamicASN,
 				HoldTime:        p.cfg.HoldTime,
 				KeepAliveTime:   p.cfg.KeepaliveTime,
 				ConnectTime:     p.cfg.ConnectTime,

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -283,7 +283,8 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `myASN` _integer_ | AS number to use for the local end of the session. |
-| `peerASN` _integer_ | AS number to expect from the remote end of the session. |
+| `peerASN` _integer_ | AS number to expect from the remote end of the session.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |
+| `dynamicASN` _[DynamicASNMode](#dynamicasnmode)_ | DynamicASN detects the AS number to use for the remote end of the session<br />without explicitly setting it via the ASN field. Limited to:<br />internal - if the neighbor's ASN is different than MyASN connection is denied.<br />external - if the neighbor's ASN is the same as MyASN the connection is denied.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |
 | `peerAddress` _string_ | Address to dial when establishing the session. |
 | `sourceAddress` _string_ | Source address to use when establishing the session. |
 | `peerPort` _integer_ | Port to dial when establishing the session. |
@@ -299,5 +300,16 @@ _Appears in:_
 | `ebgpMultiHop` _boolean_ | To set if the BGPPeer is multi-hops away. Needed for FRR mode only. |
 | `vrf` _string_ | To set if we want to peer with the BGPPeer using an interface belonging to<br />a host vrf |
 | `disableMP` _boolean_ | To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions. |
+
+
+#### DynamicASNMode
+
+_Underlying type:_ _string_
+
+
+
+_Appears in:_
+- [BGPPeerSpec](#bgppeerspec)
+
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind feature

**What this PR does / why we need it**:
Adds support for FRR's "Dynamic ASN", allowing users to specify whether the peer is ibgp or ebgp without explicitly setting its asn. Leverages https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-remote-as-internal

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add DynamicASN field for a BGPPeer, which allows the speaker to detect the AS number to use without explicitly setting it. The new field is mutually exclusive with the existing PeerASN field, and one of them must be specified for any given BGPPeer. 
```
