### PR TITLE
fix: remove debug fmt.Printf left in BGP OPEN message handler

### DIFF
--- a/internal/bgp/native/messages.go
+++ b/internal/bgp/native/messages.go
@@ -201,7 +201,6 @@ func readOpen(r io.Reader) (*openResult, error) {
 	if err := binary.Read(lr, binary.BigEndian, &open); err != nil {
 		return nil, err
 	}
-	fmt.Printf("%#v\n", open)
 	if open.Version != 4 {
 		return nil, fmt.Errorf("wrong BGP version")
 	}


### PR DESCRIPTION
## Summary

A `fmt.Printf("%#v\n", open)` in `readOpen()` dumps the raw BGP OPEN message struct (ASN, router ID, hold time, capabilities) to stdout on every incoming BGP connection. This is a leftover debug statement — not guarded by any log level or debug flag — and leaks BGP session parameters to container logs.

## Changes

- `internal/bgp/native/messages.go:204` — Remove the debug `fmt.Printf` line

## Testing

- All native BGP tests pass
- One-line deletion, no behavior change