### PR TITLE
Add Jinja2 dependency to dev environment requirements

### DIFF
--- a/dev-env/requirements.txt
+++ b/dev-env/requirements.txt
@@ -3,3 +3,4 @@ invoke
 semver
 PyYAML
 black
+Jinja2


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug


**What this PR does / why we need it**:
Add Jinja2 to requirements.txt for template processing in the development environment.
Dependency was introduced in commit 8e31dc9.

```release-note 
NONE
```