### PR TITLE
Webhooks: fix Community update

### DIFF
--- a/internal/k8s/webhooks/webhookv1beta1/bfdprofile_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/bfdprofile_webhook.go
@@ -53,7 +53,7 @@ type BFDProfileValidator struct {
 }
 
 // Handle handled incoming admission requests for BFDProfile objects.
-func (v *BFDProfileValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *BFDProfileValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var bfdProfile v1beta1.BFDProfile
 	var oldBFDProfile v1beta1.BFDProfile
 	if req.Operation == v1.Delete {

--- a/internal/k8s/webhooks/webhookv1beta1/bgpadvertisement_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/bgpadvertisement_webhook.go
@@ -55,7 +55,7 @@ type BGPAdvertisementValidator struct {
 }
 
 // Handle handled incoming admission requests for BGPAdvertisement objects.
-func (v *BGPAdvertisementValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *BGPAdvertisementValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var advertisement v1beta1.BGPAdvertisement
 	var oldAdvertisement v1beta1.BGPAdvertisement
 	if req.Operation == admissionv1.Delete {

--- a/internal/k8s/webhooks/webhookv1beta1/community_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/community_webhook.go
@@ -54,7 +54,7 @@ type CommunityValidator struct {
 }
 
 // Handle handled incoming admission requests for Community objects.
-func (v *CommunityValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *CommunityValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var community v1beta1.Community
 	var oldCommunity v1beta1.Community
 	if req.Operation == v1.Delete {
@@ -83,7 +83,6 @@ func (v *CommunityValidator) Handle(ctx context.Context, req admission.Request) 
 		if err != nil {
 			return admission.Denied(err.Error())
 		}
-		return
 	case v1.Delete:
 		err := validateCommunityDelete(&community)
 		if err != nil {

--- a/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/ipaddresspool_webhook.go
@@ -54,7 +54,7 @@ type IPAddressPoolValidator struct {
 }
 
 // Handle handled incoming admission requests for IPAddressPool objects.
-func (v *IPAddressPoolValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *IPAddressPoolValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var pool v1beta1.IPAddressPool
 	var oldPool v1beta1.IPAddressPool
 	if req.Operation == v1.Delete {

--- a/internal/k8s/webhooks/webhookv1beta1/l2advertisement_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta1/l2advertisement_webhook.go
@@ -54,7 +54,7 @@ type L2AdvertisementValidator struct {
 }
 
 // Handle handled incoming admission requests for L2Advertisement objects.
-func (v *L2AdvertisementValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *L2AdvertisementValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var advertisement v1beta1.L2Advertisement
 	var oldAdvertisement v1beta1.L2Advertisement
 	if req.Operation == v1.Delete {

--- a/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook.go
@@ -54,7 +54,7 @@ type BGPPeerValidator struct {
 }
 
 // Handle handled incoming admission requests for BGPPeer objects.
-func (v *BGPPeerValidator) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+func (v *BGPPeerValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var peer v1beta2.BGPPeer
 	var oldPeer v1beta2.BGPPeer
 	if req.Operation == v1.Delete {


### PR DESCRIPTION
Updates of Commonity resources were met with:
```
admission webhook "communityvalidationwebhook.metallb.io" denied the request without explanation
```
The reason being we had an empty return in the community update path. Here we remove it + the named returns that allowed it to align the rest of the paths.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Fixes https://github.com/metallb/metallb/issues/2597
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed Community resources updates being denied without explanation.
```
