### PR TITLE
Allow exhaustion prom rules to retain all labels

### DIFF
--- a/charts/metallb/templates/prometheusrules.yaml
+++ b/charts/metallb/templates/prometheusrules.yaml
@@ -46,7 +46,7 @@ spec:
       annotations:
         summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
         description: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has exhausted address pool {{ $labels.pool }} for > 1 minute'`}}
-      expr: metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} >= on(pool) metallb_allocator_addresses_total
+      expr: metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} >= metallb_allocator_addresses_total
       for: 1m
       {{- with .Values.prometheus.prometheusRule.addressPoolExhausted.labels }}
       labels:
@@ -61,7 +61,7 @@ spec:
       annotations:
         summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
         message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has address pool {{ $labels.pool }} past `}}{{ .percent }}{{`% usage for > 1 minute'`}}
-      expr: ( metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} / on(pool) metallb_allocator_addresses_total ) * 100 > {{ .percent }}
+      expr: ( metallb_allocator_addresses_in_use_total{pool!~"{{ $exclude }}"} / metallb_allocator_addresses_total ) * 100 > {{ .percent }}
       {{- with .labels }}
       labels:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
Fixes [#2876](https://github.com/metallb/metallb/issues/2876)

Currently, the pool exhaustion Prometheus Rules keep only the pool label. This means that the labels used on the summary and description never get passed through.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix the pool exhaustion Prometheus rules so that the queries retain all labels values which are subsequently used in summary and description fields
```
