### PR TITLE
allocator: enforce no mutations of config

### DIFF
--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -82,71 +82,77 @@ func noopCallback(_ string) {}
 
 func TestAssignment(t *testing.T) {
 	alloc := New(noopCallback)
-	alloc.SetPools(&config.Pools{ByName: map[string]*config.Pool{
-		"test": {
-			Name:       "test",
-			AutoAssign: true,
-			CIDR: []*net.IPNet{
-				ipnet("1.2.3.4/31"),
-				ipnet("1000::4/127"),
+	makePools := func() *config.Pools {
+		return &config.Pools{ByName: map[string]*config.Pool{
+			"test": {
+				Name:       "test",
+				AutoAssign: true,
+				CIDR: []*net.IPNet{
+					ipnet("1.2.3.4/31"),
+					ipnet("1000::4/127"),
+				},
 			},
-		},
-		"test2": {
-			Name:          "test2",
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
-			CIDR: []*net.IPNet{
-				ipnet("1.2.4.0/24"),
-				ipnet("1000::4:0/120"),
+			"test2": {
+				Name:          "test2",
+				AvoidBuggyIPs: true,
+				AutoAssign:    true,
+				CIDR: []*net.IPNet{
+					ipnet("1.2.4.0/24"),
+					ipnet("1000::4:0/120"),
+				},
 			},
-		},
-		"test3": {
-			Name:               "test3",
-			AvoidBuggyIPs:      true,
-			AutoAssign:         true,
-			ServiceAllocations: &config.ServiceAllocation{Namespaces: sets.New("test-ns1")},
-			CIDR: []*net.IPNet{
-				ipnet("1.2.5.0/24"),
-				ipnet("1000::5:0/120"),
+			"test3": {
+				Name:               "test3",
+				AvoidBuggyIPs:      true,
+				AutoAssign:         true,
+				ServiceAllocations: &config.ServiceAllocation{Namespaces: sets.New("test-ns1")},
+				CIDR: []*net.IPNet{
+					ipnet("1.2.5.0/24"),
+					ipnet("1000::5:0/120"),
+				},
 			},
-		},
-		"test4": {
-			Name:               "test4",
-			AvoidBuggyIPs:      true,
-			AutoAssign:         true,
-			ServiceAllocations: &config.ServiceAllocation{ServiceSelectors: []labels.Selector{selector("team=metallb")}},
-			CIDR: []*net.IPNet{
-				ipnet("1.2.6.0/24"),
-				ipnet("1000::6:0/120"),
+			"test4": {
+				Name:               "test4",
+				AvoidBuggyIPs:      true,
+				AutoAssign:         true,
+				ServiceAllocations: &config.ServiceAllocation{ServiceSelectors: []labels.Selector{selector("team=metallb")}},
+				CIDR: []*net.IPNet{
+					ipnet("1.2.6.0/24"),
+					ipnet("1000::6:0/120"),
+				},
 			},
-		},
-		"test5": {
-			Name:          "test5",
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
-			ServiceAllocations: &config.ServiceAllocation{
-				Priority: 20, Namespaces: sets.New("test-ns1"),
-				ServiceSelectors: []labels.Selector{selector("team=metallb")},
+			"test5": {
+				Name:          "test5",
+				AvoidBuggyIPs: true,
+				AutoAssign:    true,
+				ServiceAllocations: &config.ServiceAllocation{
+					Priority: 20, Namespaces: sets.New("test-ns1"),
+					ServiceSelectors: []labels.Selector{selector("team=metallb")},
+				},
+				CIDR: []*net.IPNet{
+					ipnet("1.2.7.0/24"),
+					ipnet("1000::7:0/120"),
+				},
 			},
-			CIDR: []*net.IPNet{
-				ipnet("1.2.7.0/24"),
-				ipnet("1000::7:0/120"),
+			"test6": {
+				Name:          "test6",
+				AvoidBuggyIPs: true,
+				AutoAssign:    true,
+				ServiceAllocations: &config.ServiceAllocation{
+					Priority: 20, Namespaces: sets.New("test-ns2"),
+					ServiceSelectors: []labels.Selector{selector("foo=bar")},
+				},
+				CIDR: []*net.IPNet{
+					ipnet("1.2.8.0/24"),
+					ipnet("1000::9:0/120"),
+				},
 			},
-		},
-		"test6": {
-			Name:          "test6",
-			AvoidBuggyIPs: true,
-			AutoAssign:    true,
-			ServiceAllocations: &config.ServiceAllocation{
-				Priority: 20, Namespaces: sets.New("test-ns2"),
-				ServiceSelectors: []labels.Selector{selector("foo=bar")},
-			},
-			CIDR: []*net.IPNet{
-				ipnet("1.2.8.0/24"),
-				ipnet("1000::9:0/120"),
-			},
-		},
-	}})
+		}}
+	}
+
+	originalConfig := makePools()
+	passedConfig := makePools()
+	alloc.SetPools(passedConfig)
 
 	tests := []struct {
 		desc       string
@@ -655,6 +661,9 @@ func TestAssignment(t *testing.T) {
 	for _, test := range tests {
 		if len(test.ips) == 0 {
 			alloc.Unassign(test.svcKey)
+			if !reflect.DeepEqual(originalConfig, passedConfig) {
+				t.Errorf("%q: config mutated in Unassign!", test.desc)
+			}
 			continue
 		}
 		ips := []net.IP{}
@@ -672,6 +681,9 @@ func TestAssignment(t *testing.T) {
 			} else if a := assigned(alloc, test.svcKey); !alreadyHasIPs && reflect.DeepEqual(a, test.ips) {
 				t.Errorf("%q: Assign(%q, %q) failed, but allocator did record allocation", test.desc, test.svcKey, test.ips)
 			}
+			if !reflect.DeepEqual(originalConfig, passedConfig) {
+				t.Errorf("%q: config mutated in failed Assign!", test.desc)
+			}
 
 			continue
 		}
@@ -681,6 +693,9 @@ func TestAssignment(t *testing.T) {
 		}
 		if a := assigned(alloc, test.svcKey); !reflect.DeepEqual(a, test.ips) {
 			t.Errorf("%q: ran Assign(%q, %q), but allocator has recorded allocation of %q", test.desc, test.svcKey, test.ips, a)
+		}
+		if !reflect.DeepEqual(originalConfig, passedConfig) {
+			t.Errorf("%q: config mutated in Assign!", test.desc)
 		}
 	}
 }


### PR DESCRIPTION
The pool_controller was constantly reloading services even though
the actual config did not change (e.g events triggered by ns labels changing),
caused by reflect.DeepEqual returning false.
The flow goes:
  (1) pool_controller parses the config
  (2) compares with the current cached config, if they differ:
  (3) passes it to the allocator's SetPools
  (4) pool_controller caches the parsed config
Ideally, the config should not change between (1) and (4), but
in practice the allocator mutates the config when it runs ipaddr.NewPrefix(...),
making the parsed config deviate from the original config.
Here we fix this by creating a copy of the ip before running NewPrefix,
and add a unit test that ensures the allocator does not mutate the config.

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bugfix: enforce allocator does not mutate the config, enabling the pool controller to not re-trigger redundant configuration.
```
