### PR TITLE
fix: continue scanning interfaces when one fails to return addresses

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -83,7 +83,7 @@ func (a *Announce) updateInterfaces() {
 		addrs, err := ifi.Addrs()
 		if err != nil {
 			level.Error(l).Log("op", "getAddresses", "error", err, "msg", "couldn't get addresses for interface")
-			return
+			continue
 		}
 
 		if ifi.Flags&net.FlagUp == 0 {


### PR DESCRIPTION
## Summary

In `updateInterfaces()`, when `ifi.Addrs()` fails for any single interface, the function returns immediately, aborting the scan of all remaining interfaces. This also skips the cleanup phase (lines 141-154) that removes stale ARP/NDP responders for interfaces that went down. If the failure is persistent (e.g., a permanently broken interface), stale responders accumulate indefinitely.

## Changes

- `internal/layer2/announcer.go:86` — Change `return` to `continue` so the scan processes remaining interfaces and the cleanup phase always runs

## Testing

- All layer2 tests pass
- One-word fix, same pattern as other `continue`s in the same loop (e.g., line 78)