### PR TITLE
feat: Make bgp debounce configurable

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -122,6 +122,7 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.speakerMetricsTLSSecret | string | `""` |  |
 | rbac.create | bool | `true` |  |
 | speaker.affinity | object | `{}` |  |
+| speaker.bgpDebounceTimeout | string | `nil` | BGP debounce timeout for FRR configuration reloads, in milliseconds. Only applies when BGP type is frr. Default (when unset) is 3000 ms. This feature is experimental |
 | speaker.enabled | bool | `true` |  |
 | speaker.excludeInterfaces.enabled | bool | `true` |  |
 | speaker.extraContainers | list | `[]` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -274,6 +274,9 @@ spec:
         {{- if .Values.speaker.ignoreExcludeLB}}
         - --ignore-exclude-lb
         {{- end }}
+        {{- if .Values.speaker.bgpDebounceTimeout }}
+        - --bgp-debounce-timeout={{ .Values.speaker.bgpDebounceTimeout }}
+        {{- end }}
         {{- if .Values.prometheus.secureMetricsPort }}
         - --host=localhost
         {{- end }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -367,6 +367,12 @@
             "ignoreExcludeLB": {
               "type": "boolean"
             },
+            "bgpDebounceTimeout": {
+              "anyOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "null" }
+              ]
+            },
             "updateStrategy": {
               "type": "object",
               "properties": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -275,6 +275,8 @@ speaker:
     enabled: true
   # ignore the exclude-from-external-loadbalancer label
   ignoreExcludeLB: false
+  # --  BGP debounce timeout for FRR configuration reloads, in milliseconds. Only applies when BGP type is frr. Default (when unset) is 3000 ms. This feature is experimental
+  bgpDebounceTimeout: null
 
   image:
     repository: quay.io/metallb/speaker

--- a/internal/bgp/frr/docker_test.go
+++ b/internal/bgp/frr/docker_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"errors"
 
@@ -64,7 +63,6 @@ func TestMain(m *testing.M) {
 	}
 
 	// override reloadConfig so it doesn't try to reload it.
-	debounceTimeout = time.Millisecond
 	reloadConfig = func() error { return nil }
 
 	retCode := m.Run()

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -44,6 +44,10 @@ type session struct {
 // in unit tests.
 var osHostname = os.Hostname
 
+const (
+	testDebounceTimeout = time.Millisecond
+)
+
 // sessionName() defines the format of the key of the 'sessions' map in
 // the 'frrState' struct.
 func sessionName(s session) string {
@@ -407,10 +411,9 @@ func largeCommunityPrefixList(neighbor *neighborConfig, community, ipFamily stri
 
 func (sm *sessionManager) SetEventCallback(func(interface{})) {}
 
-var debounceTimeout = 3 * time.Second
 var failureTimeout = time.Second * 5
 
-func NewSessionManager(l log.Logger, logLevel logging.Level) bgp.SessionManager {
+func NewSessionManager(l log.Logger, logLevel logging.Level, debounceTimeout time.Duration) bgp.SessionManager {
 	res := &sessionManager{
 		sessions:     map[string]*session{},
 		bfdProfiles:  []BFDProfile{},
@@ -439,7 +442,7 @@ func mockNewSessionManager(l log.Logger, logLevel logging.Level) *sessionManager
 		return generateAndReloadConfigFile(config, l)
 	}
 
-	debouncer(reload, res.reloadConfig, debounceTimeout, failureTimeout, l)
+	debouncer(reload, res.reloadConfig, testDebounceTimeout, failureTimeout, l)
 
 	return res
 }

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -509,7 +509,7 @@ var newBGP = func(cfg controllerConfig) bgp.SessionManager {
 	case bgpNative:
 		return bgpnative.NewSessionManager(cfg.Logger)
 	case bgpFrr:
-		return bgpfrr.NewSessionManager(cfg.Logger, cfg.LogLevel)
+		return bgpfrr.NewSessionManager(cfg.Logger, cfg.LogLevel, cfg.BGPDebounceTimeout)
 	case bgpFrrK8s:
 		return bgpfrrk8s.NewSessionManager(cfg.Logger, cfg.LogLevel, cfg.MyNode, cfg.FRRK8sNamespace)
 	default:

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -22,8 +22,10 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -60,7 +62,8 @@ var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 })
 
 const (
-	excludeL2ConfigPath = "/etc/metallb/excludel2.yaml"
+	excludeL2ConfigPath    = "/etc/metallb/excludel2.yaml"
+	defaultDebounceTimeout = 3 * time.Second
 )
 
 // Service offers methods to mutate a Kubernetes service object.
@@ -74,6 +77,9 @@ func main() {
 	prometheus.MustRegister(announcing)
 
 	var (
+		bgpDebounceTimeoutMs = flag.String("bgp-debounce-timeout", os.Getenv("METALLB_BGP_DEBOUNCE_TIMEOUT"),
+			"BGP debounce timeout for FRR configuration reloads, in milliseconds. Only applies when METALLB_BGP_TYPE=frr. "+
+				"Can also be set via METALLB_BGP_DEBOUNCE_TIMEOUT. Default is 3000 ms. This feature is experimental.")
 		namespace         = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config file and speakers namespace")
 		host              = flag.String("host", os.Getenv("METALLB_HOST"), "HTTP host address")
 		mlBindAddr        = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
@@ -90,6 +96,7 @@ func main() {
 		ignoreLBExclude   = flag.Bool("ignore-exclude-lb", false, "ignore the exclude-from-external-load-balancers label")
 		frrK8sNamespace   = flag.String("frrk8s-namespace", os.Getenv("FRRK8S_NAMESPACE"), "the namespace frr-k8s is being deployed on")
 	)
+
 	flag.Parse()
 
 	// Note: Changing the MetalLB BGP implementation type should be considered
@@ -106,6 +113,21 @@ func main() {
 	}
 
 	level.Info(logger).Log("version", version.Version(), "commit", version.CommitHash(), "branch", version.Branch(), "goversion", version.GoString(), "msg", "MetalLB speaker starting "+version.String())
+
+	// Parse BGP debounce timeout from environment variable, CLI or use default (3 seconds).
+	// The debounce timeout throttles how often BGP/FRR configuration reloads are applied, so that
+	// bursts of updates are coalesced into fewer reloads. This setting only has an effect when
+	// running in FRR mode (METALLB_BGP_TYPE=frr). Typical values are in the 1000–10000 ms range.
+	bgpDebounceTimeout := defaultDebounceTimeout
+	if *bgpDebounceTimeoutMs != "" {
+		parsed, err := strconv.Atoi(*bgpDebounceTimeoutMs)
+		if err != nil || parsed <= 0 {
+			level.Error(logger).Log("msg", "invalid BGP debounce timeout value, must be a positive integer value", "provided", *bgpDebounceTimeoutMs)
+			os.Exit(1)
+		}
+		bgpDebounceTimeout = time.Duration(parsed) * time.Millisecond
+	}
+	level.Debug(logger).Log("msg", "using BGP debounce timeout", "milliseconds", bgpDebounceTimeout.Milliseconds())
 
 	if *namespace == "" {
 		bs, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
@@ -173,6 +195,7 @@ func main() {
 		bgpType:                bgpImplementation(bgpType),
 		InterfaceExcludeRegexp: interfacesToExclude,
 		IgnoreExcludeLB:        *ignoreLBExclude,
+		BGPDebounceTimeout:     bgpDebounceTimeout,
 		Layer2StatusChange: func(namespacedName types.NamespacedName) {
 			l2StatusChan <- controllers.NewL2StatusEvent(namespacedName.Namespace, namespacedName.Name)
 		},
@@ -280,6 +303,7 @@ type controllerConfig struct {
 	AnnouncedInterfacesToExclude []string `yaml:"announcedInterfacesToExclude"`
 	InterfaceExcludeRegexp       *regexp.Regexp
 	IgnoreExcludeLB              bool
+	BGPDebounceTimeout           time.Duration
 	Layer2StatusChange           func(types.NamespacedName)
 	BGPAdsChangedCallback        func(string)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
Part of https://github.com/metallb/metallb/issues/2900

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
BGP debounce timeout for FRR configuration reloads is configurable. Only applies when METALLB_BGP_TYPE=frr. Can also be set via METALLB_BGP_DEBOUNCE_TIMEOUT or by bgp-debounce-timeout flag, default is 3000 ms.
```
