### PR TITLE
Docs: specify the service account to use on OCP / helm

### DIFF
--- a/website/content/installation/clouds.md
+++ b/website/content/installation/clouds.md
@@ -85,6 +85,9 @@ load balancers work. You can do this with:
 oc adm policy add-scc-to-user privileged -n metallb-system -z speaker
 ```
 
+Please note that if you are deploying MetalLB via helm, the ServiceAccount
+name is metallb-speaker.
+
 After that, MetalLB should work normally.
 
 ### MetalLB on OpenStack


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
/kind documentation
> /kind regression

**What this PR does / why we need it**:

The documentation explains how to enable the service account in case MetalLB was deployed via the manifests, but not via the Helm Charts.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Docs: clarify how to install on Openshift via Helm.
```

Fixes https://github.com/metallb/metallb/issues/2422