### PR TITLE
Docs: document the ip reconciliation behavior

### DIFF
--- a/website/content/concepts/_index.md
+++ b/website/content/concepts/_index.md
@@ -40,6 +40,11 @@ providing cluster services to your LAN.
 Or, you could do both! MetalLB lets you define as many address pools
 as you want, and doesn't care what "kind" of addresses you give it.
 
+When one or more IPs are assigned to a service, MetalLB tries to keep
+them assigned to that service. In case of removal of those IPs from the pools
+(deletion or edit of the IPAddressPool those IPs are taken from),
+MetalLB will assign another set of IPs to the service (when available). 
+
 ## External announcement
 
 After MetalLB has assigned an external IP address to a service, it


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
/kind documentation
> /kind regression

**What this PR does / why we need it**:
We moved from a behavior where the configuration was stale if the ips were still used to a behavior where we reconcile the service with the available ips. Here we clarify (hopefully) it in the docs.


Fixes https://github.com/metallb/metallb/issues/2449

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
