### PR TITLE
WIP: fix: change log output for frr container

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -115,7 +115,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
 {{- end }}
 ---
 {{- if .Values.speaker.enabled }}
@@ -403,20 +403,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
         command:
           - /bin/sh
           - -c
-          - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+          - /sbin/tini -- /usr/lib/frr/docker-start
         {{- with .Values.speaker.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/config/frr/frr-cm.yaml
+++ b/config/frr/frr-cm.yaml
@@ -95,4 +95,4 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -64,20 +64,10 @@ spec:
               mountPath: /var/run/frr
             - name: frr-conf
               mountPath: /etc/frr
-          # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-          # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-          # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
           command:
             - /bin/sh
             - -c
-            - |
-              /sbin/tini -- /usr/lib/frr/docker-start &
-              attempts=0
-              until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-                sleep 1
-                attempts=$(( $attempts + 1 ))
-              done
-              tail -f /etc/frr/frr.log
+            - /sbin/tini -- /usr/lib/frr/docker-start
           livenessProbe:
             httpGet:
               path: /livez

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -1926,7 +1926,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -2194,14 +2194,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+        - /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1871,7 +1871,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -2017,14 +2017,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+        - /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1647,7 +1647,7 @@ var _ = ginkgo.Describe("BGP", func() {
 					return cfgStr
 				}, 1*time.Minute).Should(
 					And(
-						ContainSubstring("log file /etc/frr/frr.log"),
+						ContainSubstring("log stdout"),
 						WithTransform(substringCount("\n profile fullbfdprofile1"), Equal(1)),
 						ContainSubstring("receive-interval 93"),
 						ContainSubstring("transmit-interval 95"),

--- a/e2etest/bgptests/dump.go
+++ b/e2etest/bgptests/dump.go
@@ -53,7 +53,7 @@ func dumpBGPInfo(basePath, testName string, cs clientset.Interface, namespace st
 		podExec, err := FRRProvider.FRRExecutorFor(pod.Namespace, pod.Name)
 		Expect(err).NotTo(HaveOccurred())
 
-		dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
+		dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf")
 		if err != nil {
 			ginkgo.GinkgoWriter.Printf("External frr dump for pod %s failed %v", pod.Name, err)
 			continue

--- a/internal/bgp/frr/templates/frr.tmpl
+++ b/internal/bgp/frr/templates/frr.tmpl
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log {{.Loglevel}}
+log stdout {{.Loglevel}}
 log timestamp precision 3
 {{- if eq .Loglevel "debugging" }}
 debug zebra events

--- a/internal/bgp/frr/testdata/TestBFDProfileAllDefault.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileAllDefault.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestBFDProfileCornerCases.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileCornerCases.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestBFDProfileNoSessions.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileNoSessions.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestBFDProfileThenDelete.golden
+++ b/internal/bgp/frr/testdata/TestBFDProfileThenDelete.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestIPv4AndIPv6SessionsDisableMP.golden
+++ b/internal/bgp/frr/testdata/TestIPv4AndIPv6SessionsDisableMP.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestIPv4AndIPv6SessionsDualStackFamily.golden
+++ b/internal/bgp/frr/testdata/TestIPv4AndIPv6SessionsDualStackFamily.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestLargeCommunities.golden
+++ b/internal/bgp/frr/testdata/TestLargeCommunities.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestLoggingConfiguration.golden
+++ b/internal/bgp/frr/testdata/TestLoggingConfiguration.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log warnings
+log stdout warnings
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestLoggingConfigurationDebug.golden
+++ b/internal/bgp/frr/testdata/TestLoggingConfigurationDebug.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log debugging
+log stdout debugging
 log timestamp precision 3
 debug zebra events
 debug zebra nht

--- a/internal/bgp/frr/testdata/TestLoggingConfigurationOverrideByEnvironmentVar.golden
+++ b/internal/bgp/frr/testdata/TestLoggingConfigurationOverrideByEnvironmentVar.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log alerts
+log stdout alerts
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
+++ b/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalid.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalid.golden
@@ -1,5 +1,5 @@
 
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname
 

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementInvalidPrefix.golden
@@ -1,5 +1,5 @@
 
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionClose.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionClose.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionExtras.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionExtras.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithGracefulRestart.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithGracefulRestart.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithNoTimers.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithNoTimers.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithZeroTimers.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithZeroTimers.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestUnnumberedSession.golden
+++ b/internal/bgp/frr/testdata/TestUnnumberedSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/troubleshooting/collect.sh
+++ b/troubleshooting/collect.sh
@@ -19,7 +19,7 @@ function get_metallb_crs() {
 }
 
 function gather_frr_logs() {
-    declare -a FILES_TO_GATHER=("frr.conf" "frr.log" "daemons" "vtysh.conf")
+    declare -a FILES_TO_GATHER=("frr.conf" "daemons" "vtysh.conf")
     declare -a COMMANDS=("show running-config" "show bgp ipv4" "show bgp ipv6" "show bgp neighbor" "show bfd peer")
     LOGS_DIR="${OUTPUT}/pods/${1}/frr/logs"
     mkdir -p ${LOGS_DIR}


### PR DESCRIPTION
Proposal for a solution to the issue https://github.com/metallb/metallb/issues/2644
In the main branch I see exactly the same approach, frr logs can consume all node disk space and lead to a disk preassure state. So I recommend changing the place where the frr container logs are sent in speaker pod. Changing destination place frr logs from /etc/frr/frr.log to stdout will allow to natively manage the space of frr container logs, which will be available using 
`kubectl logs -c frr < speaker_pod_name >`
without any  workaround  like [this](https://github.com/metallb/metallb/blob/main/charts/metallb/templates/speaker.yaml#L390-L403).   


/kind bug


```release-note
Allow rotation for the logs of the frr container
```