### PR TITLE
E2E: add function to fetch BGP routes using iproute2

### DIFF
--- a/e2etest/pkg/container/routes.go
+++ b/e2etest/pkg/container/routes.go
@@ -3,7 +3,9 @@
 package container
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/netip"
 
 	"go.universe.tf/e2etest/pkg/executor"
 	"go.universe.tf/e2etest/pkg/netdev"
@@ -92,4 +94,93 @@ func SetupVRFForNetwork(containerName, vrfNetwork, vrfName, vrfRoutingTable stri
 	}
 
 	return nil
+}
+
+// BGPRoutes executes `ip route show proto bgp` in the executor and returns all
+// routes filtered by device e.g. net0.  The return is map[destination CIDR]-> set[nextHops].
+// The return json from the kernel varies depend if ipv4 with single entry, or
+// ipv4 with multiple entries or ipv6. The use of maps, and using keys the types
+// netip.{Prefix,Addr} allows direct comparison.
+func BGPRoutes(exc executor.Executor, dev string) (map[netip.Prefix]map[netip.Addr]struct{}, error) {
+	ret := make(map[netip.Prefix]map[netip.Addr]struct{})
+
+	type Nexthop struct {
+		Gateway string   `json:"gateway"`
+		Dev     string   `json:"dev"`
+		Weight  int      `json:"weight"`
+		Flags   []string `json:"flags"`
+	}
+
+	type IPRoute struct {
+		Dst      string    `json:"dst"`
+		Nexthops []Nexthop `json:"nexthops,omitempty"`
+		Gateway  string    `json:"gateway,omitempty"`
+		Via      *struct {
+			Family string `json:"family"`
+			Host   string `json:"host"`
+		} `json:"via,omitempty"`
+		Dev string `json:"dev"`
+	}
+
+	for _, proto := range []string{"-4", "-6"} {
+		out, err := exc.Exec("ip", proto, "--json", "route", "show", "proto", "bgp")
+		if err != nil {
+			return nil, fmt.Errorf("%s - %w", out, err)
+		}
+
+		var routes []IPRoute
+		err = json.Unmarshal([]byte(out), &routes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse JSON output: %w", err)
+		}
+
+		for _, r := range routes {
+			dst, err := netip.ParsePrefix(r.Dst)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prefix %s: %w", r.Dst, err)
+			}
+
+			nextHops := make(map[netip.Addr]struct{})
+			// this is for ipv4 single next-hop
+			if r.Via != nil {
+				addr, err := netip.ParseAddr(r.Via.Host)
+				if err != nil {
+					return nil, fmt.Errorf("invalid next-hop %s: %w", r.Via.Host, err)
+				}
+				if r.Dev == dev {
+					nextHops[addr] = struct{}{}
+				}
+			}
+
+			// this is for ipv4 multiple next-hops
+			for _, nh := range r.Nexthops {
+				addr, err := netip.ParseAddr(nh.Gateway)
+				if err != nil {
+					return nil, fmt.Errorf("invalid next-hop %s: %w", nh.Gateway, err)
+				}
+
+				if nh.Dev == dev {
+					nextHops[addr] = struct{}{}
+				}
+			}
+
+			// this is for ipv6
+			if r.Gateway != "" {
+				addr, err := netip.ParseAddr(r.Gateway)
+				if err != nil {
+					return nil, fmt.Errorf("invalid next-hop %s: %w", r.Gateway, err)
+				}
+				if r.Dev == dev {
+					nextHops[addr] = struct{}{}
+				}
+			}
+
+			if len(nextHops) == 0 {
+				continue
+			}
+			ret[dst] = nextHops
+		}
+	}
+
+	return ret, nil
 }


### PR DESCRIPTION
The function returns a map of destination prefixes to their next-hop addresses, supporting both IPv4 and IPv6 routes with single or multiple next-hops, and uses netip.{Prefix,Addr} to allow direct comparison.

 /kind feature


**What this PR does / why we need it**:
We cannot use the normal vtysh approach because FRR is restarting

**Special notes for your reviewer**:
Same function exists in https://github.com/metallb/metallb/pull/2595 as needed by the unnumbered BGP testing

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
