### PR TITLE
Fix: optimize poolFor lookup by adding early-exit logic

### DIFF
--- a/speaker/main.go
+++ b/speaker/main.go
@@ -492,21 +492,26 @@ func (c *controller) deleteBalancerProtocol(l log.Logger, protocol config.Proto,
 }
 
 func poolFor(pools *config.Pools, ips []net.IP) string {
-	if pools == nil {
+	if pools == nil || len(ips) == 0 {
 		return ""
 	}
 	for pname, p := range pools.ByName {
-		cnt := 0
+		allMatched := true
 		for _, ip := range ips {
+			matched := false
 			for _, cidr := range p.CIDR {
 				if cidr.Contains(ip) {
-					cnt++
+					matched = true
 					break
 				}
 			}
-			if cnt == len(ips) {
-				return pname
+			if !matched {
+				allMatched = false
+				break
 			}
+		}
+		if allMatched {
+			return pname
 		}
 	}
 	return ""


### PR DESCRIPTION
Background:
The previous implementation of poolFor counted CIDR matches for each IP address, resulting in unnecessary iterations even after a mismatch was detected.

Problem:
When checking multiple IPs against multiple pools and CIDRs, the function performed redundant Contains() calls, causing O(pools × ips × cidrs) complexity with no early termination.

Fix:
Replaced the counter-based approach with a boolean match flag and introduced early exits when mismatches occur. This reduces unnecessary Contains() calls and slightly improves performance without changing behavior.

**Is this a BUG FIX or a FEATURE ?**:
/kind feature

**What this PR does / why we need it**:
Replaces the counter-based matching logic in poolFor with an 
early-exit approach: for each pool, stop scanning CIDRs as soon 
as any IP fails to match, and treat nil/empty IP slices as no-match.

Why this is needed
Improves performance by avoiding unnecessary CIDR iterations 
for pools that already fail to match.

```release-note
Fix pool matching logic for better performance
```