### PR TITLE
ConfigurationState: react to deletions

### DIFF
--- a/e2etest/configurationstatetests/configurationstate.go
+++ b/e2etest/configurationstatetests/configurationstate.go
@@ -189,6 +189,25 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 		}, 60*time.Second, 5*time.Second).Should(Succeed())
 	})
 
+	ginkgo.It("should self-heal after deletion", func() {
+		stateName := "speaker-" + allNodes.Items[0].Name
+
+		ginkgo.By("Deleting the ConfigurationState resource")
+		toDelete := &metallbv1beta1.ConfigurationState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stateName,
+				Namespace: metallb.Namespace,
+			},
+		}
+		err := ConfigUpdater.Client().Delete(context.Background(), toDelete)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying the ConfigurationState is recreated and returns to valid")
+		Eventually(func() error {
+			return stateMatches(stateName, validStatus)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+	})
+
 })
 
 func allStatesExist(allNodes *corev1.NodeList) error {
@@ -236,6 +255,29 @@ func allStatesExist(allNodes *corev1.NodeList) error {
 	}
 	if diff := cmp.Diff(want, got.Items, opts...); diff != "" {
 		return fmt.Errorf("ConfigurationState list mismatch (-want +got):\n%s", diff)
+	}
+
+	componentFieldOwners := map[string]string{
+		"controller": "poolReconciler",
+		"speaker":    "configReconciler",
+	}
+	for _, item := range got.Items {
+		componentType := item.Labels["metallb.io/component-type"]
+		wantManager, ok := componentFieldOwners[componentType]
+		if !ok {
+			return fmt.Errorf("ConfigurationState %q has unknown component-type label %q", item.Name, componentType)
+		}
+
+		found := false
+		for _, mf := range item.ManagedFields {
+			if mf.Subresource == "status" && mf.Manager == wantManager {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("ConfigurationState %q (component=%s) missing SSA field owner %q in status managed fields", item.Name, componentType, wantManager)
+		}
 	}
 
 	return nil

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -215,6 +216,8 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}).
 		Watches(&corev1.Namespace{}, &handler.EnqueueRequestForObject{}).
 		Watches(&corev1.ConfigMap{}, &handler.EnqueueRequestForObject{}).
+		Watches(&metallbv1beta1.ConfigurationState{}, &handler.EnqueueRequestForObject{},
+			builder.WithPredicates(NewConfigStateConditionReporterPredicate(r.Namespace, r.ConfigStateName))).
 		WithEventFilter(p).
 		Complete(r)
 }
@@ -280,7 +283,7 @@ func (r *ConfigReconciler) reportCondition(ctx context.Context, conditionErr err
 	}
 
 	condition := metav1.Condition{
-		Type:    "configReconcilerValid",
+		Type:    ConditionTypeConfigReconcilerValid,
 		Status:  metav1.ConditionTrue,
 		Reason:  ErrorTypeNone,
 		Message: "",

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -50,7 +50,7 @@ func TestConfigController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []metav1.Condition{
 				{
-					Type:   "configReconcilerValid",
+					Type:   ConditionTypeConfigReconcilerValid,
 					Status: metav1.ConditionTrue,
 					Reason: ErrorTypeNone,
 				},
@@ -64,7 +64,7 @@ func TestConfigController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []metav1.Condition{
 				{
-					Type:    "configReconcilerValid",
+					Type:    ConditionTypeConfigReconcilerValid,
 					Status:  metav1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: general handler sync state error",
@@ -79,7 +79,7 @@ func TestConfigController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []metav1.Condition{
 				{
-					Type:    "configReconcilerValid",
+					Type:    ConditionTypeConfigReconcilerValid,
 					Status:  metav1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: general handler sync state error",
@@ -94,7 +94,7 @@ func TestConfigController(t *testing.T) {
 			expectForceReloadCalled: true,
 			wantConditions: []metav1.Condition{
 				{
-					Type:    "configReconcilerValid",
+					Type:    ConditionTypeConfigReconcilerValid,
 					Status:  metav1.ConditionTrue,
 					Reason:  ErrorTypeNone,
 					Message: "",
@@ -109,7 +109,7 @@ func TestConfigController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []metav1.Condition{
 				{
-					Type:    "configReconcilerValid",
+					Type:    ConditionTypeConfigReconcilerValid,
 					Status:  metav1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: parsing peer peer1 missing local ASN",

--- a/internal/k8s/controllers/configuration_state_controller.go
+++ b/internal/k8s/controllers/configuration_state_controller.go
@@ -106,6 +106,31 @@ func NewConfigurationStateReconcilerPredicate(namespace, name string) predicate.
 	}
 }
 
+// NewConfigStateConditionReporterPredicate returns a predicate for controllers that write
+// conditions to a ConfigurationState CR. It fires only on Create events for the
+// target CR, so that conditions are re-reported after the resource is recreated.
+// Updates are handled by Server-Side Apply field ownership.
+func NewConfigStateConditionReporterPredicate(namespace, name string) predicate.Predicate {
+	matchesTarget := func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace && obj.GetName() == name
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return matchesTarget(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
 func (r *ConfigurationStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	p := NewConfigurationStateReconcilerPredicate(r.Namespace, r.ConfigStateName)
 

--- a/internal/k8s/controllers/configuration_state_controller_test.go
+++ b/internal/k8s/controllers/configuration_state_controller_test.go
@@ -57,13 +57,13 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:    "configReconcilerValid",
+							Type:    ConditionTypeConfigReconcilerValid,
 							Status:  metav1.ConditionTrue,
 							Reason:  "Valid",
 							Message: "",
 						},
 						{
-							Type:    "nodeReconcilerValid",
+							Type:    "testCondition",
 							Status:  metav1.ConditionTrue,
 							Reason:  "Valid",
 							Message: "",
@@ -85,13 +85,13 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:    "configReconcilerValid",
+							Type:    ConditionTypeConfigReconcilerValid,
 							Status:  metav1.ConditionFalse,
 							Reason:  ErrorTypeConfiguration,
 							Message: "peer peer1 referencing non existing bfd profile",
 						},
 						{
-							Type:    "nodeReconcilerValid",
+							Type:    "testCondition",
 							Status:  metav1.ConditionTrue,
 							Reason:  "Valid",
 							Message: "",
@@ -159,6 +159,115 @@ func TestConfigurationStateReconciler(t *testing.T) {
 
 			if diff := cmp.Diff(test.want, &got, opts...); diff != "" {
 				t.Errorf("ConfigurationState mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewConfigStateConditionReporterPredicate(t *testing.T) {
+	const (
+		targetNamespace = "metallb-system"
+		targetName      = "controller"
+	)
+
+	p := NewConfigStateConditionReporterPredicate(targetNamespace, targetName)
+
+	tests := map[string]struct {
+		event any
+		want  bool
+	}{
+		"Create matching CR": {
+			event: event.CreateEvent{
+				Object: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: targetNamespace,
+					},
+				},
+			},
+			want: true,
+		},
+		"Create different name": {
+			event: event.CreateEvent{
+				Object: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other",
+						Namespace: targetNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		"Create different namespace": {
+			event: event.CreateEvent{
+				Object: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: "other-namespace",
+					},
+				},
+			},
+			want: false,
+		},
+		"Update always returns false": {
+			event: event.UpdateEvent{
+				ObjectOld: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: targetNamespace,
+					},
+				},
+				ObjectNew: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: targetNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		"Delete matching CR": {
+			event: event.DeleteEvent{
+				Object: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: targetNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		"Generic matching CR": {
+			event: event.GenericEvent{
+				Object: &metallbv1beta1.ConfigurationState{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      targetName,
+						Namespace: targetNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got bool
+			switch e := test.event.(type) {
+			case event.CreateEvent:
+				got = p.Create(e)
+			case event.UpdateEvent:
+				got = p.Update(e)
+			case event.DeleteEvent:
+				got = p.Delete(e)
+			case event.GenericEvent:
+				got = p.Generic(e)
+			default:
+				t.Fatalf("unknown event type: %T", e)
+			}
+
+			if got != test.want {
+				t.Errorf("predicate returned %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/internal/k8s/controllers/pool_controller.go
+++ b/internal/k8s/controllers/pool_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -139,6 +140,8 @@ func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&metallbv1beta1.IPAddressPool{}).
 		Watches(&metallbv1beta1.Community{}, &handler.EnqueueRequestForObject{}).
 		Watches(&corev1.Namespace{}, &handler.EnqueueRequestForObject{}).
+		Watches(&metallbv1beta1.ConfigurationState{}, &handler.EnqueueRequestForObject{},
+			builder.WithPredicates(NewConfigStateConditionReporterPredicate(r.Namespace, r.ConfigStateName))).
 		WithEventFilter(p).
 		Complete(r)
 }
@@ -163,7 +166,7 @@ func (r *PoolReconciler) reportCondition(ctx context.Context, conditionErr error
 	}
 
 	condition := metav1.Condition{
-		Type:    "poolReconcilerValid",
+		Type:    ConditionTypePoolReconcilerValid,
 		Status:  metav1.ConditionTrue,
 		Reason:  ErrorTypeNone,
 		Message: "",

--- a/internal/k8s/controllers/pool_controller_test.go
+++ b/internal/k8s/controllers/pool_controller_test.go
@@ -48,7 +48,7 @@ func TestPoolController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []v1.Condition{
 				{
-					Type:   "poolReconcilerValid",
+					Type:   ConditionTypePoolReconcilerValid,
 					Status: v1.ConditionTrue,
 					Reason: ErrorTypeNone,
 				},
@@ -62,7 +62,7 @@ func TestPoolController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []v1.Condition{
 				{
-					Type:    "poolReconcilerValid",
+					Type:    ConditionTypePoolReconcilerValid,
 					Status:  v1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: general handler sync state error",
@@ -77,7 +77,7 @@ func TestPoolController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []v1.Condition{
 				{
-					Type:    "poolReconcilerValid",
+					Type:    ConditionTypePoolReconcilerValid,
 					Status:  v1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: general handler sync state error",
@@ -92,7 +92,7 @@ func TestPoolController(t *testing.T) {
 			expectForceReloadCalled: true,
 			wantConditions: []v1.Condition{
 				{
-					Type:    "poolReconcilerValid",
+					Type:    ConditionTypePoolReconcilerValid,
 					Status:  v1.ConditionTrue,
 					Reason:  ErrorTypeNone,
 					Message: "",
@@ -107,7 +107,7 @@ func TestPoolController(t *testing.T) {
 			expectForceReloadCalled: false,
 			wantConditions: []v1.Condition{
 				{
-					Type:    "poolReconcilerValid",
+					Type:    ConditionTypePoolReconcilerValid,
 					Status:  v1.ConditionFalse,
 					Reason:  ErrorTypeConfiguration,
 					Message: "configuration error: parsing address pool pool1: pool has no prefixes defined",

--- a/internal/k8s/controllers/values.go
+++ b/internal/k8s/controllers/values.go
@@ -35,6 +35,12 @@ const (
 	LabelServiceNamespace = "metallb.io/service-namespace"
 )
 
+// Condition types for ConfigurationState status reporting.
+const (
+	ConditionTypeConfigReconcilerValid = "configReconcilerValid"
+	ConditionTypePoolReconcilerValid   = "poolReconcilerValid"
+)
+
 // Error types for condition reporting.
 const (
 	ErrorTypeConfiguration = "ConfigurationError"


### PR DESCRIPTION
ConfigReconciler and PoolReconciler now watch ConfigurationState and
re-report their conditions when the resource is recreated.
We explicitly don't act on the UPDATE path, because this is
handled by SSA.


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix ConfigurationState to be updated when the resource is recreated.
```
