### PR TITLE
fix: deprecated managed annotation not being removed

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -474,6 +474,63 @@ func TestControllerMutation(t *testing.T) {
 		},
 
 		{
+			desc: "deprecated annotation removed from service from older version",
+			in: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						DeprecatedAnnotationIPAllocateFromPool: "pool1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+				},
+				Status: statusAssigned([]string{"1.2.3.0"}),
+			},
+			want: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationIPAllocateFromPool: "pool1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+				},
+				Status: statusAssigned([]string{"1.2.3.0"}),
+			},
+		},
+
+		{
+			desc: "deprecated annotation removed from service with new annotation",
+			in: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationIPAllocateFromPool:           "pool1",
+						DeprecatedAnnotationIPAllocateFromPool: "pool1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+				},
+				Status: statusAssigned([]string{"1.2.3.0"}),
+			},
+			want: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationIPAllocateFromPool: "pool1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+				},
+				Status: statusAssigned([]string{"1.2.3.0"}),
+			},
+		},
+
+		{
 			desc: "invalid IP assigned",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -124,17 +124,12 @@ func TestControllerMutation(t *testing.T) {
 		"pool1": {
 			Name:       "pool1",
 			AutoAssign: true,
-			CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
+			CIDR:       []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
 		},
 		"pool2": {
 			Name:       "pool2",
 			AutoAssign: false,
 			CIDR:       []*net.IPNet{ipnet("3.4.5.6/32")},
-		},
-		"pool3": {
-			Name:       "pool3",
-			AutoAssign: true,
-			CIDR:       []*net.IPNet{ipnet("1000::/127")},
 		},
 		"pool4": {
 			Name:       "pool4",
@@ -143,8 +138,8 @@ func TestControllerMutation(t *testing.T) {
 		},
 		"pool5": {
 			Name:       "pool5",
-			AutoAssign: true,
-			CIDR:       []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
+			AutoAssign: false,
+			CIDR:       []*net.IPNet{ipnet("28.29.30.0/31"), ipnet("4000::/127")},
 		},
 		"pool6": {
 			Name:       "pool6",
@@ -716,7 +711,7 @@ func TestControllerMutation(t *testing.T) {
 					ClusterIPs:     []string{"1.2.3.4", "3000::1"},
 					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
 				},
-				Status: statusAssigned([]string{"1.2.3.0", "1000::"}),
+				Status: statusAssigned([]string{"28.29.30.0", "4000::"}),
 			},
 		},
 		{
@@ -767,7 +762,7 @@ func TestControllerMutation(t *testing.T) {
 			in: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool5",
+						AnnotationAddressPool: "pool1",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -779,7 +774,7 @@ func TestControllerMutation(t *testing.T) {
 			want: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool5",
+						AnnotationAddressPool: "pool1",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -795,7 +790,7 @@ func TestControllerMutation(t *testing.T) {
 			in: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool1",
+						AnnotationAddressPool: "pool2",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -807,7 +802,7 @@ func TestControllerMutation(t *testing.T) {
 			want: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool1",
+						AnnotationAddressPool: "pool2",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -815,7 +810,7 @@ func TestControllerMutation(t *testing.T) {
 					ClusterIPs:     []string{"1.2.3.4", "1000::"},
 					IPFamilyPolicy: &IPFamilyPolicyPreferDualStack,
 				},
-				Status: statusAssigned([]string{"1.2.3.0"}),
+				Status: statusAssigned([]string{"3.4.5.6"}),
 			},
 		},
 		{
@@ -823,7 +818,7 @@ func TestControllerMutation(t *testing.T) {
 			in: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool3",
+						AnnotationAddressPool: "pool4",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -835,7 +830,7 @@ func TestControllerMutation(t *testing.T) {
 			want: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						AnnotationAddressPool: "pool3",
+						AnnotationAddressPool: "pool4",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -843,7 +838,7 @@ func TestControllerMutation(t *testing.T) {
 					ClusterIPs:     []string{"1000::1"},
 					IPFamilyPolicy: &IPFamilyPolicyPreferDualStack,
 				},
-				Status: statusAssigned([]string{"1000::"}),
+				Status: statusAssigned([]string{"2000::1"}),
 			},
 		},
 		{

--- a/controller/main.go
+++ b/controller/main.go
@@ -101,10 +101,10 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	// Normally, we would check the svc object within convergeBalancer.
 	// However, generating an event every time the svc is processed would be very noisy.
 	// Therefore, we check for deprecated annotations only, if there is something to do.
-	for key := range svcRo.Annotations {
+	for key := range svc.Annotations {
 		if strings.HasPrefix(key, DeprecatedAnnotationPrefix) {
 			level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", key, "msg", "The used annotation is deprecated. Support might get removed in future versions")
-			c.client.Errorf(svcRo, "deprecatedAnnotation", "Service uses deprecated annotation %s", key)
+			c.client.Errorf(svc, "deprecatedAnnotation", "Service uses deprecated annotation %s", key)
 		}
 	}
 

--- a/controller/service.go
+++ b/controller/service.go
@@ -214,6 +214,9 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	}
 	svc.Annotations[AnnotationIPAllocateFromPool] = pool
 
+	// Remove deprecated annotation set by old MetalLB versions.
+	delete(svc.Annotations, DeprecatedAnnotationIPAllocateFromPool)
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug


**What this PR does / why we need it**:

Fixes #2642.

**Special notes for your reviewer**:

The fix itself is very simple, most of the code in this PR is improvements for the controller tests.

Summary of the changes:

- Fixed controller tests containing overlapping IP pools. It is normally impossible to create overlapping IP pools because the IPAdressPool validation webhook prevents it.
- Fixed controller tests ignoring annotations changed by the controller. UpdateStatus in the Kubernetes API updates the object meta, but the mocked client ignored object meta changes.
- Fixed pool assignment in tests not being deterministic because of multiple pools with auto assign enabled.
- Added expected annotations to all controller tests.
- Added tests ensuring the deprecated annotation is removed with no warnings.
- Fixed the issue by removing the deprecated annotation from resources.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed deprecated `metallb.universe.tf/ip-allocated-from-pool` annotation remaining on Service resources and causing warnings.
```
