### PR TITLE
Fix wrong 'error' string in ConfigurationStateReconciler

### DIFF
--- a/internal/k8s/controllers/configuration_state_controller.go
+++ b/internal/k8s/controllers/configuration_state_controller.go
@@ -52,7 +52,7 @@ func (r *ConfigurationStateReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 
-		level.Info(r.Logger).Log("controller", r, "error", "ConfigurationState created", "name", r.ConfigStateName)
+		level.Info(r.Logger).Log("controller", r, "event", "ConfigurationState created", "name", r.ConfigStateName)
 		return ctrl.Result{}, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

/kind bug

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
