### PR TITLE
Docs: update Community page to reflect CR-based configuration

### DIFF
--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -77,10 +77,10 @@ currently have, relative to the top-level directory:
   Kubernetes apiserver to get and modify service information. It
   allows most of the rest of the MetalLB code to be ignorant of the
   Kubernetes client library, other than the objects (Service,
-  ConfigMap...) that they manipulate.
-- `internal/config` parses and validates the MetalLB configmap.
+  CRs...) that they manipulate.
+- `internal/config` parses and validates the MetalLB Custom Resources (e.g., IPAddressPool, L2Advertisement)
 - `internal/allocator` is the IP address manager. Given pools from the
-  MetalLB configmap, it can allocate addresses on demand.
+  IPAddressPool Custom Resource, it can allocate addresses on demand.
 - `internal/bgp/native` is a _very_ stripped down implementation of BGP. It
   speaks just enough of the protocol to keep peering sessions up, and
   to push routes to the peer.


### PR DESCRIPTION
Background: Since v0.13,
MetalLB is configured using CRs instead of ConfigMap (IPAddressPool, L2Advertisement, BGPAdvertisement, BGPPeer, etc.).

Problem: The Community & Contributing page still refers to internal packages as if MetalLB were configured via a ConfigMap.

Fix: Updated the Community & Contributing page to describe CR-based configuration. Removed outdated references to ConfigMap usage and aligned the documentation with the changes introduced in v0.13.

**Is this a BUG FIX or a FEATURE ?**:
/kind documentation

**What this PR does / why we need it**:
Update Community & Contributing page to reflect CR-based configuration.

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
NONE
```
