### PR TITLE
fix: make sortPools comparator satisfy strict weak ordering

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -596,16 +596,22 @@ func sortPools(pools []*config.Pool) {
 	// pools from higher to low priority. when no priority (0) set on
 	// the pool, then that is considered as lowest priority.
 	sort.Slice(pools, func(i, j int) bool {
-		if pools[i].ServiceAllocations.Priority > 0 &&
-			pools[j].ServiceAllocations.Priority > 0 {
-			return pools[i].ServiceAllocations.Priority <
-				pools[j].ServiceAllocations.Priority
+		iPrio := pools[i].ServiceAllocations.Priority
+		jPrio := pools[j].ServiceAllocations.Priority
+		// Both have explicit priority: sort by ascending priority value
+		if iPrio > 0 && jPrio > 0 {
+			return iPrio < jPrio
 		}
-		if pools[i].ServiceAllocations.Priority == 0 &&
-			pools[j].ServiceAllocations.Priority > 0 {
+		// Only i has priority: i comes first
+		if iPrio > 0 && jPrio == 0 {
+			return true
+		}
+		// Only j has priority: j comes first
+		if iPrio == 0 && jPrio > 0 {
 			return false
 		}
-		return true
+		// Both have no priority: they are equal, neither is less
+		return false
 	})
 }
 

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -592,9 +592,9 @@ func (a *Allocator) CountersForPool(name string) PoolCounters {
 }
 
 func sortPools(pools []*config.Pool) {
-	// A lower value for pool priority equals a higher priority and sort
-	// pools from higher to low priority. when no priority (0) set on
-	// the pool, then that is considered as lowest priority.
+	// A lower value for pool priority equals a higher priority. Sort
+	// pools from high to low priority. When no priority (0) is set on
+	// a pool, it is considered as lowest priority.
 	sort.Slice(pools, func(i, j int) bool {
 		iPrio := pools[i].ServiceAllocations.Priority
 		jPrio := pools[j].ServiceAllocations.Priority


### PR DESCRIPTION
## Summary

The `sort.Slice` comparator in `sortPools()` violated strict weak ordering: when both pools had priority 0, `less(i,j)` and `less(j,i)` both returned `true`. This means `i < j` and `j < i` simultaneously, which is undefined behavior for `sort.Slice`. Depending on the Go runtime version and input size, this can cause non-deterministic pool ordering or panics.

The fix rewrites the comparator with explicit handling for all four priority cases and returns `false` when both priorities are equal (neither is "less than" the other).

## Changes

- `internal/allocator/allocator.go:594-610` — Rewrote `sortPools` comparator with explicit cases for all priority combinations

## Testing

- All allocator tests pass
- The fix preserves existing sort semantics: pools with explicit priority sort ascending, pools without priority sort last