### PR TITLE
Fix unreachable code in BFDPeersMatchNodes validation

### DIFF
--- a/e2etest/pkg/frr/validation.go
+++ b/e2etest/pkg/frr/validation.go
@@ -66,6 +66,8 @@ func RoutesMatchNodes(nodes []v1.Node, route Route, ipFamily ipfamily.Family, vr
 	return nil
 }
 
+// BFDPeersMatchNodes verifies that the BFD peers exactly match the node IPs for the given
+// IP family and VRF.
 func BFDPeersMatchNodes(nodes []v1.Node, peers map[string]BFDPeer, ipFamily ipfamily.Family, vrfName string) error {
 	nodesIPs := map[string]struct{}{}
 	ips, err := k8s.NodeIPsForFamily(nodes, ipFamily, vrfName)
@@ -78,15 +80,10 @@ func BFDPeersMatchNodes(nodes []v1.Node, peers map[string]BFDPeer, ipFamily ipfa
 			return fmt.Errorf("address %s not found in peers", ip)
 		}
 	}
-
 	for k := range peers {
-		if _, ok := nodesIPs[k]; !ok { // skipping neighbors that are not nodes
+		if _, ok := nodesIPs[k]; !ok {
 			return fmt.Errorf("%s not found in nodes ips %v", k, nodesIPs)
 		}
-		delete(nodesIPs, k)
-	}
-	if len(nodesIPs) != 0 { // some leftover, meaning more nodes than routes
-		return fmt.Errorf("IP %v found in nodes but not in bfd peers", nodesIPs)
 	}
 	return nil
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
The check for remaining entries in nodesIPs after the peers loop was
unreachable because the first loop already validates that every node IP
exists in peers, and the second loop validates the reverse. This means
both maps have identical keys, so nodesIPs is always empty after the
deletions.

Removed the unreachable length check and updated the function comment
to better describe the one-to-one correspondence validation between
BFD peers and nodes.

**Special notes for your reviewer**:

**Release note**:

```release-note

```
