### PR TITLE
fix: use correct variable in FRR neighbor parse error messages

### DIFF
--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -117,7 +117,7 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 	for k, n := range res {
 		ip := net.ParseIP(k)
 		if ip == nil {
-			return nil, fmt.Errorf("failed to parse %s as ip", ip)
+			return nil, fmt.Errorf("failed to parse %s as ip", k)
 		}
 		connected := true
 		if n.BgpState != bgpConnected {
@@ -154,7 +154,7 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 	for k, n := range toParse {
 		ip := net.ParseIP(k)
 		if ip == nil {
-			return nil, fmt.Errorf("failed to parse %s as ip", ip)
+			return nil, fmt.Errorf("failed to parse %s as ip", k)
 		}
 		connected := true
 		if n.BgpState != bgpConnected {


### PR DESCRIPTION
## Summary

Both `ParseNeighbour` and `ParseNeighbours` in `internal/bgp/frr/parse.go` log the nil result of `net.ParseIP(k)` instead of the original string `k` when IP parsing fails. This produces useless error messages like `"failed to parse <nil> as ip"` instead of showing the actual malformed input string.

## Changes

- `internal/bgp/frr/parse.go:120` — Change `ip` to `k` in error format string
- `internal/bgp/frr/parse.go:157` — Same fix in `ParseNeighbours`

## Testing

- All FRR tests pass
- Two-character fix per line, no behavior change except error message content