### PR TITLE
Lint tasks.py for black-26.1

### DIFF
--- a/dev-env/requirements.txt
+++ b/dev-env/requirements.txt
@@ -2,5 +2,5 @@
 invoke
 semver
 PyYAML
-black
+black>=26.1
 Jinja2

--- a/tasks.py
+++ b/tasks.py
@@ -486,8 +486,7 @@ def dev_env(
         }
 
         if with_api_audit:
-            config["nodes"][0]["kubeadmConfigPatches"] = [
-                r"""kind: ClusterConfiguration
+            config["nodes"][0]["kubeadmConfigPatches"] = [r"""kind: ClusterConfiguration
 apiServer:
   # enable auditing flags on the API server
   extraArgs:
@@ -504,8 +503,7 @@ apiServer:
       hostPath: "/var/log/kubernetes"
       mountPath: "/var/log/kubernetes"
       readOnly: false
-      pathType: DirectoryOrCreate"""
-            ]
+      pathType: DirectoryOrCreate"""]
             config["nodes"][0]["extraMounts"] = [
                 {
                     "hostPath": "./dev-env/audit-policy.yaml",


### PR DESCRIPTION
CI now uses black-26.1 and that complains about tasks.py. Fix this

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
