### PR TITLE
allocator: return error when pool has no available IPs

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1297,6 +1297,9 @@ func TestDeleteRecyclesIP(t *testing.T) {
 	if k.gotService(svc2) != nil {
 		t.Fatal("SetBalancer svc2 mutated svc2 even though it should not have allocated")
 	}
+	if !k.loggedWarning {
+		t.Fatal("SetBalancer svc2 should have produced a warning event when pool has no available IPs")
+	}
 	k.reset()
 
 	// Deleting the first LB should tell us to reprocess all services.


### PR DESCRIPTION
We explicitly return an error when there is no IPs in the pool instead of relying on the caller to handle nil ips correctly. As a side-effect, the AllocationFailed event changes from: `Failed to allocate IP for "service-a": ["<nil>"] is not allowed in config for service` to:
`Failed to allocate IP for "service-a": no available IPs in pool x`

When service-a requests an IP from a pool that doesn't have any left.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
allocation: fix the AllocationFailed event to indicate when the pool doesn't have any IPs left.
```
