### PR TITLE
Add webhookSecretName support to the metallb helm chart

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -188,7 +188,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: metallb-webhook-cert
+          secretName: {{ .Values.controller.webhookSecretName | quote }}
       {{- if .Values.prometheus.controllerMetricsTLSSecret }}
       - name: metrics-certs
         secret:

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -71,6 +71,9 @@ spec:
         {{- if .Values.controller.webhookMode }}
         - --webhook-mode={{ .Values.controller.webhookMode }}
         {{- end }}
+        {{- if .Values.controller.webhookSecretName }}
+        - --webhook-secret={{ .Values.controller.webhookSecretName }}
+        {{- end }}
         {{- if .Values.controller.tlsMinVersion }}
         - --tls-min-version={{ .Values.controller.tlsMinVersion }}
         {{- end }}

--- a/charts/metallb/templates/webhooks.yaml
+++ b/charts/metallb/templates/webhooks.yaml
@@ -144,7 +144,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: metallb-webhook-cert
+  name: {{ .Values.controller.webhookSecretName | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -320,6 +320,9 @@
             "webhookMode" : {
               "type": "string"
             },
+            "webhookSecretName" : {
+              "type": "string"
+            },
             "extraContainers": {
               "type": "array",
               "items": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -196,6 +196,7 @@ controller:
   logLevel: info
   # command: /controller
   # webhookMode: enabled
+  # webhookSecretName: webhook-server-cert
   image:
     repository: quay.io/metallb/controller
     tag:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Recently webhookSecretName was added as webhook-secret to the controller cli arguments.   This PR modifies the helm chart to allow overriding this value via helm.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Added controller.webhookSecretMode to helm chart values to allow setting --webhook-secret for controller runtime.
```
