### PR TITLE
IP Assignement: match clusterip family in case of single stack clusterip

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -847,6 +847,51 @@ func TestControllerMutation(t *testing.T) {
 			},
 		},
 		{
+			desc: "request IPs from dualstack pool with PreferDualStack policy but single stack clusterip",
+			in: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationAddressPool: "pool5",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4"},
+					IPFamilyPolicy: &IPFamilyPolicyPreferDualStack,
+				},
+			},
+			want: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationAddressPool: "pool5",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4"},
+					IPFamilyPolicy: &IPFamilyPolicyPreferDualStack,
+				},
+				Status: statusAssigned([]string{"1.2.3.0"}),
+			},
+		},
+		{
+			desc: "request IPs from dualstack pool with RequireDualStack policy but single stack clusterip",
+			in: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationAddressPool: "pool5",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:           "LoadBalancer",
+					ClusterIPs:     []string{"1.2.3.4"},
+					IPFamilyPolicy: &IPFamilyPolicyRequireDualStack,
+				},
+			},
+			wantErr: true,
+		},
+
+		{
 			desc: "request specific loadbalancer IP with dual-stack",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{

--- a/internal/allocator/allocation.go
+++ b/internal/allocator/allocation.go
@@ -58,6 +58,14 @@ func (a *Allocation) selectIPsForFamilyAndPolicy(
 	ipv4 := a.getIPForFamily(ipfamily.IPv4)
 	ipv6 := a.getIPForFamily(ipfamily.IPv6)
 
+	// if we don't have dual cluster ips, we should align the lb ip to the clusterip
+	if serviceIPFamily == ipfamily.IPv4 {
+		return []net.IP{ipv4}, nil
+	}
+	if serviceIPFamily == ipfamily.IPv6 {
+		return []net.IP{ipv6}, nil
+	}
+
 	switch serviceIPFamilyPolicy {
 	case v1.IPFamilyPolicySingleStack:
 		if ip := a.getIPForFamily(serviceIPFamily); ip != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

There is no point in adding a dual stack loadbalancer ip if the cluster ip is single family.

Additionally, when they do not match we feel free to clean the service and reassign:
https://github.com/metallb/metallb/blob/v0.14.9/controller/service.go#L109

which might cause an active service to change its ip.


Fixes https://github.com/metallb/metallb/issues/2724 and https://github.com/metallb/metallb/issues/2723

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Even if the service is prefer dual stack and dual stack pools are available, provide loadbalancer ips that match address family (single, dual) of the service's cluster ip.
```
