### PR TITLE
Reprocess services if shareability of a given service changes

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -78,9 +78,17 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	syncStateRes := controllers.SyncStateSuccess
 
 	prevIPs := c.ips.IPs(name)
+	prevAllocKey := c.ips.AllocationKey(name)
 
 	if c.convergeBalancer(l, name, svc) != nil {
 		syncStateRes = controllers.SyncStateErrorNoRetry
+	}
+
+	newAllocKey := c.ips.AllocationKey(name)
+
+	if prevAllocKey != newAllocKey {
+		level.Debug(l).Log("event", "allocation key changed", "msg", "allocation changed for shared service, reprocessing")
+		syncStateRes = controllers.SyncStateReprocessAll
 	}
 
 	if reflect.DeepEqual(svcRo, svc) {

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -389,7 +389,6 @@ var _ = ginkgo.Describe("BGP", func() {
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
 				svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
-				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort)
 			})
 		defer testservice.Delete(cs, svc)
 		svc1, _ := testservice.CreateWithBackendPort(cs, testNamespace, "second-service",
@@ -397,7 +396,6 @@ var _ = ginkgo.Describe("BGP", func() {
 			func(svc *corev1.Service) {
 				svc.Spec.LoadBalancerIP = serviceIP
 				svc.Annotations = map[string]string{"metallb.io/allow-shared-ip": "foo"}
-				svc.Spec.Ports[0].Port = int32(testservice.TestServicePort + 1)
 			})
 		defer testservice.Delete(cs, svc1)
 

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -19,6 +19,7 @@ import (
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 
 	jigservice "go.universe.tf/e2etest/pkg/jigservice"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -27,7 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const secondNamespace = "test-namespace"
+const (
+	secondNamespace         = "test-namespace"
+	allowSharedIPAnnotation = "metallb.io" + "/" + "allow-shared-ip"
+)
 
 var (
 	firstNsLabels = map[string]string{
@@ -220,6 +224,99 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			for i := 0; i < numOfRestarts; i++ {
 				restartAndAssert()
 			}
+		})
+
+		ginkgo.It("should reconsider services when sharing the ip and conditions change", func() {
+			ip, err := config.GetIPFromRangeByIndex(IPV4ServiceRange, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "singleip-pool",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{
+								fmt.Sprintf("%s/32", ip),
+							},
+						},
+					},
+				},
+			}
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkHasLBIP := func(svc *corev1.Service, ip string) {
+				Eventually(func() string {
+					s, err := cs.CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					if len(s.Status.LoadBalancer.Ingress) == 0 {
+						return ""
+					}
+					return s.Status.LoadBalancer.Ingress[0].IP
+				}, time.Minute, 1*time.Second).Should(Equal(ip))
+			}
+
+			checkLBIPGetsRemoved := func(svc *corev1.Service) {
+				Eventually(func() int {
+					s, err := cs.CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					return len(s.Status.LoadBalancer.Ingress)
+				}, time.Minute, 1*time.Second).Should(BeZero())
+			}
+
+			svc, jig := service.CreateWithBackendPort(cs, testNamespace, "changesharing", 80, func(svc *corev1.Service) {
+				service.TrafficPolicyCluster(svc)
+				svc.Annotations = map[string]string{allowSharedIPAnnotation: "share"}
+			})
+
+			ginkgo.By("Creating another service")
+			svc1, jig1 := service.CreateWithBackendPort(cs, testNamespace, "changesharing1", 81, func(svc *corev1.Service) {
+				service.TrafficPolicyCluster(svc)
+				svc.Annotations = map[string]string{allowSharedIPAnnotation: "share"}
+				svc.Spec.Selector = jig.Labels // assigning the same selector to the two services
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				service.Delete(cs, svc)
+				service.Delete(cs, svc1)
+			}()
+
+			checkHasLBIP(svc, ip)
+			checkHasLBIP(svc1, ip)
+
+			ginkgo.By("changing etp policy of the second service to local")
+			jig1.UpdateService(context.Background(), func(svc *corev1.Service) {
+				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+			})
+
+			ginkgo.By("checking the second service loses its ip")
+			checkLBIPGetsRemoved(svc1)
+
+			ginkgo.By("changing etp policy of the first service to local")
+			jig.UpdateService(context.Background(), func(svc *corev1.Service) {
+				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+			})
+
+			ginkgo.By("checking both services now got their ips")
+			checkHasLBIP(svc, ip)
+			checkHasLBIP(svc1, ip)
+
+			ginkgo.By("changing the selector of the first service")
+			jig.UpdateService(context.Background(), func(svc *corev1.Service) {
+				svc.Spec.Selector = map[string]string{"foo": "bar"}
+			})
+			ginkgo.By("checking the first service loses its ip")
+			checkLBIPGetsRemoved(svc)
+
+			ginkgo.By("aligning the selector of the second service")
+			jig1.UpdateService(context.Background(), func(svc *corev1.Service) {
+				svc.Spec.Selector = map[string]string{"foo": "bar"}
+			})
+			checkHasLBIP(svc, ip)
+			checkHasLBIP(svc1, ip)
 		})
 	})
 

--- a/e2etest/l2tests/assignment.go
+++ b/e2etest/l2tests/assignment.go
@@ -295,6 +295,13 @@ var _ = ginkgo.Describe("IP Assignment", func() {
 			ginkgo.By("checking the second service loses its ip")
 			checkLBIPGetsRemoved(svc1)
 
+			ginkgo.By("checking the first service keeps its ip")
+			Consistently(func() string {
+				toCheck, err := cs.CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return toCheck.Status.LoadBalancer.Ingress[0].IP
+			}, 2*time.Minute, 1*time.Second).Should(Equal(ip))
+
 			ginkgo.By("changing etp policy of the first service to local")
 			jig.UpdateService(context.Background(), func(svc *corev1.Service) {
 				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal

--- a/e2etest/pkg/service/create.go
+++ b/e2etest/pkg/service/create.go
@@ -50,6 +50,7 @@ func Delete(cs clientset.Interface, svc *corev1.Service) {
 }
 
 func tweakServicePort(svc *corev1.Service, port int) {
+	svc.Spec.Ports[0].Port = int32(port)
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(port)
 }
 

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -541,6 +541,13 @@ func (a *Allocator) IPs(svc string) []net.IP {
 	return nil
 }
 
+func (a *Allocator) AllocationKey(svc string) string {
+	if alloc := a.allocated[svc]; alloc != nil {
+		return alloc.key.backend + alloc.key.sharing
+	}
+	return ""
+}
+
 // PoolForIP returns the pool structure associated with an IP.
 func (a *Allocator) PoolForIP(ips []net.IP) *config.Pool {
 	return poolFor(a.pools.ByName, ips)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

If the sharing criteria (ETP, endpoint selector) of a given service change, it might mean that the IP can be shared with other services.
Because of this,  we reprocess all the services.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Reprocess the services and reassign IPs if the sharing criteria of a given service changes (ie, the external traffic policy changes and suddenly another service in pending becomes compatible).
```

Fixes https://github.com/metallb/metallb/issues/2403