### PR TITLE
bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,54 +1,72 @@
+version: "2"
 run:
   issues-exit-code: 2
 linters:
   enable:
-  - godot
-  - goimports
-  - gofmt
-  - ginkgolinter
-  - dogsled
-  - copyloopvar
-  - gocritic
-  - misspell
-  - nolintlint
-  - stylecheck
-  - unconvert
-  - unparam
-  - whitespace
-  - revive
-  - unused
-  - wastedassign
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - (github.com/go-kit/log.Logger).Log
-  godot:
-    scope: toplevel
-    capital: true
-    exclude:
-    - 'SPDX-License-Identifier.*'
-    - '\+groupName.*'
-  misspell:
-    locale: US
-    ignore-words:
-      - neighbours
-      - neighbour
-  stylecheck:
-    dot-import-whitelist:
-    - github.com/onsi/ginkgo
-    - github.com/onsi/gomega
-  gocritic:
-    disabled-checks:
-      - captLocal
-      - exitAfterDefer
-  revive:
+    - copyloopvar
+    - dogsled
+    - ginkgolinter
+    - gocritic
+    - godot
+    - misspell
+    - nolintlint
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
+  settings:
+    errcheck:
+      exclude-functions:
+        - (github.com/go-kit/log.Logger).Log
+    gocritic:
+      disabled-checks:
+        - captLocal
+        - exitAfterDefer
+    godot:
+      scope: toplevel
+      exclude:
+        - SPDX-License-Identifier.*
+        - \+groupName.*
+      capital: true
+    misspell:
+      locale: US
+      ignore-rules:
+        - neighbours
+        - neighbour
+    revive:
+      rules:
+        - name: receiver-naming
+          disabled: true
+        - name: dot-imports
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo
+        - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-    - name: receiver-naming
-      disabled: true
-    - name: dot-imports
-      disabled: true
-issues:
-  exclude-rules:
-    - path: 'api'
-      linters:
-        - stylecheck
+      - linters:
+          - staticcheck
+        path: api
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -29,13 +29,13 @@ func diffService(a, b *v1.Service) string {
 	if a != nil {
 		newA := new(v1.Service)
 		*newA = *a
-		newA.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+		newA.DeletionTimestamp = &metav1.Time{}
 		a = newA
 	}
 	if b != nil {
 		newB := new(v1.Service)
 		*newB = *b
-		newB.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+		newB.DeletionTimestamp = &metav1.Time{}
 		b = newB
 	}
 	return cmp.Diff(a, b)

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -562,7 +562,7 @@ func (a *Allocator) IPs(svc string) []net.IP {
 
 func (a *Allocator) AllocationKey(svc string) string {
 	if alloc := a.allocated[svc]; alloc != nil {
-		return alloc.key.backend + alloc.key.sharing
+		return alloc.backend + alloc.sharing
 	}
 	return ""
 }

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1229,12 +1229,17 @@ func TestPoolAllocation(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: AllocateFromPool(%q, \"test\"): %s", test.desc, test.svcKey, err)
 		}
-		validIPs := validIP4s
-		if test.ipFamily == ipfamily.IPv6 {
+
+		var validIPs map[string]bool
+		switch test.ipFamily {
+		case ipfamily.IPv6:
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		case ipfamily.DualStack:
 			validIPs = validIPDualStacks
+		default:
+			validIPs = validIP4s
 		}
+
 		for _, ip := range ips {
 			if !validIPs[ip.String()] {
 				t.Errorf("%s: allocated unexpected IP %q", test.desc, ip)
@@ -1605,12 +1610,16 @@ func TestAllocation(t *testing.T) {
 			t.Errorf("%s: Allocate(%q, \"test\"): %s", test.desc, test.svcKey, err)
 		}
 
-		validIPs := validIP4s
-		if test.ipFamily == ipfamily.IPv6 {
+		var validIPs map[string]bool
+		switch test.ipFamily {
+		case ipfamily.IPv6:
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		case ipfamily.DualStack:
 			validIPs = validIPDualStacks
+		default:
+			validIPs = validIP4s
 		}
+
 		for _, ip := range ips {
 			if !validIPs[ip.String()] {
 				t.Errorf("%s allocated unexpected IP %q", test.desc, ip)
@@ -2022,11 +2031,14 @@ func TestAutoAssign(t *testing.T) {
 		if err != nil {
 			t.Errorf("#%d Allocate(%q, \"test\"): %s", i+1, test.svcKey, err)
 		}
-		validIPs := validIP4s
-		if test.ipFamily == ipfamily.IPv6 {
+		var validIPs map[string]bool
+		switch test.ipFamily {
+		case ipfamily.IPv6:
 			validIPs = validIP6s
-		} else if test.ipFamily == ipfamily.DualStack {
+		case ipfamily.DualStack:
 			validIPs = validIPDualStacks
+		default:
+			validIPs = validIP4s
 		}
 		for _, ip := range ips {
 			if !validIPs[ip.String()] {

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -55,8 +55,8 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 var requestHandler = func(r *ConfigReconciler, ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "ConfigReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "ConfigReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "ConfigReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "ConfigReconciler", "end reconcile", req.String())
 	updates.Inc()
 
 	var ipAddressPools metallbv1beta1.IPAddressPoolList

--- a/internal/k8s/controllers/frrk8s_config_controller.go
+++ b/internal/k8s/controllers/frrk8s_config_controller.go
@@ -75,8 +75,8 @@ type FRRK8sReconciler struct {
 }
 
 func (r *FRRK8sReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "FRRK8sReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "FRRK8sReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "FRRK8sReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "FRRK8sReconciler", "end reconcile", req.String())
 	updates.Inc()
 
 	r.Lock()

--- a/internal/k8s/controllers/layer2_status_controller.go
+++ b/internal/k8s/controllers/layer2_status_controller.go
@@ -65,14 +65,14 @@ type Layer2StatusReconciler struct {
 }
 
 func (r *Layer2StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "Layer2StatusReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "Layer2StatusReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "Layer2StatusReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "Layer2StatusReconciler", "end reconcile", req.String())
 
 	serviceName, serviceNamespace := req.Name, req.Namespace
 
 	ipAdvS := r.StatusFetcher(types.NamespacedName{Name: serviceName, Namespace: serviceNamespace})
 	var serviceL2statuses v1beta1.ServiceL2StatusList
-	if err := r.Client.List(ctx, &serviceL2statuses, client.MatchingFields{
+	if err := r.List(ctx, &serviceL2statuses, client.MatchingFields{
 		serviceIndexName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}.String(),
 	}); err != nil {
 		return ctrl.Result{}, err
@@ -84,7 +84,7 @@ func (r *Layer2StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			if item.Labels[LabelAnnounceNode] != r.NodeName {
 				continue
 			}
-			if err := r.Client.Delete(ctx, &serviceL2statuses.Items[key]); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, &serviceL2statuses.Items[key]); err != nil && !errors.IsNotFound(err) {
 				errs = append(errs, err)
 			}
 		}
@@ -98,7 +98,7 @@ func (r *Layer2StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			if serviceL2statuses.Items[i+1].Labels[LabelAnnounceNode] != r.NodeName {
 				continue
 			}
-			if err := r.Client.Delete(ctx, &serviceL2statuses.Items[i+1]); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, &serviceL2statuses.Items[i+1]); err != nil && !errors.IsNotFound(err) {
 				deleteRedundantErrs = append(deleteRedundantErrs, err)
 			}
 		}

--- a/internal/k8s/controllers/node_controller.go
+++ b/internal/k8s/controllers/node_controller.go
@@ -42,8 +42,8 @@ type NodeReconciler struct {
 }
 
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "NodeReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "NodeReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "NodeReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "NodeReconciler", "end reconcile", req.String())
 	updates.Inc()
 
 	var n corev1.Node

--- a/internal/k8s/controllers/pool_controller.go
+++ b/internal/k8s/controllers/pool_controller.go
@@ -45,8 +45,8 @@ type PoolReconciler struct {
 }
 
 func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "PoolReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "PoolReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "PoolReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "PoolReconciler", "end reconcile", req.String())
 	updates.Inc()
 
 	var ipAddressPools metallbv1beta1.IPAddressPoolList

--- a/internal/k8s/controllers/pool_status_controller.go
+++ b/internal/k8s/controllers/pool_status_controller.go
@@ -50,8 +50,8 @@ type PoolStatusReconciler struct {
 }
 
 func (r *PoolStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "PoolStatusReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "PoolStatusReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "PoolStatusReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "PoolStatusReconciler", "end reconcile", req.String())
 
 	var pool v1beta1.IPAddressPool
 	err := r.Get(ctx, req.NamespacedName, &pool)

--- a/internal/k8s/controllers/service_controller.go
+++ b/internal/k8s/controllers/service_controller.go
@@ -61,8 +61,8 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "ServiceReconciler", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "ServiceReconciler", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "ServiceReconciler", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "ServiceReconciler", "end reconcile", req.String())
 	updates.Inc()
 
 	var service *v1.Service
@@ -94,14 +94,14 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
 	if service != nil {
 		level.Debug(r.Logger).Log("controller", "ServiceReconciler", "processing service", dumpResource(service))
 	} else {
-		level.Debug(r.Logger).Log("controller", "ServiceReconciler", "processing deletion on service", req.NamespacedName.String())
+		level.Debug(r.Logger).Log("controller", "ServiceReconciler", "processing deletion on service", req.String())
 	}
 
-	res := r.Handler(r.Logger, req.NamespacedName.String(), service, epSlices)
+	res := r.Handler(r.Logger, req.String(), service, epSlices)
 	switch res {
 	case SyncStateError:
 		updateErrors.Inc()
-		level.Info(r.Logger).Log("controller", "ServiceReconciler", "name", req.NamespacedName.String(), "service", dumpResource(service), "endpoints", dumpResource(epSlices), "event", "failed to handle service")
+		level.Info(r.Logger).Log("controller", "ServiceReconciler", "name", req.String(), "service", dumpResource(service), "endpoints", dumpResource(epSlices), "event", "failed to handle service")
 		return ctrl.Result{}, errRetry
 	case SyncStateReprocessAll:
 		level.Info(r.Logger).Log("controller", "ServiceReconciler", "event", "force service reload")
@@ -109,7 +109,7 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	case SyncStateErrorNoRetry:
 		updateErrors.Inc()
-		level.Error(r.Logger).Log("controller", "ServiceReconciler", "name", req.NamespacedName.String(), "service", dumpResource(service), "endpoints", dumpResource(epSlices), "event", "failed to handle service")
+		level.Error(r.Logger).Log("controller", "ServiceReconciler", "name", req.String(), "service", dumpResource(service), "endpoints", dumpResource(epSlices), "event", "failed to handle service")
 		return ctrl.Result{}, nil
 	}
 	return ctrl.Result{}, nil

--- a/internal/k8s/controllers/service_controller_reload.go
+++ b/internal/k8s/controllers/service_controller_reload.go
@@ -60,8 +60,8 @@ func isReloadReq(req ctrl.Request) bool {
 }
 
 func (r *ServiceReconciler) reprocessAll(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	level.Info(r.Logger).Log("controller", "ServiceReconciler - reprocessAll", "start reconcile", req.NamespacedName.String())
-	defer level.Info(r.Logger).Log("controller", "ServiceReconciler - reprocessAll", "end reconcile", req.NamespacedName.String())
+	level.Info(r.Logger).Log("controller", "ServiceReconciler - reprocessAll", "start reconcile", req.String())
+	defer level.Info(r.Logger).Log("controller", "ServiceReconciler - reprocessAll", "end reconcile", req.String())
 
 	var services v1.ServiceList
 	if err := r.List(ctx, &services); err != nil {

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -197,10 +197,11 @@ func main() {
 		validateConfig = config.DiscardNativeOnly
 	}
 
-	listenFRRK8s := false
-	if bgpType == string(bgpFrrK8s) {
-		listenFRRK8s = true
-	}
+	// listenFRRK8s := false
+	listenFRRK8s := bgpType == string(bgpFrrK8s)
+	// if bgpType == string(bgpFrrK8s) {
+	// 	listenFRRK8s = true
+	// }
 	client, err := k8s.New(&k8s.Config{
 		ProcessName: "metallb-speaker",
 		NodeName:    *myNode,

--- a/tasks.py
+++ b/tasks.py
@@ -1130,7 +1130,7 @@ def lint(ctx, env="container"):
     convenient to install the golangci-lint binaries on the host. This can be
     achieved by running `inv lint --env host`.
     """
-    version = "1.64.7"
+    version = "2.1.6"
     golangci_cmd = "golangci-lint run --timeout 10m0s ./..."
 
     if env == "container":


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
This bumps `golangci-lint` to the latest v2 release to take advantage of updated linters and converts the config file to use the new config format. Addresses any lints that come along with latest release(s)

**Special notes for your reviewer**:
N/A
**Release note**:
<!--  Write your release note:

```release-note
NONE
```
