### PR TITLE
MetalLB: translate disableMP to frr-k8s

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -83,6 +83,7 @@ type SessionParameters struct {
 	VRFName                string
 	SessionName            string
 	DualStackAddressFamily bool
+	DisableMP              bool
 }
 type SessionManager interface {
 	NewSession(logger log.Logger, args SessionParameters) (Session, error)

--- a/internal/bgp/frrk8s/frrk8s.go
+++ b/internal/bgp/frrk8s/frrk8s.go
@@ -271,6 +271,7 @@ func (sm *sessionManager) updateConfig() error {
 				EnableGracefulRestart:  s.GracefulRestart,
 				EBGPMultiHop:           s.EBGPMultiHop,
 				DualStackAddressFamily: s.DualStackAddressFamily,
+				DisableMP:              s.DisableMP,
 				ToAdvertise: frrv1beta1.Advertise{
 					Allowed: frrv1beta1.AllowedOutPrefixes{
 						Prefixes: make([]string, 0),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,8 @@ type Peer struct {
 	VRF string
 	// Option to advertise v4 addresses over v6 sessions and viceversa.
 	DualStackAddressFamily bool
+	// Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+	DisableMP bool
 }
 
 // Pool is the configuration of an IP address pool.
@@ -484,6 +486,7 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 		EBGPMultiHop:           p.Spec.EBGPMultiHop,
 		VRF:                    p.Spec.VRFName,
 		DualStackAddressFamily: p.Spec.DualStackAddressFamily,
+		DisableMP:              p.Spec.DisableMP,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3633,6 +3633,39 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "peer with DisableMP field",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "peer1",
+						},
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:     42,
+							ASN:       142,
+							Address:   "1.2.3.4",
+							DisableMP: true,
+						},
+					},
+				},
+			},
+			want: &Config{
+				Peers: map[string]*Peer{
+					"peer1": {
+						Name:                   "peer1",
+						MyASN:                  42,
+						ASN:                    142,
+						Addr:                   net.ParseIP("1.2.3.4"),
+						NodeSelectors:          []labels.Selector{labels.Everything()},
+						DisableMP:              true,
+						DualStackAddressFamily: false,
+					},
+				},
+				Pools:       &Pools{ByName: map[string]*Pool{}},
+				BFDProfiles: map[string]*BFDProfile{},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -265,6 +265,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				SessionName:            p.cfg.Name,
 				VRFName:                p.cfg.VRF,
 				DualStackAddressFamily: p.cfg.DualStackAddressFamily,
+				DisableMP:              p.cfg.DisableMP, //nolint:staticcheck // SA1019: intentionally using deprecated field for translation
 			}
 			sessionParams.Password, sessionParams.PasswordRef = passwordForSession(p.cfg, c.bgpType, c.secretHandling)
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:



> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:


Even if disableMP is not handled anymore, the frr-k8s version still has the field and if the field is set, we should honor the request of the user in translating it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Translate the disablemp flag to frrconfiguration.
```
