### PR TITLE
speaker: add periodic gratuitous ARP support

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -32,8 +32,10 @@ type Announce struct {
 	excludeRegexp *regexp.Regexp
 }
 
-// New returns an initialized Announce.
-func New(l log.Logger, excludeRegexp *regexp.Regexp) (*Announce, error) {
+// New returns an initialized Announce. If gratuitousARPInterval is positive,
+// a background goroutine periodically sends gratuitous ARP/NDP for all
+// announced IPs at that interval.
+func New(l log.Logger, excludeRegexp *regexp.Regexp, gratuitousARPInterval time.Duration) (*Announce, error) {
 	ret := &Announce{
 		logger:         l,
 		nodeInterfaces: []string{},
@@ -47,6 +49,10 @@ func New(l log.Logger, excludeRegexp *regexp.Regexp) (*Announce, error) {
 
 	go ret.interfaceScan()
 	go ret.spamLoop()
+	if gratuitousARPInterval > 0 {
+		level.Info(l).Log("op", "periodicGARP", "msg", "periodic gratuitous ARP enabled", "interval", gratuitousARPInterval)
+		go ret.periodicGARPLoop(gratuitousARPInterval)
+	}
 
 	return ret, nil
 }
@@ -198,6 +204,62 @@ func (a *Announce) spamLoop() {
 
 func (a *Announce) doSpam(adv IPAdvertisement) {
 	a.spamCh <- adv
+}
+
+func (a *Announce) periodicGARPLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		a.sendPeriodicGratuitous()
+	}
+}
+
+func (a *Announce) sendPeriodicGratuitous() {
+	for _, adv := range a.mergedAdvertisementsPerIP() {
+		a.gratuitous(adv)
+	}
+}
+
+// mergedAdvertisementsPerIP returns one IPAdvertisement per unique IP,
+// merging interface constraints across all advertisements for that IP:
+// allInterfaces=true if any source advertisement has it, otherwise the
+// union of interface sets. This ensures periodic gratuitous announcements
+// reach every interface where the IP is being advertised.
+func (a *Announce) mergedAdvertisementsPerIP() []IPAdvertisement {
+	a.RLock()
+	defer a.RUnlock()
+
+	merged := map[string]IPAdvertisement{}
+	for _, ipAdvs := range a.ips {
+		for _, adv := range ipAdvs {
+			ipStr := adv.ip.String()
+			existing, ok := merged[ipStr]
+			if !ok {
+				m := adv
+				if !m.allInterfaces {
+					m.interfaces = m.interfaces.Clone()
+				}
+				merged[ipStr] = m
+				continue
+			}
+			if existing.allInterfaces {
+				continue
+			}
+			if adv.allInterfaces {
+				existing.allInterfaces = true
+				existing.interfaces = nil
+			} else {
+				existing.interfaces = existing.interfaces.Union(adv.interfaces)
+			}
+			merged[ipStr] = existing
+		}
+	}
+
+	advs := make([]IPAdvertisement, 0, len(merged))
+	for _, adv := range merged {
+		advs = append(advs, adv)
+	}
+	return advs
 }
 
 func (a *Announce) gratuitous(adv IPAdvertisement) {

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -62,3 +62,98 @@ func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 		t.Fatalf("ip 192.168.1.20 has not 2 refcnt: %d", announce.ipRefcnt["192.168.1.20"])
 	}
 }
+
+func Test_MergedAdvertisementsPerIP(t *testing.T) {
+	ipA := net.IPv4(192, 168, 1, 100)
+	ipB := net.IPv4(192, 168, 1, 101)
+
+	tests := []struct {
+		name              string
+		ips               map[string][]IPAdvertisement
+		wantAllInterfaces map[string]bool
+		wantInterfaces    map[string]sets.Set[string]
+	}{
+		{
+			name: "allInterfaces wins over interface set",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, allInterfaces: true}},
+				"svc2": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+			},
+			wantAllInterfaces: map[string]bool{ipA.String(): true},
+		},
+		{
+			name: "interface sets are unioned",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+				"svc2": {{ip: ipA, interfaces: sets.New("eth1"), allInterfaces: false}},
+			},
+			wantAllInterfaces: map[string]bool{ipA.String(): false},
+			wantInterfaces:    map[string]sets.Set[string]{ipA.String(): sets.New("eth0", "eth1")},
+		},
+		{
+			name: "distinct IPs produce distinct entries",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+				"svc2": {{ip: ipB, allInterfaces: true}},
+			},
+			wantAllInterfaces: map[string]bool{ipA.String(): false, ipB.String(): true},
+			wantInterfaces:    map[string]sets.Set[string]{ipA.String(): sets.New("eth0")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			announce := &Announce{
+				ips: tt.ips,
+			}
+			merged := announce.mergedAdvertisementsPerIP()
+			if len(merged) != len(tt.wantAllInterfaces) {
+				t.Fatalf("got %d merged advs, want %d", len(merged), len(tt.wantAllInterfaces))
+			}
+			byIP := map[string]IPAdvertisement{}
+			for _, adv := range merged {
+				byIP[adv.ip.String()] = adv
+			}
+			for ip, wantAll := range tt.wantAllInterfaces {
+				adv, ok := byIP[ip]
+				if !ok {
+					t.Fatalf("missing merged advertisement for %s", ip)
+				}
+				if adv.allInterfaces != wantAll {
+					t.Errorf("ip %s: allInterfaces=%v, want %v", ip, adv.allInterfaces, wantAll)
+				}
+				if !wantAll {
+					if !adv.interfaces.Equal(tt.wantInterfaces[ip]) {
+						t.Errorf("ip %s: interfaces=%v, want %v", ip, adv.interfaces, tt.wantInterfaces[ip])
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_MergedAdvertisementsPerIP_DoesNotMutateInputs(t *testing.T) {
+	ip := net.IPv4(192, 168, 1, 100)
+	original := sets.New("eth0")
+	announce := &Announce{
+		ips: map[string][]IPAdvertisement{
+			"svc1": {{ip: ip, interfaces: original, allInterfaces: false}},
+			"svc2": {{ip: ip, interfaces: sets.New("eth1"), allInterfaces: false}},
+		},
+	}
+	_ = announce.mergedAdvertisementsPerIP()
+	if !original.Equal(sets.New("eth0")) {
+		t.Fatalf("source interface set was mutated: %v", original)
+	}
+}
+
+func Test_SendPeriodicGratuitous_SkipsWhenNoIPs(t *testing.T) {
+	announce := &Announce{
+		ips:      map[string][]IPAdvertisement{},
+		ipRefcnt: map[string]int{},
+		spamCh:   make(chan IPAdvertisement, 1024),
+	}
+
+	// No IPs registered — should be a no-op.
+	announce.sendPeriodicGratuitous()
+}

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -49,7 +49,7 @@ type layer2Controller struct {
 	onStatusChange  func(types.NamespacedName)
 }
 
-func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
+func (c *layer2Controller) SetConfig(_ log.Logger, _ *config.Config) error {
 	return nil
 }
 

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"os/signal"
@@ -66,6 +67,10 @@ var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 const (
 	excludeL2ConfigPath    = "/etc/metallb/excludel2.yaml"
 	defaultDebounceTimeout = 3 * time.Second
+	// Cap the gratuitous ARP interval well below the time.Duration overflow
+	// point (max ~9.2e9 seconds for an int64 ns duration) while still
+	// allowing any sensible value.
+	maxGratuitousARPInterval = math.MaxInt32
 )
 
 // Service offers methods to mutate a Kubernetes service object.
@@ -77,6 +82,18 @@ type service interface {
 
 func main() {
 	crmetrics.Registry.MustRegister(announcing)
+
+	// Resolve env-var default for gratuitous ARP interval before flag.Parse
+	// so an explicit --gratuitous-arp-interval=0 can override a non-zero env.
+	gratuitousARPDefault := 0
+	if envVal := os.Getenv("METALLB_GRATUITOUS_ARP_INTERVAL"); envVal != "" {
+		parsed, err := strconv.Atoi(envVal)
+		if err != nil || parsed < 0 || parsed > maxGratuitousARPInterval {
+			fmt.Fprintf(os.Stderr, "invalid METALLB_GRATUITOUS_ARP_INTERVAL value %q, must be a non-negative integer number of seconds <= %d\n", envVal, maxGratuitousARPInterval)
+			os.Exit(1)
+		}
+		gratuitousARPDefault = parsed
+	}
 
 	var (
 		bgpDebounceTimeoutMs = flag.String("bgp-debounce-timeout", os.Getenv("METALLB_BGP_DEBOUNCE_TIMEOUT"),
@@ -103,6 +120,8 @@ func main() {
 		tlsCipherSuites         = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS cipher suites. Only applies to TLS 1.2. If empty, uses Go defaults.")
 		tlsCurvePreferences     = flag.String("tls-curve-preferences", "", "Comma-separated list of numeric CurveID values (see https://pkg.go.dev/crypto/tls#CurveID). If empty, uses Go defaults.")
 		metricsCertDir          = flag.String("metrics-cert-dir", "", "Directory containing tls.crt and tls.key for metrics TLS. If empty, auto-generated self-signed cert is used.")
+		gratuitousARPInterval   = flag.Int("gratuitous-arp-interval", gratuitousARPDefault, "Interval in seconds for periodic gratuitous ARP/NDP announcements. "+
+			"0 disables periodic announcements. Can also be set via METALLB_GRATUITOUS_ARP_INTERVAL.")
 	)
 
 	flag.Parse()
@@ -140,6 +159,12 @@ func main() {
 		bgpDebounceTimeout = time.Duration(parsed) * time.Millisecond
 	}
 	level.Debug(logger).Log("msg", "using BGP debounce timeout", "milliseconds", bgpDebounceTimeout.Milliseconds())
+
+	if *gratuitousARPInterval < 0 || *gratuitousARPInterval > maxGratuitousARPInterval {
+		level.Error(logger).Log("msg", "invalid --gratuitous-arp-interval value, must be a non-negative integer number of seconds within bound", "provided", *gratuitousARPInterval, "max", maxGratuitousARPInterval)
+		os.Exit(1)
+	}
+	garpInterval := time.Duration(*gratuitousARPInterval) * time.Second
 
 	if bgpType == "frr" {
 		level.Warn(logger).Log("op", "startup", "msg", "The FRR mode is deprecated and will be removed in a future release. Please migrate to the frr-k8s mode, which is now the default BGP backend. See https://metallb.io/concepts/bgp/#frr-k8s-mode for details.")
@@ -224,6 +249,7 @@ func main() {
 		InterfaceExcludeRegexp:  interfacesToExclude,
 		IgnoreExcludeLB:         *ignoreLBExclude,
 		BGPDebounceTimeout:      bgpDebounceTimeout,
+		GratuitousARPInterval:   garpInterval,
 		Layer2StatusChange: func(namespacedName types.NamespacedName) {
 			l2StatusChan <- controllers.NewL2StatusEvent(namespacedName.Namespace, namespacedName.Name)
 		},
@@ -332,6 +358,7 @@ type controllerConfig struct {
 	InterfaceExcludeRegexp       *regexp.Regexp
 	IgnoreExcludeLB              bool
 	BGPDebounceTimeout           time.Duration
+	GratuitousARPInterval        time.Duration
 	Layer2StatusChange           func(types.NamespacedName)
 	BGPAdsChangedCallback        func(string)
 }
@@ -364,7 +391,7 @@ func newController(cfg controllerConfig) (*controller, error) {
 
 	layer2StatusFetcher := func(types.NamespacedName) []layer2.IPAdvertisement { return nil }
 	if !cfg.DisableLayer2 {
-		a, err := layer2.New(cfg.Logger, cfg.InterfaceExcludeRegexp)
+		a, err := layer2.New(cfg.Logger, cfg.InterfaceExcludeRegexp, cfg.GratuitousARPInterval)
 		layer2StatusFetcher = a.GetStatus
 		if err != nil {
 			return nil, fmt.Errorf("making layer2 announcer: %s", err)

--- a/website/content/concepts/layer2.md
+++ b/website/content/concepts/layer2.md
@@ -67,6 +67,24 @@ about 10s), please [file a bug](https://github.com/metallb/metallb/issues/new)!
 We can help you investigate and determine if the issue is with the client, or a
 bug in MetalLB.
 
+## Periodic gratuitous announcements
+
+By default MetalLB only sends gratuitous ARP/NDP packets on failover. In some
+environments — for example, switches that age FDB entries faster than upstream
+gateways age their ARP cache — this can result in periodic packet loss for
+service IPs even without a leadership change. To work around this, the speaker
+can be configured to re-emit gratuitous ARP/NDP packets for every announced IP
+on a fixed interval, via the `--gratuitous-arp-interval` flag (or the
+`METALLB_GRATUITOUS_ARP_INTERVAL` environment variable). The value is in
+seconds; `0` (the default) keeps the original failover-only behaviour.
+
+The interval applies speaker-wide to every L2-announced IP on the node. Each
+tick emits one packet per (IP, matching interface) pair, so very short
+intervals on speakers announcing many IPs across many interfaces can produce a
+noticeable amount of broadcast traffic and slow down the speaker's handling of
+service updates. As a rule of thumb, pick the largest interval that is still
+shorter than your switch's FDB aging time.
+
 ## How the L2 leader election works
 
 The election of the "leader" (the node which is going to advertise the IP) of a

--- a/website/content/concepts/layer2.md
+++ b/website/content/concepts/layer2.md
@@ -78,12 +78,11 @@ on a fixed interval, via the `--gratuitous-arp-interval` flag (or the
 `METALLB_GRATUITOUS_ARP_INTERVAL` environment variable). The value is in
 seconds; `0` (the default) keeps the original failover-only behaviour.
 
-The interval applies speaker-wide to every L2-announced IP on the node. Each
-tick emits one packet per (IP, matching interface) pair, so very short
-intervals on speakers announcing many IPs across many interfaces can produce a
-noticeable amount of broadcast traffic and slow down the speaker's handling of
-service updates. As a rule of thumb, pick the largest interval that is still
-shorter than your switch's FDB aging time.
+The interval applies speaker-wide to every L2-announced IP on the node, so
+very short intervals on speakers announcing many IPs across many interfaces
+can produce a noticeable amount of broadcast traffic and slow down the
+speaker's handling of service updates. As a rule of thumb, pick the largest
+interval that is still shorter than your switch's FDB aging time.
 
 ## How the L2 leader election works
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug

**What this PR does / why we need it**:
Fixes: metallb/metallb#2910
We hit regular packet loss issue with Hetzner public IPs in vSwitch. Gratuitous ARP fixed it in our tests.

**Special notes for your reviewer**:

Adds a speaker-wide `--gratuitous-arp-interval` flag (also configurable via the `METALLB_GRATUITOUS_ARP_INTERVAL` environment variable) that enables periodic gratuitous ARP/NDP announcements at a user-defined interval, in seconds. This prevents traffic blackholes caused by switch FDB entry aging when FDB aging time is shorter than gateway ARP timeout.

When set to 0 (default), only failover announcements are sent (existing behavior). The interval applies to every IP currently announced by this speaker via L2; per-`L2Advertisement` configuration is intentionally not exposed here to keep the surface area small — the pain point this addresses is environmental (switch/network), not per-service.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add a speaker --gratuitous-arp-interval flag (also configurable via METALLB_GRATUITOUS_ARP_INTERVAL) to enable periodic gratuitous ARP/NDP announcements
```
