### PR TITLE
Add readOnlyRootFilesystem=true to containers missing it

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -140,6 +140,9 @@ spec:
       - name: kube-rbac-proxy
         image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         args:
           - --logtostderr
           - --secure-listen-address=:{{ .Values.prometheus.secureMetricsPort }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -203,6 +203,12 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        - name: frr-tmp
+          emptyDir: {}
+        - name: frr-lib
+          emptyDir: {}
+        - name: frr-log
+          emptyDir: {}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
@@ -385,6 +391,8 @@ spec:
       {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
@@ -403,6 +411,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
+          - name: frr-tmp
+            mountPath: /var/tmp/frr
+          - name: frr-lib
+            mountPath: /var/lib/frr
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
@@ -451,6 +463,9 @@ spec:
         {{- if .Values.speaker.frr.image.pullPolicy }}
         imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
         {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         command: ["/etc/frr_reloader/frr-reloader.sh"]
         volumeMounts:
           - name: frr-sockets
@@ -459,12 +474,17 @@ spec:
             mountPath: /etc/frr
           - name: reloader
             mountPath: /etc/frr_reloader
+          - name: frr-log
+            mountPath: /var/log/frr
         {{- with .Values.speaker.reloader.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
       - name: frr-metrics
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         command: ["/etc/frr_metrics/frr-metrics"]
         args:
           - --metrics-port={{ .Values.speaker.frr.metricsPort }}
@@ -493,6 +513,9 @@ spec:
       - name: kube-rbac-proxy
         image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         args:
           - --logtostderr
           - --secure-listen-address=:{{ .Values.prometheus.secureMetricsPort }}
@@ -522,6 +545,9 @@ spec:
       - name: kube-rbac-proxy-frr
         image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         args:
           - --logtostderr
           - --secure-listen-address=:{{ .Values.speaker.frr.secureMetricsPort }}

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -23,6 +23,12 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        - name: frr-tmp
+          emptyDir: {}
+        - name: frr-lib
+          emptyDir: {}
+        - name: frr-log
+          emptyDir: {}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
@@ -53,6 +59,8 @@ spec:
       containers:
         - name: frr
           securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
           image: quay.io/frrouting/frr:10.4.1
@@ -92,6 +100,9 @@ spec:
             periodSeconds: 5
         - name: reloader
           image: quay.io/frrouting/frr:10.4.1
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           command: ["/etc/frr_reloader/frr-reloader.sh"]
           volumeMounts:
             - name: frr-sockets
@@ -100,8 +111,13 @@ spec:
               mountPath: /etc/frr
             - name: reloader
               mountPath: /etc/frr_reloader
+            - name: frr-log
+              mountPath: /var/log/frr
         - name: frr-metrics
           image: quay.io/frrouting/frr:10.4.1
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           command: ["/etc/frr_metrics/frr-metrics"]
           args:
             - --metrics-port=7473

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3015,6 +3015,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -3549,6 +3550,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2191,6 +2191,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       - command:
         - /bin/sh
         - -c
@@ -2214,12 +2215,14 @@ spec:
           periodSeconds: 5
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -2235,6 +2238,9 @@ spec:
         - /etc/frr_reloader/frr-reloader.sh
         image: quay.io/frrouting/frr:10.4.1
         name: reloader
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2242,6 +2248,8 @@ spec:
           name: frr-conf
         - mountPath: /etc/frr_reloader
           name: reloader
+        - mountPath: /var/log/frr
+          name: frr-log
       - args:
         - --metrics-port=7473
         command:
@@ -2254,6 +2262,9 @@ spec:
         ports:
         - containerPort: 7473
           name: frrmetrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2394,6 +2405,12 @@ spec:
         name: reloader
       - emptyDir: {}
         name: metrics
+      - emptyDir: {}
+        name: frr-tmp
+      - emptyDir: {}
+        name: frr-lib
+      - emptyDir: {}
+        name: frr-log
       - name: memberlist
         secret:
           defaultMode: 420

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2037,12 +2037,14 @@ spec:
           periodSeconds: 5
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -2058,6 +2060,9 @@ spec:
         - /etc/frr_reloader/frr-reloader.sh
         image: quay.io/frrouting/frr:10.4.1
         name: reloader
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2065,6 +2070,8 @@ spec:
           name: frr-conf
         - mountPath: /etc/frr_reloader
           name: reloader
+        - mountPath: /var/log/frr
+          name: frr-log
       - args:
         - --metrics-port=7473
         command:
@@ -2077,6 +2084,9 @@ spec:
         ports:
         - containerPort: 7473
           name: frrmetrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2217,6 +2227,12 @@ spec:
         name: reloader
       - emptyDir: {}
         name: metrics
+      - emptyDir: {}
+        name: frr-tmp
+      - emptyDir: {}
+        name: frr-lib
+      - emptyDir: {}
+        name: frr-log
       - name: memberlist
         secret:
           defaultMode: 420

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -1950,6 +1950,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       - args:
         - --port=7472
         - --log-level=info
@@ -2060,6 +2061,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       - args:
         - --port=7472
         - --log-level=info

--- a/config/prometheus-frr/rbac-proxy-patch.yaml
+++ b/config/prometheus-frr/rbac-proxy-patch.yaml
@@ -71,6 +71,7 @@ spec:
         - name: kube-rbac-proxy-frr
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - "ALL"

--- a/config/prometheus-native/rbac-proxy-patch.yaml
+++ b/config/prometheus-native/rbac-proxy-patch.yaml
@@ -11,6 +11,7 @@ spec:
         - name: kube-rbac-proxy
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - "ALL"
@@ -43,6 +44,7 @@ spec:
         - name: kube-rbac-proxy
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - "ALL"


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
`readOnlyRootFilesystem` prevents containers from writing to the root filesystem, reducing attack surface and improving security posture by limiting potential malicious file modifications and ensuring immutable container runtime.

`allowPrivilegeEscalation=false` prevents containers from gaining additional privileges beyond those initially granted, further hardening the security posture by blocking privilege escalation attacks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Added `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false` to containers missing these security flags, enhancing container security posture without affecting functionality.
```
