### PR TITLE
TEMPORARY FIX: replace kube-rbac-proxy registry

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -61,6 +61,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.webhookMode | string | `"enabled"` |  |
 | crds.enabled | bool | `true` |  |
 | crds.validationFailurePolicy | string | `"Fail"` |  |
+| frr-k8s.prometheus.rbacProxy.repository | string | `"registry.k8s.io/kubebuilder/kube-rbac-proxy"` |  |
 | frrk8s.enabled | bool | `false` |  |
 | frrk8s.external | bool | `false` |  |
 | frrk8s.namespace | string | `""` |  |
@@ -104,7 +105,7 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.prometheusRule.staleConfig.labels.severity | string | `"warning"` |  |
 | prometheus.rbacPrometheus | bool | `true` |  |
 | prometheus.rbacProxy.pullPolicy | string | `nil` |  |
-| prometheus.rbacProxy.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
+| prometheus.rbacProxy.repository | string | `"registry.k8s.io/kubebuilder/kube-rbac-proxy"` |  |
 | prometheus.rbacProxy.tag | string | `"v0.12.0"` |  |
 | prometheus.scrapeAnnotations | bool | `false` |  |
 | prometheus.serviceAccount | string | `""` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -55,7 +55,7 @@ prometheus:
 
   # the image to be used for the kuberbacproxy container
   rbacProxy:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
     tag: v0.12.0
     pullPolicy:
 
@@ -378,6 +378,11 @@ frrk8s:
   enabled: false
   external: false
   namespace: ""
+
+frr-k8s:
+  prometheus:
+    rbacProxy:
+      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
 
 # networkpolicies
 networkpolicies:

--- a/config/frr-k8s/kustomization.yaml
+++ b/config/frr-k8s/kustomization.yaml
@@ -16,3 +16,6 @@ patchesJson6902:
       kind: ClusterRole
       name: metallb-system:speaker
     path: clusterrole-patch.yaml
+images:
+  - name: gcr.io/kubebuilder/kube-rbac-proxy
+    newName: registry.k8s.io/kubebuilder/kube-rbac-proxy

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3326,7 +3326,7 @@ spec:
         - --upstream=http://127.0.0.1:7472/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120
@@ -3496,7 +3496,7 @@ spec:
         - --upstream=http://127.0.0.1:7572/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 9140
@@ -3519,7 +3519,7 @@ spec:
         - --upstream=http://127.0.0.1:7573/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy-frr
         ports:
         - containerPort: 9141
@@ -3864,7 +3864,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -3377,7 +3377,7 @@ spec:
         - --upstream=http://127.0.0.1:7572/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 9140
@@ -3400,7 +3400,7 @@ spec:
         - --upstream=http://127.0.0.1:7573/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy-frr
         ports:
         - containerPort: 9141

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2308,7 +2308,7 @@ spec:
         - --upstream=http://127.0.0.1:7472/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120
@@ -2420,7 +2420,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120
@@ -2448,7 +2448,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy-frr
         ports:
         - containerPort: 9121

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -2207,7 +2207,7 @@ spec:
         - --upstream=http://127.0.0.1:7472/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120
@@ -2318,7 +2318,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9120

--- a/config/prometheus-frr-k8s/kustomization.yaml
+++ b/config/prometheus-frr-k8s/kustomization.yaml
@@ -24,3 +24,6 @@ patches:
       kind: ServiceMonitor
       name: frr-k8s-metrics-monitor
 namespace: metallb-system
+images:
+  - name: gcr.io/kubebuilder/kube-rbac-proxy
+    newName: registry.k8s.io/kubebuilder/kube-rbac-proxy

--- a/config/prometheus-frr/rbac-proxy-patch.yaml
+++ b/config/prometheus-frr/rbac-proxy-patch.yaml
@@ -14,7 +14,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+          image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:9120"
             - "--upstream=http://127.0.0.1:7472/"
@@ -46,7 +46,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+          image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:9120"
             - "--upstream=http://$(METALLB_HOST):7472/"
@@ -75,7 +75,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+          image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:9121"
             - "--upstream=http://$(METALLB_HOST):7473/"

--- a/config/prometheus-native/rbac-proxy-patch.yaml
+++ b/config/prometheus-native/rbac-proxy-patch.yaml
@@ -15,7 +15,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+          image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:9120"
             - "--upstream=http://127.0.0.1:7472/"
@@ -48,7 +48,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+          image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:9120"
             - "--upstream=http://$(METALLB_HOST):7472/"

--- a/tasks.py
+++ b/tasks.py
@@ -558,12 +558,23 @@ apiServer:
 
     frr_k8s_ns = "frr-k8s-system"
     if bgp_type == "frr-k8s-external":
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            frr_k8s_manifest_path = f.name
+            result = run(
+                "curl -sL https://raw.githubusercontent.com/metallb/frr-k8s/v0.0.22/config/all-in-one/frr-k8s.yaml",
+                hide=True,
+            )
+            f.write(
+                result.stdout.replace(
+                    "gcr.io/kubebuilder/kube-rbac-proxy",
+                    "registry.k8s.io/kubebuilder/kube-rbac-proxy",
+                )
+            )
         run(
-            "{} apply -f https://raw.githubusercontent.com/metallb/frr-k8s/v0.0.22/config/all-in-one/frr-k8s.yaml".format(
-                kubectl_path
-            ),
+            "{} apply -f {}".format(kubectl_path, frr_k8s_manifest_path),
             echo=True,
         )
+        os.unlink(frr_k8s_manifest_path)
         time.sleep(2)
         run(
             "{} -n {} wait --for=condition=Ready --all pods --timeout 300s".format(


### PR DESCRIPTION
gcr.io is no longer available for the kube-rbac-proxy image, we replace it with registry.k8s.io.
This fix is temporary (and unblocks CI), the real fix is removing the dependency on kube-rbac-proxy as was suggested a while ago.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
/kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
