### PR TITLE
Update setup-envtest version to release-0.22

### DIFF
--- a/dev-env/unittest/setup-envtest.sh
+++ b/dev-env/unittest/setup-envtest.sh
@@ -3,4 +3,4 @@
 bin_dir=$1/bin/
 
 mkdir -p ${bin_dir}
-GOBIN=${bin_dir} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9
+GOBIN=${bin_dir} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22


### PR DESCRIPTION
To fix CI failure:
```
unable to fetch checksum for requested version: unable
fetch metadata for kubebuilder-tools-1.27.1-linux-amd64.tar.gz
-- got status "401 Unauthorized" from GCS
```

Reported-at: https://github.com/metallb/metallb/issues/2950
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
