### PR TITLE
Add redirect for the metallb.io/metallb vanity url

### DIFF
--- a/website/content/metallb.md
+++ b/website/content/metallb.md
@@ -1,0 +1,4 @@
+---
+title: "vanity url"
+layout: vanityurl
+---

--- a/website/layouts/_default/vanityurl.html
+++ b/website/layouts/_default/vanityurl.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta name="go-import" content="metallb.io/metallb git https://github.com/metallb/metallb">
+<meta name="go-source" content="metallb.io/metallb https://github.com/metallb/metallb https://github.com/metallb/metallb/tree/master{/dir} https://github.com/metallb/metallb/blob/master{/dir}/{file}#L{line}">
+<meta http-equiv="refresh" content="0; url=https://godoc.org/metallb.io/metallb">
+</head>
+<body>
+Nothing to see here; <a href="https://godoc.org/metallb.io/metallb">move along</a>.
+</body>
+</html>


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
As part of the process of moving from metallb.universe.tf to metallb.io, we'd have to rename the package.
In order to do so, a vanity url page must be implemented to refer metallb.io/metallb to the actual repo.

Note: this could made parametric, and it will probably make sense to do so if we need vanity urls for frr-k8s and / or a separated test repo.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
