### PR TITLE
E2E: increase debugging for the external peers

### DIFF
--- a/e2etest/pkg/frr/config/config.go
+++ b/e2etest/pkg/frr/config/config.go
@@ -27,11 +27,21 @@ log file /tmp/frr.log debugging`
 const bgpConfigTemplate = `
 password zebra
 
-debug bgp updates
-debug bgp neighbor
+debug zebra events
+debug zebra kernel
+debug zebra rib
 debug zebra nht
+debug zebra nexthop
+debug bgp keepalives
+debug bgp neighbor-events
 debug bgp nht
+debug bgp updates in
+debug bgp updates out
+debug bgp zebra
 debug bfd peer
+debug bfd zebra
+debug bfd network
+!
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
 


### PR DESCRIPTION
Currently we are not printing all debug messages for zebra and bfd
subsystem on the peers side in the e2etests. Therefore tests like
graceful restart test and future tests with BFD are harder to debug in
case of failure. This commit increases the debug in the frr config to be
the same as the frr config on the node, which includes zebra,bfd.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
 /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

-->

```release-note
NONE
```
