### PR TITLE
E2E: make interface optional when fetching routes

### DIFF
--- a/e2etest/pkg/container/routes.go
+++ b/e2etest/pkg/container/routes.go
@@ -135,7 +135,8 @@ func WireContainers(containerA, containerB, dev string) error {
 }
 
 // BGPRoutes executes `ip route show proto bgp` in the executor and returns all
-// routes filtered by device e.g. net0.  The return is map[destination CIDR]-> set[nextHops].
+// routes filtered by device name e.g. net0. If device name is the empty string
+// no filtering takes place. The return is map[destination CIDR]-> set[nextHops].
 func BGPRoutes(exc executor.Executor, dev string) (map[netip.Prefix]map[netip.Addr]struct{}, error) {
 	ret := make(map[netip.Prefix]map[netip.Addr]struct{})
 
@@ -182,7 +183,7 @@ func BGPRoutes(exc executor.Executor, dev string) (map[netip.Prefix]map[netip.Ad
 				if err != nil {
 					return nil, fmt.Errorf("invalid next-hop %s: %w", r.Via.Host, err)
 				}
-				if r.Dev == dev {
+				if dev == "" || r.Dev == dev {
 					nextHops[addr] = struct{}{}
 				}
 			}
@@ -194,7 +195,7 @@ func BGPRoutes(exc executor.Executor, dev string) (map[netip.Prefix]map[netip.Ad
 					return nil, fmt.Errorf("invalid next-hop %s: %w", nh.Gateway, err)
 				}
 
-				if nh.Dev == dev {
+				if dev == "" || nh.Dev == dev {
 					nextHops[addr] = struct{}{}
 				}
 			}
@@ -205,7 +206,7 @@ func BGPRoutes(exc executor.Executor, dev string) (map[netip.Prefix]map[netip.Ad
 				if err != nil {
 					return nil, fmt.Errorf("invalid next-hop %s: %w", r.Gateway, err)
 				}
-				if r.Dev == dev {
+				if dev == "" || r.Dev == dev {
 					nextHops[addr] = struct{}{}
 				}
 			}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:
I use this function from a test in frr-k8s that does not need to be interface agnostic

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
