### PR TITLE
bgp: allow duplicated bgppeer per neighbor ip

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,9 +257,6 @@ func For(resources ClusterResources, validate Validate) (*Config, error) {
 	}
 
 	cfg.BGPExtras = bgpExtrasFor(resources)
-	if err != nil {
-		return nil, err
-	}
 
 	err = validateConfig(cfg)
 	if err != nil {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -5,7 +5,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
@@ -235,7 +234,7 @@ func peerIdentifier(peer metallbv1beta2.BGPPeerSpec) string {
 }
 
 // validateDuplicatePeers validates that duplicate peers (same address/interface + VRF)
-// either have non-overlapping node selectors, or are compatible if they might overlap.
+// have non-overlapping node selectors.
 func validateDuplicatePeers(peerID string, peers []metallbv1beta2.BGPPeer) error {
 	// Check if all duplicate peers have node selectors
 	for _, p := range peers {
@@ -250,35 +249,13 @@ func validateDuplicatePeers(peerID string, peers []metallbv1beta2.BGPPeer) error
 			peer1 := peers[i].Spec
 			peer2 := peers[j].Spec
 
-			// Check if the node selectors might overlap
-			// Note: We can't definitively determine overlap without knowing all node labels,
-			// so we check if selectors are obviously disjoint. If uncertain, we require compatibility.
-			canOverlap := nodeSelectorsCanOverlap(peer1.NodeSelectors, peer2.NodeSelectors)
-
-			if canOverlap {
-				// Selectors might overlap, so peers must be compatible
-				if !arePeersCompatible(peer1, peer2) {
-					return fmt.Errorf("duplicate peers with address/interface %s might select the same nodes but have incompatible configurations (different ASN, ports, timers, BFD profiles, etc.)", peerID)
-				}
+			if nodeSelectorsCanOverlap(peer1.NodeSelectors, peer2.NodeSelectors) {
+				return fmt.Errorf("duplicate peers with address/interface %s have overlapping node selectors and might select the same nodes", peerID)
 			}
 		}
 	}
 
 	return nil
-}
-
-// arePeersCompatible returns true if two peer configurations are compatible
-// (i.e., it would be safe for them to run on the same node).
-// Two peers are compatible if they would create the exact same BGP session configuration.
-// This means all fields must match except NodeSelectors (which determine node eligibility).
-func arePeersCompatible(p1, p2 metallbv1beta2.BGPPeerSpec) bool {
-	// Create copies and clear the NodeSelectors since those don't affect session compatibility
-	p1Copy := p1
-	p2Copy := p2
-	p1Copy.NodeSelectors = nil
-	p2Copy.NodeSelectors = nil
-
-	return reflect.DeepEqual(p1Copy, p2Copy)
 }
 
 // nodeSelectorsCanOverlap returns true if two sets of node selectors might select

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -514,7 +514,59 @@ func TestValidateFRR(t *testing.T) {
 				},
 			},
 			mustFail: true,
-		}, {
+		},
+		{
+			desc: "duplicate bgp address, with nodeSelectors",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"key": "value"},
+								},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"key2": "value2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: false,
+		},
+		{
+			desc: "duplicate bgp address, only one with nodeSelectors",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"key": "value"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
 			desc: "duplicate bgp address, different vrfs",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -516,11 +516,13 @@ func TestValidateFRR(t *testing.T) {
 			mustFail: true,
 		},
 		{
-			desc: "duplicate bgp address, with nodeSelectors",
+			desc: "duplicate bgp address, with nodeSelectors, might overlap - incompatible peers",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
 						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501,
 							Address: "1.2.3.4",
 							NodeSelectors: []v1.LabelSelector{
 								{
@@ -531,10 +533,78 @@ func TestValidateFRR(t *testing.T) {
 					},
 					{
 						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64502, // Different ASN - incompatible
 							Address: "1.2.3.4",
 							NodeSelectors: []v1.LabelSelector{
 								{
 									MatchLabels: map[string]string{"key2": "value2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
+			desc: "duplicate bgp address, with nodeSelectors, might overlap - compatible peers",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501,
+							Address: "1.2.3.4",
+							Port:    179,
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"key": "value"},
+								},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501, // Same config - compatible
+							Address: "1.2.3.4",
+							Port:    179,
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"key2": "value2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: false,
+		},
+		{
+			desc: "duplicate bgp address, with obviously disjoint nodeSelectors - incompatible allowed",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501,
+							Address: "1.2.3.4",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"zone": "us-east"},
+								},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64502, // Different ASN but selectors are disjoint
+							Address: "1.2.3.4",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"zone": "us-west"},
 								},
 							},
 						},
@@ -590,20 +660,16 @@ func TestValidateFRR(t *testing.T) {
 			},
 			mustFail: false,
 		}, {
-			desc: "duplicate bgp address, same vrf",
+			desc: "duplicate bgp address, same vrf, no nodeSelectors",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
 						Spec: v1beta2.BGPPeerSpec{
 							Address: "1.2.3.4",
+							VRFName: "red",
 						},
 					},
 					{
-						Spec: v1beta2.BGPPeerSpec{
-							Address: "1.2.3.4",
-							VRFName: "red",
-						},
-					}, {
 						Spec: v1beta2.BGPPeerSpec{
 							Address: "1.2.3.4",
 							VRFName: "red",
@@ -612,6 +678,39 @@ func TestValidateFRR(t *testing.T) {
 				},
 			},
 			mustFail: true,
+		}, {
+			desc: "duplicate bgp address, same vrf, with disjoint nodeSelectors and compatible config",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501,
+							Address: "1.2.3.4",
+							VRFName: "red",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"zone": "a"},
+								},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:   64500,
+							ASN:     64501,
+							Address: "1.2.3.4",
+							VRFName: "red",
+							NodeSelectors: []v1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"zone": "b"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: false,
 		},
 		{
 			desc: "two peers with interface set different",

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -548,7 +548,7 @@ func TestValidateFRR(t *testing.T) {
 			mustFail: true,
 		},
 		{
-			desc: "duplicate bgp address, with nodeSelectors, might overlap - compatible peers",
+			desc: "duplicate bgp address, with nodeSelectors, might overlap - same config peers",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{
 					{
@@ -567,7 +567,7 @@ func TestValidateFRR(t *testing.T) {
 					{
 						Spec: v1beta2.BGPPeerSpec{
 							MyASN:   64500,
-							ASN:     64501, // Same config - compatible
+							ASN:     64501, // Same config
 							Address: "1.2.3.4",
 							Port:    179,
 							NodeSelectors: []v1.LabelSelector{
@@ -579,7 +579,7 @@ func TestValidateFRR(t *testing.T) {
 					},
 				},
 			},
-			mustFail: false,
+			mustFail: true,
 		},
 		{
 			desc: "duplicate bgp address, with obviously disjoint nodeSelectors - incompatible allowed",

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -64,7 +64,8 @@ type bgpController struct {
 	logger             log.Logger
 	myNode             string
 	nodeLabels         labels.Set
-	peers              []*peer
+	peers              []*peer // filtered peers that should run on this node
+	allPeers           []*peer // all configured peers before filtering
 	svcAds             map[string][]*bgp.Advertisement
 	activeAds          map[string]sets.Set[string] // svc -> the peers it is advertised to
 	activeAdsMutex     sync.RWMutex
@@ -79,13 +80,13 @@ func (c *bgpController) SetConfig(l log.Logger, cfg *config.Config) error {
 	newPeers := make([]*peer, 0, len(cfg.Peers))
 newPeers:
 	for _, p := range cfg.Peers {
-		for i, ep := range c.peers {
+		for i, ep := range c.allPeers {
 			if ep == nil {
 				continue
 			}
 			if reflect.DeepEqual(p, ep.cfg) {
 				newPeers = append(newPeers, ep)
-				c.peers[i] = nil
+				c.allPeers[i] = nil
 				continue newPeers
 			}
 		}
@@ -101,10 +102,15 @@ newPeers:
 		})
 	}
 
-	oldPeers := c.peers
-	c.peers = newPeers
+	oldAllPeers := c.allPeers
+	c.allPeers = newPeers
 
-	for _, p := range oldPeers {
+	// Filter peers by node eligibility and deduplicate before assigning
+	filteredPeers, removed, err := c.filterAndDeduplicatePeers(l, newPeers)
+	c.peers = filteredPeers
+
+	// Close sessions for removed peers (both obsolete and filtered out)
+	for _, p := range oldAllPeers {
 		if p == nil {
 			continue
 		}
@@ -118,13 +124,28 @@ newPeers:
 		level.Debug(l).Log("event", "peerRemoved", "peer", p.id, "reason", "removedFromConfig", "msg", "peer deconfigured, BGP session closed")
 	}
 
-	err := c.syncBFDProfiles(cfg.BFDProfiles)
-	if err != nil {
-		return errors.Join(err, errors.New("failed to sync bfd profiles"))
+	// Close sessions for peers filtered out due to node selector mismatch or duplicates
+	for _, p := range removed {
+		level.Info(l).Log("event", "peerRemoved", "peer", p.id, "reason", p.cfg.Name, "msg", "peer filtered, closing BGP session")
+		if p.session != nil {
+			if closeErr := p.session.Close(); closeErr != nil {
+				level.Error(l).Log("op", "setConfig", "error", closeErr, "peer", p.id, "msg", "failed to shut down BGP session")
+			}
+		}
 	}
-	err = c.sessionManager.SyncExtraInfo(cfg.BGPExtras)
+
+	// If duplicates were found, return error before syncing BFD/sessions
 	if err != nil {
-		return errors.Join(err, errors.New("failed to sync extra info"))
+		return err
+	}
+
+	bfdErr := c.syncBFDProfiles(cfg.BFDProfiles)
+	if bfdErr != nil {
+		return errors.Join(bfdErr, errors.New("failed to sync bfd profiles"))
+	}
+	extraErr := c.sessionManager.SyncExtraInfo(cfg.BGPExtras)
+	if extraErr != nil {
+		return errors.Join(extraErr, errors.New("failed to sync extra info"))
 	}
 
 	return c.syncPeers(l)
@@ -132,6 +153,51 @@ newPeers:
 
 func (c *bgpController) SetEventCallback(callback func(interface{})) {
 	c.sessionManager.SetEventCallback(callback)
+}
+
+// filterAndDeduplicatePeers filters peers based on node selector eligibility
+// and removes duplicates (same address/interface for the same node).
+// Returns the filtered peer list, the list of removed peers, and an error if duplicates were found.
+func (c *bgpController) filterAndDeduplicatePeers(l log.Logger, peers []*peer) ([]*peer, []*peer, error) {
+	var filtered []*peer
+	var removed []*peer
+	var duplicateFound bool
+	seen := make(map[string]bool) // track peer IDs we've already added
+
+	for _, p := range peers {
+		// Check if peer matches this node's labels
+		shouldRun := len(p.cfg.NodeSelectors) == 0 // no selectors = match all nodes
+		for _, ns := range p.cfg.NodeSelectors {
+			if ns.Matches(c.nodeLabels) {
+				shouldRun = true
+				break
+			}
+		}
+
+		if !shouldRun {
+			// Peer doesn't match this node's selectors
+			removed = append(removed, p)
+			continue
+		}
+
+		// Check for duplicates
+		if seen[p.id] {
+			level.Error(l).Log("op", "filterAndDeduplicatePeers", "peer", p.id, "msg", "duplicate peer found in config, please ensure each peer has a unique address or interface per node via nodeSelectors")
+			removed = append(removed, p)
+			duplicateFound = true
+			continue
+		}
+
+		seen[p.id] = true
+		filtered = append(filtered, p)
+	}
+
+	var err error
+	if duplicateFound {
+		err = fmt.Errorf("duplicate peers found for this node")
+	}
+
+	return filtered, removed, err
 }
 
 // hasHealthyEndpoint return true if this node has at least one healthy endpoint.
@@ -202,49 +268,20 @@ func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ []net.IP, po
 
 // Called when either the peer list or node labels have changed,
 // implying that the set of running BGP sessions may need tweaking.
+// Note: This function expects c.peers to already be filtered and deduplicated
+// by filterAndDeduplicatePeers.
 func (c *bgpController) syncPeers(l log.Logger) error {
 	var (
-		errs           int
-		needUpdateAds  bool
-		duplicatePeers = make(map[string]bool) // address/interface -> true if already seen
+		errs          int
+		needUpdateAds bool
 	)
 	for _, p := range c.peers {
-		// First, determine if the peering should be active for this
-		// node.
-		shouldRun := false
-		if len(p.cfg.NodeSelectors) == 0 {
-			shouldRun = true
-		}
-		for _, ns := range p.cfg.NodeSelectors {
-			if ns.Matches(c.nodeLabels) {
-				shouldRun = true
-				break
-			}
-		}
+		// c.peers already contains only peers that should run on this node (filtered by node selectors)
+		// and are deduplicated. We just need to manage session lifecycle.
 
-		// Now, compare current state to intended state, and correct.
-		if p.session != nil && !shouldRun {
-			// Oops, session is running but shouldn't be. Shut it down.
-			level.Info(l).Log("event", "peerRemoved", "peer", p.id, "reason", "filteredByNodeSelector", "msg", "peer deconfigured, closing BGP session")
-			if err := p.session.Close(); err != nil {
-				level.Error(l).Log("op", "syncPeers", "error", err, "peer", p.id, "msg", "failed to shut down BGP session")
-			}
-			p.session = nil
-
-			// Remove from the list of deduplicate peers.
-			delete(duplicatePeers, p.id)
-		} else if p.session == nil && shouldRun {
-			// Session doesn't exist, but should be running. Create
-			// it.
-
-			// Check for duplicate peers based on address or interface.
-			if _, ok := duplicatePeers[p.id]; ok {
-				level.Error(l).Log("op", "syncPeers", "peer", p.id, "msg", "duplicate peer found in config, please ensure each peer has a unique address or interface per node via nodeSelectors")
-				errs++
-				continue
-			}
-			duplicatePeers[p.id] = true
-
+		// Compare current state to intended state, and correct.
+		if p.session == nil {
+			// Session doesn't exist, but should be running. Create it.
 			level.Info(l).Log("event", "peerAdded", "peer", p.id, "msg", "peer configured, starting BGP session")
 			var routerID net.IP
 			if p.cfg.RouterID != nil {
@@ -287,11 +324,8 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				p.session = s
 				needUpdateAds = true
 			}
-		} else {
-			// Session is running and should be, nothing to do.
-			// Add it to the list of deduplicate peers.
-			duplicatePeers[p.id] = true
 		}
+		// If session exists, it should continue running (nothing to do)
 	}
 	if needUpdateAds {
 		// Some new sessions came up, resync advertisement state.
@@ -501,6 +535,28 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	}
 	c.nodeLabels = ns
 	level.Info(l).Log("event", "nodeLabelsChanged", "msg", "Node labels changed, resyncing BGP peers")
+
+	// Re-filter ALL configured peers based on new node labels and deduplicate
+	filteredPeers, removed, err := c.filterAndDeduplicatePeers(l, c.allPeers)
+	c.peers = filteredPeers
+
+	// Close sessions for peers that no longer match node selectors
+	for _, p := range removed {
+		level.Info(l).Log("event", "peerRemoved", "peer", p.id, "reason", "nodeLabelsChanged", "msg", "peer no longer matches node selectors, closing BGP session")
+		if p.session != nil {
+			if closeErr := p.session.Close(); closeErr != nil {
+				level.Error(l).Log("op", "setNode", "error", closeErr, "peer", p.id, "msg", "failed to shut down BGP session")
+			}
+		}
+	}
+
+	// If duplicates were found after re-filtering, log but continue with syncPeers
+	// (syncPeers will handle starting new sessions for eligible peers)
+	if err != nil {
+		// Don't return error here - we want syncPeers to run and establish valid sessions
+		level.Warn(l).Log("event", "duplicatePeersDetected", "error", err, "msg", "duplicate peers detected after node label change")
+	}
+
 	return c.syncPeers(l)
 }
 

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -204,8 +204,9 @@ func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ []net.IP, po
 // implying that the set of running BGP sessions may need tweaking.
 func (c *bgpController) syncPeers(l log.Logger) error {
 	var (
-		errs          int
-		needUpdateAds bool
+		errs           int
+		needUpdateAds  bool
+		duplicatePeers = make(map[string]bool) // address/interface -> true if already seen
 	)
 	for _, p := range c.peers {
 		// First, determine if the peering should be active for this
@@ -229,9 +230,21 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				level.Error(l).Log("op", "syncPeers", "error", err, "peer", p.id, "msg", "failed to shut down BGP session")
 			}
 			p.session = nil
+
+			// Remove from the list of deduplicate peers.
+			delete(duplicatePeers, p.id)
 		} else if p.session == nil && shouldRun {
 			// Session doesn't exist, but should be running. Create
 			// it.
+
+			// Check for duplicate peers based on address or interface.
+			if _, ok := duplicatePeers[p.id]; ok {
+				level.Error(l).Log("op", "syncPeers", "peer", p.id, "msg", "duplicate peer found in config, please ensure each peer has a unique address or interface per node via nodeSelectors")
+				errs++
+				continue
+			}
+			duplicatePeers[p.id] = true
+
 			level.Info(l).Log("event", "peerAdded", "peer", p.id, "msg", "peer configured, starting BGP session")
 			var routerID net.IP
 			if p.cfg.RouterID != nil {
@@ -274,6 +287,10 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				p.session = s
 				needUpdateAds = true
 			}
+		} else {
+			// Session is running and should be, nothing to do.
+			// Add it to the list of deduplicate peers.
+			duplicatePeers[p.id] = true
 		}
 	}
 	if needUpdateAds {

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -1205,15 +1205,17 @@ func TestNodeSelectors(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc            string
-		config          *config.Config
-		node            *v1.Node
-		wantAds         map[string][]*bgp.Advertisement
-		wantReturnState controllers.SyncState
+		desc                     string
+		config                   *config.Config
+		node                     *v1.Node
+		wantAds                  map[string][]*bgp.Advertisement
+		setConfigWantReturnState controllers.SyncState
+		setNodeWantReturnState   controllers.SyncState
 	}{
 		{
-			desc:    "No config, no advertisements",
-			wantAds: map[string][]*bgp.Advertisement{},
+			desc:                     "No config, no advertisements",
+			wantAds:                  map[string][]*bgp.Advertisement{},
+			setConfigWantReturnState: controllers.SyncStateErrorNoRetry,
 		},
 
 		{
@@ -1230,6 +1232,28 @@ func TestNodeSelectors(t *testing.T) {
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+		},
+
+		{
+			desc: "Duplicate peer, default node selector",
+			config: &config.Config{
+				Peers: map[string]*config.Peer{
+					"peer1": {
+						Addr:          net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+					},
+					"peer2": {
+						Addr:          net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+					},
+				},
+				Pools: &config.Pools{ByName: pools},
+			},
+			wantAds: map[string][]*bgp.Advertisement{
+				"1.2.3.4": nil, // It matches one peer, so we still advertise it.
+			},
+			setConfigWantReturnState: controllers.SyncStateErrorNoRetry,
 		},
 
 		{
@@ -1252,6 +1276,7 @@ func TestNodeSelectors(t *testing.T) {
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
 		},
 
 		{
@@ -1268,6 +1293,8 @@ func TestNodeSelectors(t *testing.T) {
 				"1.2.3.4": nil,
 				"2.3.4.5": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
 		},
 
 		{
@@ -1283,6 +1310,8 @@ func TestNodeSelectors(t *testing.T) {
 			wantAds: map[string][]*bgp.Advertisement{
 				"1.2.3.4": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
 		},
 
 		{
@@ -1306,6 +1335,8 @@ func TestNodeSelectors(t *testing.T) {
 				"1.2.3.4": nil,
 				"2.3.4.5": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
 		},
 
 		{
@@ -1322,6 +1353,8 @@ func TestNodeSelectors(t *testing.T) {
 				"1.2.3.4": nil,
 				"2.3.4.5": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
 		},
 
 		{
@@ -1346,6 +1379,8 @@ func TestNodeSelectors(t *testing.T) {
 				"1.2.3.4": nil,
 				"2.3.4.5": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
 		},
 
 		{
@@ -1362,20 +1397,70 @@ func TestNodeSelectors(t *testing.T) {
 				"1.2.3.4": nil,
 				"2.3.4.5": nil,
 			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
+			setNodeWantReturnState:   controllers.SyncStateSuccess,
+		},
+
+		{
+			desc: "Duplicate peer, node selector matches",
+			config: &config.Config{
+				Peers: map[string]*config.Peer{
+					"peer1": {
+						Addr:          net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+					},
+					"peer2": {
+						Addr: net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{
+							mustSelector("host=frontend"),
+						},
+					},
+				},
+				Pools: &config.Pools{ByName: pools},
+			},
+			wantAds: map[string][]*bgp.Advertisement{
+				"1.2.3.4": nil, // It matches one peer, so we still advertise it.
+			},
+			setConfigWantReturnState: controllers.SyncStateErrorNoRetry,
+		},
+
+		{
+			desc: "Duplicate peer, node selector only matches one node",
+			config: &config.Config{
+				Peers: map[string]*config.Peer{
+					"peer1": {
+						Addr: net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{
+							mustSelector("host=frontend"),
+						},
+					},
+					"peer2": {
+						Addr: net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{
+							mustSelector("host!=frontend"),
+						},
+					},
+				},
+				Pools: &config.Pools{ByName: pools},
+			},
+			wantAds: map[string][]*bgp.Advertisement{
+				"1.2.3.4": nil,
+			},
+			setConfigWantReturnState: controllers.SyncStateReprocessAll,
 		},
 	}
 
 	l := log.NewNopLogger()
 	for _, test := range tests {
 		if test.config != nil {
-			if c.SetConfig(l, test.config) == controllers.SyncStateError {
-				t.Errorf("%q: SetConfig failed", test.desc)
+			if r := c.SetConfig(l, test.config); r != test.setConfigWantReturnState {
+				t.Errorf("%q: SetConfig failed, got: %+v, want: %+v", test.desc, r, test.setConfigWantReturnState)
 			}
 		}
 
 		if test.node != nil {
-			if r := c.SetNode(l, test.node); r != test.wantReturnState {
-				t.Fatalf("%q: SetNode returns wrong value, got: %+v, want: %+v", test.desc, test.wantReturnState, r)
+			if r := c.SetNode(l, test.node); r != test.setNodeWantReturnState {
+				t.Fatalf("%q: SetNode returns wrong value, got: %+v, want: %+v", test.desc, r, test.setNodeWantReturnState)
 			}
 		}
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Ensure that duplicate BGP peers in FRR mode have nodeSelectors to distinguish them.
Also, add a runtime check in the BGP controller to detect duplicate peers by address or interface, and return a clear error if found.

Fixes: https://github.com/metallb/metallb/issues/2367

**Release note**:
```release-note
Allow duplicated BGPPeer per neighbor IP
```
