### PR TITLE
E2E: Handle different frr log configurations between frr-k8s and metallb

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1647,7 +1647,10 @@ var _ = ginkgo.Describe("BGP", func() {
 					return cfgStr
 				}, 1*time.Minute).Should(
 					And(
-						ContainSubstring("log file /etc/frr/frr.log"),
+						Or(
+							ContainSubstring("log file /etc/frr/frr.log"),
+							ContainSubstring("log stdout"),
+						),
 						WithTransform(substringCount("\n profile fullbfdprofile1"), Equal(1)),
 						ContainSubstring("receive-interval 93"),
 						ContainSubstring("transmit-interval 95"),


### PR DESCRIPTION
The test for BFD profile configuration was failing with frr-k8s because it expects a different log statement format. frr-k8s uses "log stdout" while metallb's frr uses "log file /etc/frr/frr.log" as of commit 80c504ca87dff7c0f7ff30048b74a6aa13e9867c in the frr-k8s repository.

Initially, I wanted to fix this with an IsFRRK8s flag in the E2Es to distinguish between the two modes and checks for the appropriate log statement accordingly. See https://github.com/metallb/metallb/pull/2896/changes/cf723da7c62da1d81ba68e6473479494d3ea7ca6

However, given that upstream metallb runs the frr-k8s tests as well, but pinned to v0.0.21, we cannot do this, either.

Instead, use a simple `Or` to unblock the frr-k8s CIs until metallb and frr-k8s E2Es use the same version of frr-k8s with log stdout; and ideally until metallb's frr also uses log stdout

Fixes https://github.com/metallb/metallb/issues/2895

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
/kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
