### PR TITLE
charts: add option to specify init container resources

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -136,6 +136,9 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
+| speaker.initContainers.cpFrrFiles.resources | object | `{}` |  |
+| speaker.initContainers.cpMetrics.resources | object | `{}` |  |
+| speaker.initContainers.cpReloader.resources | object | `{}` |  |
 | speaker.labels | object | `{}` |  |
 | speaker.livenessProbe.enabled | bool | `true` |  |
 | speaker.livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -216,6 +216,10 @@ spec:
               mountPath: /tmp/frr
             - name: frr-conf
               mountPath: /etc/frr
+          {{- with .Values.speaker.initContainers.cpFrrFiles.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         # Copies the reloader to the shared volume between the speaker and reloader.
         - name: cp-reloader
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -223,6 +227,10 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
+          {{- with .Values.speaker.initContainers.cpReloader.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -230,6 +238,10 @@ spec:
           volumeMounts:
             - name: metrics
               mountPath: /etc/frr_metrics
+          {{- with .Values.speaker.initContainers.cpMetrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       shareProcessNamespace: true
       {{- end }}
       containers:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -414,6 +414,29 @@
                 "resources": { "type": "object" }
               }
             },
+            "initContainers": {
+              "type": "object",
+              "properties": {
+                "cpFrrFiles": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                },
+                "cpReloader": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                },
+                "cpMetrics": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                }
+              }
+            },
             "extraContainers": {
               "type": "array",
               "items": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -352,6 +352,14 @@ speaker:
   frrMetrics:
     resources: {}
 
+  initContainers:
+    cpFrrFiles:
+      resources: {}
+    cpReloader:
+      resources: {}
+    cpMetrics:
+      resources: {}
+
   extraContainers: []
 
 crds:


### PR DESCRIPTION
This provides some value, and makes scanners happier.
Fixes [2774](https://github.com/metallb/metallb/issues/2774)
**Is this a BUG FIX or a FEATURE ?**:


/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
helm charts: add option to specify init container resources
```
