### PR TITLE
stop running full ci-suite on adopters update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
       - 'LICENSE'
       - 'netlify.toml'
       - 'README.md'
+      - 'ADOPTERS.md'
     branches:
       - "main"
       - "v**"


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**: 

/kind cleanup


**What this PR does / why we need it**:

This updates the CI suite to not run on update of the ADOPTERS.md markdown file.

**Special notes for your reviewer**: Similar to ignoring other markdown updates, this will save time and cycles on CI when the only update is a markdown file.

**Release note**:

```release-note
NONE
```
