### PR TITLE
E2E:  BGP graceful restart tests as flaky, repeat 3 times

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -156,8 +156,9 @@ var _ = ginkgo.Describe("BGP", func() {
 			}),
 	)
 
-	ginkgo.Describe("GracefulRestart, when speakers restart", func() {
+	markFlaky := []any{ginkgo.Label("flaky"), ginkgo.FlakeAttempts(3)}
 
+	ginkgo.Describe("GracefulRestart, when speakers restart", markFlaky, func() {
 		ginkgo.AfterEach(func() {
 			for _, c := range FRRContainers {
 				c.NeighborConfig.GracefulRestart = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:
This test requires pod restart, is timing critical (pod must be healthy within 2minutes) 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
