### PR TITLE
Document MetalLB on OpenStack

### DIFF
--- a/website/content/installation/clouds.md
+++ b/website/content/installation/clouds.md
@@ -93,15 +93,29 @@ After that, MetalLB should work normally.
 ### MetalLB on OpenStack
 
 You can run a Kubernetes cluster on OpenStack VMs, and use MetalLB as
-the load balancer. However you have to disable OpenStack's ARP
-spoofing protection if you want to use L2 mode. You must disable it on
-all the VMs that are running Kubernetes.
+the load balancer. However you have to account for OpenStack's ARP
+spoofing protection if you want to use L2 mode.
 
 By design, MetalLB's L2 mode looks like an ARP spoofing attempt to
 OpenStack, because we're announcing IP addresses that OpenStack
-doesn't know about. There's currently no way to make OpenStack
-cooperate with MetalLB here, so we have to turn off the spoofing
-protection entirely.
+doesn't know about.
+
+In order to account for this, you must add those IP addresses to the allowed 
+addresses for the network ports of kubernetes nodes that may host a MetalLB 
+speaker pod.
+
+You must also create network ports for the addresses that MetalLB will hold.
+These ports are not to be attached to an OpenStack server.
+
+To these ports, associate floating IP addresses. The floating IP lisitng will
+present you with pairs of floating IP address and fixed IP address. Assign
+the fixed IP addresses to MetalLB IPAddressPool resources. Also, add the fixed
+ip addresses as allowed addresses to the ports that may hold the IP address.
+
+Traffic to the floating IP address will be routed to the port holding the 
+floating IP address. The port is down, but the traffic is routed to the 
+correct network. The L2 advertisement ensures the packets are then routed
+to the port of the node holding the fixed IP address.
 
 ### MetalLB on Equinix Metal
 


### PR DESCRIPTION
Add documentation of a way of using MetalLB on OpenStack without turning off port security.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
/kind documentation
> /kind regression

**What this PR does / why we need it**:
The PR documents openstack a set-up that avoids turning off port security.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
