### PR TITLE
CI: rework the kind create cluster for the operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,11 +299,20 @@ jobs:
 
       - name: Create multi-node K8s Kind Cluster
         run: |
-          cd ${GITHUB_WORKSPACE}/metallboperator
-          ./hack/kind-multi-node-cluster-without-registry.sh
+          which kind
+          kind version
+          cat <<EOF | kind create cluster --config -
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+          - role: worker
+          - role: worker
+          EOF
           kind load docker-image quay.io/metallb/speaker:dev-amd64
           kind load docker-image quay.io/metallb/controller:dev-amd64
-          export KUBECONFIG=${HOME}/.kube/config
+          kind get clusters
+          kubectl version
 
       - name: Deploy Metal LB Operator
         run: |

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -15,10 +15,6 @@ runs:
         sudo apt-get update
         sudo apt-get install python3-pip arping ndisc6
         sudo pip3 install -r dev-env/requirements.txt
-        GO111MODULE="on" go get sigs.k8s.io/kind@v0.19.0
-        go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
-        #NOTE: This pulls the ginkgo version that is pinned in go.mod
-        go install github.com/onsi/ginkgo/v2/ginkgo
 
     - name: Download MetalLB images
       uses: actions/download-artifact@v4


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
We need to bump the kind cluster on the operator ci test

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
