### PR TITLE
e2etests: add nodeSelector with bgpAdv update

### DIFF
--- a/e2etest/bgptests/node_selector.go
+++ b/e2etest/bgptests/node_selector.go
@@ -263,6 +263,91 @@ var _ = ginkgo.Describe("BGP Node Selector", func() {
 		ginkgo.Entry("IPV6", ipfamily.IPv6, "fc00:f853:0ccd:e799::/116"),
 	)
 
+	ginkgo.DescribeTable("Two advertisements - updating one nodeSelector to non-matching withdraws its service without affecting the other",
+		func(pairingIPFamily ipfamily.Family, addresses []string) {
+			var allNodes *corev1.NodeList
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "first-pool",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{addresses[0]},
+						},
+					}, {
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "second-pool",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{addresses[1]},
+						},
+					},
+				},
+				Peers: metallb.PeersForContainers(FRRContainers, pairingIPFamily),
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "first-adv",
+						},
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							NodeSelectors:   k8s.SelectorsForNodes(allNodes.Items),
+							IPAddressPools: []string{"first-pool"},
+						},
+					}, {
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "second-adv",
+						},
+						Spec: metallbv1beta1.BGPAdvertisementSpec{
+							NodeSelectors:   k8s.SelectorsForNodes(allNodes.Items),
+							IPAddressPools: []string{"second-pool"},
+						},
+					},
+				},
+			}
+			for _, c := range FRRContainers {
+				err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			firstService, _ := testservice.CreateWithBackend(cs, testNamespace, "first-lb", testservice.WithSpecificPool("first-pool"))
+			defer testservice.Delete(cs, firstService)
+			secondService, _ := testservice.CreateWithBackend(cs, testNamespace, "second-lb", testservice.WithSpecificPool("second-pool"))
+			defer testservice.Delete(cs, secondService)
+
+			ginkgo.By("Checking first service announced from all nodes")
+			for _, c := range FRRContainers {
+				validateService(firstService, allNodes.Items, c)
+			}
+			ginkgo.By("Checking second service announced from all nodes")
+			for _, c := range FRRContainers {
+				validateService(secondService, allNodes.Items, c)
+			}
+
+			ginkgo.By("Updating second BGP advertisement with non-existing node selector")
+			resources.BGPAdvs[1].Spec.NodeSelectors = []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"non-existing-label": "true"}},
+			}
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Validating first service still advertised from all nodes")
+			for _, c := range FRRContainers {
+				validateService(firstService, allNodes.Items, c)
+			}
+			ginkgo.By("Validating second service no longer advertised from all nodes")
+			checkServiceNotOnNodes(secondService, allNodes.Items, pairingIPFamily)
+		},
+		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{"192.168.10.0/24", "192.168.16.0/24"}),
+		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{"fc00:f853:0ccd:e799::/116", "fc00:f853:0ccd:e800::/116"}),
+	)
+
 	ginkgo.Context("Peer selector", func() {
 		// nodeForPeers is a map between container index and the indexes of the nodes we want to peer it with.
 		// we cant use strings to avoid making assumptions on the names of the containers / nodes.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**: New e2e test for bgpAdvertisement with nodeSelector update

> Uncomment only one, leave it on its own line:
>
> /kind bug
 /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**: Migrate tests from eco-gotests

**Special notes for your reviewer**: 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
