### PR TITLE
manifests: fix duplicate port name

### DIFF
--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -464,7 +464,7 @@ spec:
             value: /dev/null
         ports:
           - containerPort: {{ .Values.speaker.frr.metricsPort }}
-            name: monitoring
+            name: frrmetrics
         volumeMounts:
           - name: frr-sockets
             mountPath: /var/run/frr

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -110,7 +110,7 @@ spec:
               value: /dev/null
           ports:
             - containerPort: 7473
-              name: monitoring
+              name: frrmetrics
           volumeMounts:
             - name: frr-sockets
               mountPath: /var/run/frr

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2253,7 +2253,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7473
-          name: monitoring
+          name: frrmetrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2076,7 +2076,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7473
-          name: monitoring
+          name: frrmetrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets


### PR DESCRIPTION
This fixes the warning:
```
I0706 12:39:04.892381   38561 warnings.go:110] "Warning: spec.template.spec.containers[3].ports[0]: duplicate port name \"monitoring\" with spec.template.spec.containers[0].ports[0], services and probes that select ports by name will use spec.template.spec.containers[0].ports[0]"
```
aligning the name to frrmetrics as it should have been according to:
```
{{- define "metrics.exposedfrrportname" -}}
{{- if .Values.speaker.frr.secureMetricsPort -}}
"frrmetricshttps"
{{- else -}}
"frrmetrics"
{{- end }}
{{- end }}
```

validated by running:
```
helm install metallb --create-namespace .
```

Fixes https://github.com/metallb/metallb/issues/2768

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
