### PR TITLE
Augment logs for easier debugging

### DIFF
--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -82,12 +82,12 @@ func nodesWithEndpoint(eps []discovery.EndpointSlice, speakers map[string]bool) 
 func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce []net.IP, pool *config.Pool, svc *v1.Service, eps []discovery.EndpointSlice, nodes map[string]*v1.Node) string {
 	if !activeEndpointExists(eps) { // no active endpoints, just return
 		level.Debug(l).Log("event", "shouldannounce", "protocol", "l2", "message", "failed no active endpoints", "service", name)
-		return "notOwner"
+		return "noActiveEndpoints"
 	}
 
 	if !poolMatchesNodeL2(pool, c.myNode) {
 		level.Debug(l).Log("event", "skipping should announce l2", "service", name, "reason", "pool not matching my node")
-		return "notOwner"
+		return "poolNotMatchingNode"
 	}
 
 	speakerMap := c.speakersForPool(l, name, pool, nodes)
@@ -98,7 +98,7 @@ func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce 
 
 	if len(availableNodes) == 0 {
 		level.Debug(l).Log("event", "skipping should announce l2", "service", name, "reason", "no available nodes")
-		return "notOwner"
+		return "nodesUnavailable"
 	}
 
 	level.Debug(l).Log("event", "shouldannounce", "protocol", "l2", "nodes", availableNodes, "service", name)

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -363,9 +363,10 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 		},
 	}
 	c1, err := newController(controllerConfig{
-		MyNode: "iris1",
-		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
-		SList:  fakeSL,
+		MyNode:  "iris1",
+		Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:   fakeSL,
+		bgpType: bgpNative,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
@@ -373,9 +374,10 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 	c1.client = &testK8S{t: t}
 
 	c2, err := newController(controllerConfig{
-		MyNode: "iris2",
-		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
-		SList:  fakeSL,
+		MyNode:  "iris2",
+		Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:   fakeSL,
+		bgpType: bgpNative,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
@@ -499,10 +501,10 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				},
 			},
 			c1ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noActiveEndpoints",
 			},
 			c2ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noActiveEndpoints",
 			},
 		}, {
 			desc: "One service, two endpoints across two hosts, controller2 should announce",
@@ -602,10 +604,10 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				},
 			},
 			c1ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noActiveEndpoints",
 			},
 			c2ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noActiveEndpoints",
 			},
 		}, {
 			desc: "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
 /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
The logs emitted by the l2_controller shouldAnnounce was the same for different reasons the announcement was not done. Updating the logs will make it easy to debug the issues.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
