### PR TITLE
feat(oci): publish chart to quay registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -130,11 +130,18 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Log into Quay
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Chart releaser
         if: startsWith(github.ref, 'refs/tags/v') # we craft releases only for tags
         run: |
           # Download chart releaser
-          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.4.0/chart-releaser_1.4.0_linux_amd64.tar.gz"
+          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.7.0/chart-releaser_1.7.0_linux_amd64.tar.gz"
           tar -xzf cr.tar.gz
           rm -f cr.tar.gz
           repo=$(basename "$GITHUB_REPOSITORY")
@@ -144,6 +151,11 @@ jobs:
           exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://github.com/$GITHUB_REPOSITORY/releases/tag/$repo-chart-$tag -w %{http_code} -o /dev/null)
           helm repo add frrk8s https://metallb.github.io/frr-k8s
           if [[ $exists != "200" ]]; then
+            echo "Updated chart version"
+            sed -i -E 's/0.0.0/'"$tag"'/g' charts/metallb/charts/crds/Chart.yaml
+            sed -i -E 's/0.0.0/'"$tag"'/g' charts/metallb/Chart.yaml
+            helm dependency update charts/$repo
+
             echo "Creating release..."
             # package chart
             ./cr package charts/$repo
@@ -160,6 +172,8 @@ jobs:
                 --index-path index.yaml \
                 --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
                 --push
+            # upload chart to quay
+            helm push .cr-release-packages/*.tgz oci://quay.io/metallb/chart
           else
             echo "Release already exists"
           fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Publish the `metallb` helm chart to the `quay.io` oci registry

**Special notes for your reviewer**:

Fixes #2296 

**Release note**:

```release-note
Publish charts to quay, along side existing publishing methods.
```
