### PR TITLE
Unit tests: Fix wrong environment variable configuration

### DIFF
--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -1016,9 +1016,7 @@ func TestLoggingConfigurationDebug(t *testing.T) {
 func TestLoggingConfigurationOverrideByEnvironmentVar(t *testing.T) {
 	testSetup(t)
 
-	orig := os.Getenv("FRR_LOGGING_LEVEL")
-	os.Setenv("FRR_LOGGING_LEVEL", "alerts")
-	t.Cleanup(func() { os.Setenv("FRR_LOGGING_LEVEL", orig) })
+	t.Setenv("FRR_LOGGING_LEVEL", "alerts")
 
 	l := log.NewNopLogger()
 	sessionManager := mockNewSessionManager(l, logging.LevelDebug)

--- a/internal/bgp/frr/testdata/TestLargeCommunities.golden
+++ b/internal/bgp/frr/testdata/TestLargeCommunities.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
+++ b/internal/bgp/frr/testdata/TestManyAdvertisementsSameCommunity.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithNoTimers.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithNoTimers.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleSessionWithZeroTimers.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithZeroTimers.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestUnnumberedSession.golden
+++ b/internal/bgp/frr/testdata/TestUnnumberedSession.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
@@ -1,4 +1,4 @@
-log stdout 
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default


### PR DESCRIPTION
TestLoggingConfigurationOverrideByEnvironmentVar read env var via os.Getenv (which, if unset, yields "") and would then set the env variable for all subsequent tests explicitly to "". Use t.Setenv instead.

Reported-at: https://github.com/metallb/metallb/issues/2929

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
