### PR TITLE
Fix log message for invalidFileErr in docker test

### DIFF
--- a/internal/bgp/frr/docker_test.go
+++ b/internal/bgp/frr/docker_test.go
@@ -96,17 +96,19 @@ func testFileIsValid(fileName string) error {
 	if err != nil {
 		return errors.Join(err, errors.New("failed to copy frr.conf inside the container"))
 	}
-	buf := new(bytes.Buffer)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
 	code, err := containerHandle.Exec([]string{"python3", "/usr/lib/frr/frr-reload.py", "--test", "--stdout", "/etc/frr/frr.conf"},
 		dockertest.ExecOptions{
-			StdErr: buf,
+			StdOut: stdout,
+			StdErr: stderr,
 		})
 	if err != nil {
 		return errors.Join(err, errors.New("failed to exec reloader into the container"))
 	}
 
 	if code != 0 {
-		return invalidFileErr{Reason: buf.String()}
+		return invalidFileErr{Reason: fmt.Sprintf("stdout: %q, stderr: %q", stdout.String(), stderr.String())}
 	}
 	return nil
 }


### PR DESCRIPTION
When the frr-reload.py failed, it would log its error to stdout. The containerhandler would only catch stderr and thus would log an empty string. Fix this by reporting both stdout and stderr.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
