### PR TITLE
fix: remove deprecated metallb.universe.tf managed annotations on upgrade

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -213,6 +213,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		svc.Annotations = make(map[string]string)
 	}
 	svc.Annotations[AnnotationIPAllocateFromPool] = pool
+	delete(svc.Annotations, DeprecatedAnnotationIPAllocateFromPool)
 
 	return nil
 }
@@ -246,6 +247,7 @@ func serviceFamilyChanged(
 func (c *controller) clearServiceState(key string, svc *v1.Service) {
 	c.ips.Unassign(key)
 	delete(svc.Annotations, AnnotationIPAllocateFromPool)
+	delete(svc.Annotations, DeprecatedAnnotationIPAllocateFromPool)
 	svc.Status.LoadBalancer = v1.LoadBalancerStatus{}
 }
 


### PR DESCRIPTION
## Summary
- Delete the deprecated `metallb.universe.tf/ip-allocated-from-pool` annotation when setting the new `metallb.io/ip-allocated-from-pool` annotation
- Also clean up the deprecated annotation in `clearServiceState`

## Motivation
Fixes #2642 — Services deployed with older MetalLB versions retain the deprecated `metallb.universe.tf/ip-allocated-from-pool` annotation after upgrading. The controller sets the new `metallb.io` annotation but never removes the old `metallb.universe.tf` one, leaving stale annotations on services.

## Root Cause
`convergeBalancer` (line 215) sets `AnnotationIPAllocateFromPool` but doesn't delete `DeprecatedAnnotationIPAllocateFromPool`. `clearServiceState` (line 248) only deletes the new annotation.

## Changes
- `controller/service.go`: Add `delete(svc.Annotations, DeprecatedAnnotationIPAllocateFromPool)` in both `convergeBalancer` and `clearServiceState`

## Test plan
- [x] When MetalLB assigns an IP, the deprecated annotation is removed if present
- [x] When service state is cleared, both annotations are removed
- [x] No change in behavior for services without deprecated annotations