### PR TITLE
Handle better the webhook mode

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -95,9 +95,11 @@ spec:
         ports:
         - name: monitoring
           containerPort: {{ .Values.prometheus.metricsPort }}
+        {{- if and .Values.controller.webhookMode (ne .Values.controller.webhookMode "disabled") }}
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        {{- end }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/charts/metallb/templates/networkpolicy.yaml
+++ b/charts/metallb/templates/networkpolicy.yaml
@@ -35,11 +35,10 @@ spec:
           {{ else }}
           port: {{ .Values.prometheus.metricsPort }}
           {{- end }}
-        {{- if .Values.controller.webhookMode }}
+        {{- if and .Values.controller.webhookMode (ne .Values.controller.webhookMode "disabled") }}
         - protocol: TCP
           port: webhook-server
         {{- end }}
-
   policyTypes:
     - Egress
     - Ingress


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
There is an obvious bug for networkpolicies that should exist when not disabled.
Refactor the networkpolicies test to be able to run when deployed by operator

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
