### PR TITLE
fix: handle lbIP family error by clearing state instead of continuing

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -100,8 +100,8 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	} else {
 		lbIPsIPFamily, err := ipfamily.ForAddressesIPs(lbIPs)
 		if err != nil {
-			level.Error(l).Log("event", "clearAssignment", "reason", "nolbIPsIPFamily", "msg", "Failed to retrieve lbIPs family")
-			c.client.Errorf(svc, "nolbIPsIPFamily", "Failed to retrieve LBIPs IPFamily for %q: %s", lbIPs, err)
+			level.Error(l).Log("event", "clearAssignment", "reason", "nolbIPsIPFamily", "msg", "Failed to retrieve lbIPs family", "err", err, "lbIPs", lbIPs)
+			c.client.Errorf(svc, "nolbIPsIPFamily", "Failed to retrieve LBIPs IPFamily for %v: %s", lbIPs, err)
 			c.clearServiceState(key, svc)
 			lbIPs = []net.IP{}
 		} else {

--- a/controller/service.go
+++ b/controller/service.go
@@ -102,19 +102,22 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		if err != nil {
 			level.Error(l).Log("event", "clearAssignment", "reason", "nolbIPsIPFamily", "msg", "Failed to retrieve lbIPs family")
 			c.client.Errorf(svc, "nolbIPsIPFamily", "Failed to retrieve LBIPs IPFamily for %q: %s", lbIPs, err)
-		}
-		clusterIPsIPFamily, err := ipfamily.ForService(svc)
-		if err != nil {
-			level.Error(l).Log("event", "clearAssignment", "reason", "noclusterIPsIPFamily", "msg", "Failed to retrieve clusterIPs family")
-			c.client.Errorf(svc, "noclusterIPsIPFamily", "Failed to retrieve ClusterIPs IPFamily for %q %s: %s", svc.Spec.ClusterIPs, svc.Spec.ClusterIP, err)
-			return ErrConverge
-		}
-
-		// if the lbIP family has changed from its supposed state, clear the lbIP.
-		// (this should not happen since the "ipFamily" of a service is immutable)
-		if serviceFamilyChanged(lbIPsIPFamily, clusterIPsIPFamily, familyPolicy) {
 			c.clearServiceState(key, svc)
 			lbIPs = []net.IP{}
+		} else {
+			clusterIPsIPFamily, err := ipfamily.ForService(svc)
+			if err != nil {
+				level.Error(l).Log("event", "clearAssignment", "reason", "noclusterIPsIPFamily", "msg", "Failed to retrieve clusterIPs family")
+				c.client.Errorf(svc, "noclusterIPsIPFamily", "Failed to retrieve ClusterIPs IPFamily for %q %s: %s", svc.Spec.ClusterIPs, svc.Spec.ClusterIP, err)
+				return ErrConverge
+			}
+
+			// if the lbIP family has changed from its supposed state, clear the lbIP.
+			// (this should not happen since the "ipFamily" of a service is immutable)
+			if serviceFamilyChanged(lbIPsIPFamily, clusterIPsIPFamily, familyPolicy) {
+				c.clearServiceState(key, svc)
+				lbIPs = []net.IP{}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

In `convergeBalancer()`, when `ipfamily.ForAddressesIPs(lbIPs)` fails, the error is logged but execution continues to `serviceFamilyChanged()` using the potentially invalid `lbIPsIPFamily` value. The adjacent `ForService()` error correctly returns `ErrConverge`, but this path was missing equivalent handling.

The fix clears the service state and resets `lbIPs` on family detection failure, then wraps the family comparison check in an `else` branch so it only runs when family detection succeeds. This allows the convergence logic to re-allocate a valid IP rather than operating on an undefined family value.

## Changes

- `controller/service.go:101-119` — Added `clearServiceState` + `lbIPs` reset on `ForAddressesIPs` error, moved `ForService` and `serviceFamilyChanged` into an `else` block

## Testing

- Existing test `"simple LoadBalancer, ips already assigned but can't determine family"` validates this exact scenario — the service gets its state cleared and a valid IP re-allocated
- All controller tests pass