### PR TITLE
Adjust permission modes for speaker volumes

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -183,12 +183,12 @@ spec:
         - name: memberlist
           secret:
             secretName: {{ include "metallb.secretName" . }}
-            defaultMode: 420
+            defaultMode: 256
       {{- end }}
       {{- if .Values.speaker.excludeInterfaces.enabled }}
         - name: metallb-excludel2
           configMap:
-            defaultMode: 256
+            defaultMode: 416
             name: metallb-excludel2
       {{- end }}
       {{- if .Values.speaker.frr.enabled }}

--- a/config/controllers/speaker.yaml
+++ b/config/controllers/speaker.yaml
@@ -108,8 +108,8 @@ spec:
       - name: memberlist 
         secret: 
           secretName: memberlist
-          defaultMode: 420
+          defaultMode: 256
       - name: metallb-excludel2
         configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3551,10 +3551,10 @@ spec:
       volumes:
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -3405,10 +3405,10 @@ spec:
       volumes:
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2389,10 +2389,10 @@ spec:
         name: metrics
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2212,10 +2212,10 @@ spec:
         name: metrics
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -2135,10 +2135,10 @@ spec:
       volumes:
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1989,10 +1989,10 @@ spec:
       volumes:
       - name: memberlist
         secret:
-          defaultMode: 420
+          defaultMode: 256
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 416
           name: metallb-excludel2
         name: metallb-excludel2
 ---


### PR DESCRIPTION
- `256` in decimal is `0400` in octal (read-only for owner, no permissions for group and others)
- `416` in decimal is `0640` in octal (read/write for owner, read-only for group, no permissions for others)

Note: `kubectl kustomize`  converts the octal value  to its decimal
/kind bug

```release-note
Fix Incorrect Permissions for Secret and ConfigMap in Speaker DaemonSet
```

Fixes 2738