### PR TITLE
Helm: add option to exclude pools from triggering alerts

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -79,8 +79,10 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.podMonitor.relabelings | list | `[]` |  |
 | prometheus.prometheusRule.additionalLabels | object | `{}` |  |
 | prometheus.prometheusRule.addressPoolExhausted.enabled | bool | `true` |  |
+| prometheus.prometheusRule.addressPoolExhausted.excludePools | string | `""` |  |
 | prometheus.prometheusRule.addressPoolExhausted.labels.severity | string | `"critical"` |  |
 | prometheus.prometheusRule.addressPoolUsage.enabled | bool | `true` |  |
+| prometheus.prometheusRule.addressPoolUsage.excludePools | string | `""` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[0].labels.severity | string | `"warning"` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[0].percent | int | `75` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[1].labels.severity | string | `"warning"` |  |

--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -41,11 +41,12 @@ spec:
       {{- end }}
     {{- end }}
     {{- if .Values.prometheus.prometheusRule.addressPoolExhausted.enabled }}
+    {{ $exclude := .Values.prometheus.prometheusRule.addressPoolExhausted.excludePools }}
     - alert: MetalLBAddressPoolExhausted
       annotations:
         summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
         description: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has exhausted address pool {{ $labels.pool }} for > 1 minute'`}}
-      expr: metallb_allocator_addresses_in_use_total >= on(pool) metallb_allocator_addresses_total
+      expr: metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} >= on(pool) metallb_allocator_addresses_total
       for: 1m
       {{- with .Values.prometheus.prometheusRule.addressPoolExhausted.labels }}
       labels:
@@ -54,12 +55,13 @@ spec:
     {{- end }}
 
     {{- if .Values.prometheus.prometheusRule.addressPoolUsage.enabled }}
+    {{ $exclude := .Values.prometheus.prometheusRule.addressPoolUsage.excludePools }}
     {{- range .Values.prometheus.prometheusRule.addressPoolUsage.thresholds }}
     - alert: MetalLBAddressPoolUsage{{ .percent }}Percent
       annotations:
         summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
         message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has address pool {{ $labels.pool }} past `}}{{ .percent }}{{`% usage for > 1 minute'`}}
-      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total ) * 100 > {{ .percent }}
+      expr: ( metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} / on(pool) metallb_allocator_addresses_total ) * 100 > {{ .percent }}
       {{- with .labels }}
       labels:
         {{- toYaml . | nindent 8 }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -166,6 +166,8 @@ prometheus:
       enabled: true
       labels:
         severity: critical
+      # Exclude the pools matching the regular expression from triggering the alert.
+      excludePools: ""
 
     addressPoolUsage:
       enabled: true
@@ -179,6 +181,8 @@ prometheus:
         - percent: 95
           labels:
             severity: critical
+      # Exclude the pools matching the regular expression from triggering the alert.
+      excludePools: ""
 
     # MetalLBBGPSessionDown
     bgpSessionDown:


### PR DESCRIPTION
We have some alerts that don't make sense for pools that have `autoAssign: false`, so we add a general way to exclude pools from triggering the relevant alerts.
Fixes https://github.com/metallb/metallb/issues/2665

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
/kind feature

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
helm: Add option to exclude pools from triggering the relevant prometheus alerts
```
