### PR TITLE
docs: replace deprecated metallb.universe.tf annotation prefix with metallb.io

### DIFF
--- a/website/content/configuration/_advanced_ipaddresspool_configuration.md
+++ b/website/content/configuration/_advanced_ipaddresspool_configuration.md
@@ -95,8 +95,8 @@ If multiple `IPAddressPool` objects have the same priority, the choice will be
 random.
 
 {{% notice note %}}
-When a service explicitly chooses an IPAddressPool via `metallb.universe.tf/address-pool`
-annotation or an IP address via `spec.loadBalancerIP` or `metallb.universe.tf/loadBalancerIPs`
+When a service explicitly chooses an IPAddressPool via `metallb.io/address-pool`
+annotation or an IP address via `spec.loadBalancerIP` or `metallb.io/loadBalancerIPs`
 annotation which doesn't match the service will stay in pending.
 {{% /notice %}}
 

--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -20,7 +20,7 @@ address, or if the address is already in use by another service,
 assignment will fail and MetalLB will log a warning event visible in
 `kubectl describe service <service name>`.
 
-MetalLB supports `spec.loadBalancerIP` and a custom `metallb.universe.tf/loadBalancerIPs`
+MetalLB supports `spec.loadBalancerIP` and a custom `metallb.io/loadBalancerIPs`
 annotation. The annotation also supports a comma separated list of IPs to be used in case of
 Dual Stack services.
 
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    metallb.universe.tf/loadBalancerIPs: 192.168.1.100
+    metallb.io/loadBalancerIPs: 192.168.1.100
 spec:
   ports:
   - port: 80
@@ -45,7 +45,7 @@ spec:
 MetalLB also supports requesting a specific address pool, if you want
 a certain kind of address but don't care which one exactly. To request
 assignment from a specific pool, add the
-`metallb.universe.tf/address-pool` annotation to your service, with the
+`metallb.io/address-pool` annotation to your service, with the
 name of the address pool as the annotation value. For example:
 
 ```yaml
@@ -54,7 +54,7 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    metallb.universe.tf/address-pool: production-public-ips
+    metallb.io/address-pool: production-public-ips
 spec:
   ports:
   - port: 80
@@ -181,13 +181,13 @@ at least one address pool having both addresses of version v4 and v6.
 
 Note that in case of dual stack services, it is not possible to use
 `spec.loadBalancerIP` as it does not allow to request for multiple IPs,
-so the annotation `metallb.universe.tf/loadBalancerIPs` must be used.
+so the annotation `metallb.io/loadBalancerIPs` must be used.
 
 ## IP address sharing
 
 By default, Services do not share IP addresses. If you have a need to
 colocate services on a single IP, you can enable selective IP sharing
-by adding the `metallb.universe.tf/allow-shared-ip` annotation to
+by adding the `metallb.io/allow-shared-ip` annotation to
 services.
 
 The value of the annotation is a "sharing key." Services can share an
@@ -217,7 +217,7 @@ metadata:
   name: dns-service-tcp
   namespace: default
   annotations:
-    metallb.universe.tf/allow-shared-ip: "key-to-share-1.2.3.4"
+    metallb.io/allow-shared-ip: "key-to-share-1.2.3.4"
 spec:
   type: LoadBalancer
   loadBalancerIP: 1.2.3.4
@@ -235,7 +235,7 @@ metadata:
   name: dns-service-udp
   namespace: default
   annotations:
-    metallb.universe.tf/allow-shared-ip: "key-to-share-1.2.3.4"
+    metallb.io/allow-shared-ip: "key-to-share-1.2.3.4"
 spec:
   type: LoadBalancer
   loadBalancerIP: 1.2.3.4

--- a/website/content/usage/example.md
+++ b/website/content/usage/example.md
@@ -89,7 +89,7 @@ spec:
 ```
 
 In our Helm charts for sandboxes, we tag all services with the
-annotation `metallb.universe.tf/address-pool: sandbox`. Now, whenever
+annotation `metallb.io/address-pool: sandbox`. Now, whenever
 developers spin up a sandbox, it'll come up on some IP address within
 192.168.144.0/20.
 


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

/kind documentation

**What this PR does / why we need it**:
Today's release notes for v0.14.9 state `The annotation prefix “metallb.universe.tf” is deprecated`, but the website doesn't reflect this and still references `metallb.universe.tf`. This PR should address this.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
docs: replace deprecated metallb.universe.tf annotation prefix with metallb.io
```
