### PR TITLE
Add Deutsche Telekom's Das SCHIFF / T-CaaS as an adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,6 +7,7 @@
 
 | Type | Name | Since | Website | Use-Case |
 |:-|:-|:-|:-|:-|
+| End-user | Deutsche Telekom AG | 2021 | [link](https://www.telekom.com) | MetalLB is used as the LoadBalancer in our own horizontal Telco Cloud platform [Das SCHIFF / T-CaaS](https://github.com/telekom/das-schiff) among several other use cases |
 | Vendor | Red Hat, Inc. | 2022 | [link](https://www.redhat.com) | MetalLB is distributed together with Red Hat's Openshift containers platform, as the supported implementation of LoadBalancer services on Bare Metal|
 | Vendor | SUSE | 2023 | [link](https://www.suse.com) | MetalLB is a core part of the SUSE Edge solution serving as a LoadBalancer on Bare Metal, as well as load balancing the Kubernetes API in highly available topologies |
 


### PR DESCRIPTION
Add Deutsche Telekom AG as a adopter of MetalLB.

We are a heavy user of the project in our horizontal telco cloud stack, using the metallb-controller in all instances and metallb-speaker in some of the deployments.
