### PR TITLE
e2etests: add new tests for BGPAdv/BGPPeer updates and dynamicASN test

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			err = metallb.RestartSpeakerPods(cs)
 			Expect(err).NotTo(HaveOccurred())
 
-			if gracefulRestart == GracefulRestartDisabled {
+			if !gracefulRestart {
 				Eventually(func() error {
 					for _, c := range FRRContainers {
 						err := validateServiceNoWait(svc, allNodes.Items, c)
@@ -1564,7 +1564,6 @@ var _ = ginkgo.Describe("BGP", func() {
 
 				routers := map[string]frrk8sv1beta1.Router{}
 				for _, p := range resources.Peers {
-					p := p
 					r := routers[p.Spec.VRFName]
 					r.ASN = p.Spec.MyASN
 					r.VRF = p.Spec.VRFName
@@ -1833,7 +1832,7 @@ var _ = ginkgo.Describe("BGP", func() {
 						neighborFamily := ipfamily.ForAddress(net.ParseIP(neighbor.ID))
 						for _, family := range neighbor.AddressFamilies {
 							if !strings.Contains(family, string(neighborFamily)) {
-								return fmt.Errorf("expected %s neigbour to contain only %s families but contains %s", neighbor.ID, neighborFamily, family)
+								return fmt.Errorf("expected %s neighbour to contain only %s families but contains %s", neighbor.ID, neighborFamily, family)
 							}
 						}
 					}
@@ -1951,6 +1950,118 @@ var _ = ginkgo.Describe("BGP", func() {
 					return nil
 				}, 3*time.Minute, time.Second).ShouldNot(HaveOccurred())
 			}
+		})
+		ginkgo.Context("IPV4 BGP connect time", func() {
+			expectConnectTimeOnSpeakers := func(speakerPods []*corev1.Pod, expectedSeconds int) {
+				for _, pod := range speakerPods {
+					podExec, err := FRRProvider.FRRExecutorFor(pod.Namespace, pod.Name)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						neighbors, err := frr.NeighborsInfo(podExec)
+						if err != nil {
+							return err
+						}
+						if len(neighbors) == 0 {
+							return fmt.Errorf("expected at least 1 neighbor, got %d", len(neighbors))
+						}
+						for _, neighbor := range neighbors {
+							if neighbor.ConfiguredConnectTime != expectedSeconds {
+								return fmt.Errorf("expected connect time to be %d, got %d", expectedSeconds, neighbor.ConfiguredConnectTime)
+							}
+						}
+						return nil
+					}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+				}
+			}
+
+			ginkgo.It("IPV4 retry timer reconnects to neighbor within connect time after BGP reset", func() {
+				connectTime := 10 * time.Second
+				resources := config.Resources{
+					Peers: metallb.PeersForContainers(FRRContainers, ipfamily.IPv4, func(p *metallbv1beta2.BGPPeer) {
+						p.Spec.ConnectTime = ptr.To(metav1.Duration{Duration: connectTime})
+					}),
+				}
+				err := ConfigUpdater.Update(resources)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, c := range FRRContainers {
+					err := frrcontainer.PairWithNodes(cs, c, ipfamily.IPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				for _, c := range FRRContainers {
+					validateFRRPeeredWithAllNodes(cs, c, ipfamily.IPv4)
+				}
+
+				speakerPods, err := metallb.SpeakerPods(cs)
+				Expect(err).NotTo(HaveOccurred())
+				expectConnectTimeOnSpeakers(speakerPods, int(connectTime.Seconds()))
+
+				ginkgo.By("Resetting BGP session from external FRR container")
+				_, err = FRRContainers[0].Exec("vtysh", "-c", "clear bgp *")
+				Expect(err).NotTo(HaveOccurred())
+
+				ginkgo.By("Verifying BGP session re-establishes within connect time")
+				allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					neighbors, err := frr.NeighborsInfo(FRRContainers[0])
+					if err != nil {
+						return err
+					}
+					return frr.NeighborsMatchNodes(allNodes.Items, neighbors, ipfamily.IPv4, FRRContainers[0].RouterConfig.VRF)
+				}, connectTime, time.Second).ShouldNot(HaveOccurred())
+			})
+
+			ginkgo.It("IPV4 update connect time to less than default on an existing BGP connection", func() {
+				resources := config.Resources{
+					Peers: metallb.PeersForContainers(FRRContainers, ipfamily.IPv4),
+				}
+				err := ConfigUpdater.Update(resources)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, c := range FRRContainers {
+					err := frrcontainer.PairWithNodes(cs, c, ipfamily.IPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				for _, c := range FRRContainers {
+					validateFRRPeeredWithAllNodes(cs, c, ipfamily.IPv4)
+				}
+
+				speakerPods, err := metallb.SpeakerPods(cs)
+				Expect(err).NotTo(HaveOccurred())
+
+				var baselineConnect int
+				Eventually(func() error {
+					podExec, err := FRRProvider.FRRExecutorFor(speakerPods[0].Namespace, speakerPods[0].Name)
+					if err != nil {
+						return err
+					}
+					neighbors, err := frr.NeighborsInfo(podExec)
+					if err != nil {
+						return err
+					}
+					if len(neighbors) == 0 {
+						return fmt.Errorf("expected at least 1 neighbor, got 0")
+					}
+					for _, n := range neighbors {
+						if n.ConfiguredConnectTime > 0 {
+							baselineConnect = n.ConfiguredConnectTime
+							return nil
+						}
+					}
+					return fmt.Errorf("connect retry timer not populated yet")
+				}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+				expectConnectTimeOnSpeakers(speakerPods, baselineConnect)
+
+				ginkgo.By("Updating BGP peer connect time to 10 seconds")
+				resources.Peers = metallb.PeersForContainers(FRRContainers, ipfamily.IPv4, func(p *metallbv1beta2.BGPPeer) {
+					p.Spec.ConnectTime = ptr.To(metav1.Duration{Duration: 10 * time.Second})
+				})
+				err = ConfigUpdater.Update(resources)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectConnectTimeOnSpeakers(speakerPods, 10)
+			})
 		})
 	})
 	ginkgo.DescribeTable("A service of protocol load balancer should work with two protocols", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -1842,6 +1842,116 @@ var _ = ginkgo.Describe("BGP", func() {
 			}
 
 		})
+		ginkgo.It("IPV4 BGP Timer Update", func() {
+			initialHoldTime := 180 * time.Second
+			initialKeepaliveTime := 60 * time.Second
+			updatedHoldTime := 30 * time.Second
+			updatedKeepaliveTime := 10 * time.Second
+
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{v4PoolAddresses},
+						},
+					},
+				},
+				Peers: metallb.PeersForContainers(FRRContainers, ipfamily.IPv4, func(p *metallbv1beta2.BGPPeer) {
+					p.Spec.HoldTime = &metav1.Duration{Duration: initialHoldTime}
+					p.Spec.KeepaliveTime = &metav1.Duration{Duration: initialKeepaliveTime}
+				}),
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{emptyBGPAdvertisement},
+			}
+
+			for _, c := range FRRContainers {
+				err := frrcontainer.PairWithNodes(cs, c, ipfamily.IPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			err := ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Verify initial BGP timers in speaker pods")
+			speakerPods, err := metallb.SpeakerPods(cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			initialHoldMsecs := int(initialHoldTime.Milliseconds())
+			initialKeepaliveMsecs := int(initialKeepaliveTime.Milliseconds())
+			expectSpeakerConfiguredTimers := func(pods []*corev1.Pod, holdMs, keepaliveMs int) {
+				for _, pod := range pods {
+					podExecutor, err := FRRProvider.FRRExecutorFor(pod.Namespace, pod.Name)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						neighbors, err := frr.NeighborsInfo(podExecutor)
+						if err != nil {
+							return err
+						}
+						if len(neighbors) == 0 {
+							return fmt.Errorf("expected at least 1 BGP neighbor on speaker, got 0")
+						}
+						for _, n := range neighbors {
+							if n.ConfiguredHoldTime != holdMs {
+								return fmt.Errorf("neighbor %s: expected configured hold time %d ms, got %d ms",
+									n.ID, holdMs, n.ConfiguredHoldTime)
+							}
+							if n.ConfiguredKeepAliveTime != keepaliveMs {
+								return fmt.Errorf("neighbor %s: expected configured keepalive %d ms, got %d ms",
+									n.ID, keepaliveMs, n.ConfiguredKeepAliveTime)
+							}
+						}
+						return nil
+					}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+				}
+			}
+			expectSpeakerConfiguredTimers(speakerPods, initialHoldMsecs, initialKeepaliveMsecs)
+
+			ginkgo.By("Update BGP timers")
+			resources.Peers = metallb.PeersForContainers(FRRContainers, ipfamily.IPv4, func(p *metallbv1beta2.BGPPeer) {
+				p.Spec.HoldTime = &metav1.Duration{Duration: updatedHoldTime}
+				p.Spec.KeepaliveTime = &metav1.Duration{Duration: updatedKeepaliveTime}
+			})
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Verify updated timers in speaker pods")
+			expectSpeakerConfiguredTimers(speakerPods, int(updatedHoldTime.Milliseconds()), int(updatedKeepaliveTime.Milliseconds()))
+
+			ginkgo.By("Reset BGP connection on FRR containers to re-establish with new timers")
+			for _, c := range FRRContainers {
+				_, err := c.Exec("vtysh", "-c", "clear bgp *")
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			ginkgo.By("Verify BGP timers on FRR containers after re-establishment")
+			expectedHoldTimeMsecs := int(updatedHoldTime.Milliseconds())
+			expectedKeepaliveMsecs := int(updatedKeepaliveTime.Milliseconds())
+
+			for _, c := range FRRContainers {
+				Eventually(func() error {
+					neighbors, err := frr.NeighborsInfo(c)
+					if err != nil {
+						return err
+					}
+					if len(neighbors) == 0 {
+						return fmt.Errorf("expected at least 1 neighbor, got 0")
+					}
+					for _, neighbor := range neighbors {
+						if neighbor.NegotiatedHoldTime != expectedHoldTimeMsecs {
+							return fmt.Errorf("neighbor %s: expected negotiated hold time %d ms, got %d ms",
+								neighbor.ID, expectedHoldTimeMsecs, neighbor.NegotiatedHoldTime)
+						}
+						if neighbor.NegotiatedKeepAliveInterval != expectedKeepaliveMsecs {
+							return fmt.Errorf("neighbor %s: expected negotiated keepalive %d ms, got %d ms",
+								neighbor.ID, expectedKeepaliveMsecs, neighbor.NegotiatedKeepAliveInterval)
+						}
+					}
+					return nil
+				}, 3*time.Minute, time.Second).ShouldNot(HaveOccurred())
+			}
+		})
 	})
 	ginkgo.DescribeTable("A service of protocol load balancer should work with two protocols", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {
 		_, svc := setupBGPService(cs, testNamespace, pairingIPFamily, poolAddresses, FRRContainers, func(svc *corev1.Service) {

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			err = metallb.RestartSpeakerPods(cs)
 			Expect(err).NotTo(HaveOccurred())
 
-			if !gracefulRestart {
+			if gracefulRestart == GracefulRestartDisabled {
 				Eventually(func() error {
 					for _, c := range FRRContainers {
 						err := validateServiceNoWait(svc, allNodes.Items, c)
@@ -1279,7 +1279,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				[]metallbv1beta1.Community{}))
 	})
 
-	ginkgo.DescribeTable("BGP advertisement updates of communities and localpref and aggregation length", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {
+	ginkgo.DescribeTable("BGP advertisement updates of communities and localpref and aggregation length", func(pairingIPFamily ipfamily.Family, poolAddresses []string, aggLen int32) {
 		bgpAdv := metallbv1beta1.BGPAdvertisement{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "adv-updates",
@@ -1287,7 +1287,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			},
 			Spec: metallbv1beta1.BGPAdvertisementSpec{
 				Communities:    []string{CommunityNoAdv},
-				LocalPref:      100,
+				LocalPref:      200,
 				IPAddressPools: []string{"bgp-test"},
 			},
 		}
@@ -1349,7 +1349,7 @@ var _ = ginkgo.Describe("BGP", func() {
 			if strings.Contains(c.Name, "ibgp") {
 				Eventually(func() (uint32, error) {
 					return frr.LocalPrefForPrefix(c, serviceIP, pairingIPFamily)
-				}, time.Minute, time.Second).Should(Equal(uint32(100)))
+				}, time.Minute, time.Second).Should(Equal(uint32(200)))
 			}
 		}
 
@@ -1357,46 +1357,65 @@ var _ = ginkgo.Describe("BGP", func() {
 		err = ConfigUpdater.Client().Get(context.TODO(), types.NamespacedName{Namespace: bgpAdv.Namespace, Name: bgpAdv.Name}, &bgpAdv)
 		Expect(err).NotTo(HaveOccurred())
 
-		switch pairingIPFamily {
-		case ipfamily.IPv4:
-			bgpAdv.Spec.LocalPref = 200
-			bgpAdv.Spec.AggregationLength = ptr.To(int32(28))
-			bgpAdv.Spec.Communities = []string{CustomCommunity}
-		case ipfamily.IPv6:
-			bgpAdv.Spec.LocalPref = 200
-			bgpAdv.Spec.AggregationLengthV6 = ptr.To(int32(124))
-			bgpAdv.Spec.Communities = []string{CustomCommunity}
-		default:
-			ginkgo.Fail("unsupported family for BGP advertisement updates test")
+		bgpAdv.Spec.LocalPref = 300
+		bgpAdv.Spec.Communities = []string{CustomCommunity}
+
+		var subnet *net.IPNet
+		bits := 32
+		if pairingIPFamily == ipfamily.IPv6 {
+			bits = 128
+			bgpAdv.Spec.AggregationLengthV6 = ptr.To(aggLen)
+		} else {
+			bgpAdv.Spec.AggregationLength = ptr.To(aggLen)
 		}
+
 		err = ConfigUpdater.Client().Update(context.TODO(), &bgpAdv)
 		Expect(err).NotTo(HaveOccurred())
 
 		ginkgo.By("Validating updated BGP route prefix (aggregated)")
 		ip := net.ParseIP(serviceIP)
 		Expect(ip).NotTo(BeNil())
-		var subnet *net.IPNet
-		if pairingIPFamily == ipfamily.IPv4 {
-			subnet = &net.IPNet{IP: ip.Mask(net.CIDRMask(28, 32)), Mask: net.CIDRMask(28, 32)}
-		} else {
-			subnet = &net.IPNet{IP: ip.Mask(net.CIDRMask(124, 128)), Mask: net.CIDRMask(124, 128)}
-		}
+
+		subnet = &net.IPNet{IP: ip.Mask(net.CIDRMask(int(aggLen), bits)), Mask: net.CIDRMask(int(aggLen), bits)}
+
 		// ParseRoutes indexes maps by destination IP string (see frr.ParseRoutes), not full CIDR.
 		aggregatedRouteKey := subnet.IP.String()
-
+		routeHasAggregationLength := func(routes map[string]frr.Route, key string) error {
+			r, ok := routes[key]
+			if !ok {
+				return fmt.Errorf("no route for key %q", key)
+			}
+			if r.Destination == nil {
+				return fmt.Errorf("route %q has nil Destination", key)
+			}
+			ones, _ := r.Destination.Mask.Size()
+			if ones != int(aggLen) {
+				return fmt.Errorf("route %q: want /%d advertised prefix, got /%d (%s)", key, aggLen, ones, r.Destination.String())
+			}
+			return nil
+		}
 		for _, c := range FRRContainers {
-			Eventually(func() (map[string]frr.Route, error) {
-				return frr.RoutesForFamily(c, pairingIPFamily)
-			}, time.Minute, time.Second).Should(HaveKey(aggregatedRouteKey))
+			Eventually(func() error {
+				routes, err := frr.RoutesForFamily(c, pairingIPFamily)
+				if err != nil {
+					return err
+				}
+				return routeHasAggregationLength(routes, aggregatedRouteKey)
+			}, time.Minute, time.Second).Should(Succeed())
 		}
 
 		ginkgo.By("Validate BGP Community received on FRR containers")
 		for _, c := range FRRContainers {
-			Eventually(func() (map[string]frr.Route, error) {
-				return frr.RoutesForCommunity(c, CustomCommunity, pairingIPFamily)
+			Eventually(func() error {
+				routes, err := frr.RoutesForCommunity(c, CustomCommunity, pairingIPFamily)
+				if err != nil {
+					return err
+				}
+				return routeHasAggregationLength(routes, aggregatedRouteKey)
 			}, time.Minute, time.Second).Should(
-				HaveKey(aggregatedRouteKey),
-				"BGP routes should contain aggregated subnet for community %s",
+				Succeed(),
+				"BGP routes should contain aggregated /%d prefix for community %s",
+				aggLen,
 				CustomCommunity,
 			)
 		}
@@ -1406,12 +1425,12 @@ var _ = ginkgo.Describe("BGP", func() {
 			if strings.Contains(c.Name, "ibgp") {
 				Eventually(func() (uint32, error) {
 					return frr.LocalPrefForPrefix(c, aggregatedRouteKey, pairingIPFamily)
-				}, time.Minute, time.Second).Should(Equal(uint32(200)))
+				}, time.Minute, time.Second).Should(Equal(uint32(300)))
 			}
 		}
 	},
-		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}),
-		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}))
+		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}, int32(24)),
+		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}, int32(124)))
 
 	ginkgo.Context("MetalLB FRR rejects", func() {
 		ginkgo.DescribeTable("any routes advertised by any neighbor", func(addressesRange, toInject string, pairingIPFamily ipfamily.Family) {
@@ -2009,58 +2028,7 @@ var _ = ginkgo.Describe("BGP", func() {
 						return err
 					}
 					return frr.NeighborsMatchNodes(allNodes.Items, neighbors, ipfamily.IPv4, FRRContainers[0].RouterConfig.VRF)
-				}, connectTime, time.Second).ShouldNot(HaveOccurred())
-			})
-
-			ginkgo.It("IPV4 update connect time to less than default on an existing BGP connection", func() {
-				resources := config.Resources{
-					Peers: metallb.PeersForContainers(FRRContainers, ipfamily.IPv4),
-				}
-				err := ConfigUpdater.Update(resources)
-				Expect(err).NotTo(HaveOccurred())
-
-				for _, c := range FRRContainers {
-					err := frrcontainer.PairWithNodes(cs, c, ipfamily.IPv4)
-					Expect(err).NotTo(HaveOccurred())
-				}
-				for _, c := range FRRContainers {
-					validateFRRPeeredWithAllNodes(cs, c, ipfamily.IPv4)
-				}
-
-				speakerPods, err := metallb.SpeakerPods(cs)
-				Expect(err).NotTo(HaveOccurred())
-
-				var baselineConnect int
-				Eventually(func() error {
-					podExec, err := FRRProvider.FRRExecutorFor(speakerPods[0].Namespace, speakerPods[0].Name)
-					if err != nil {
-						return err
-					}
-					neighbors, err := frr.NeighborsInfo(podExec)
-					if err != nil {
-						return err
-					}
-					if len(neighbors) == 0 {
-						return fmt.Errorf("expected at least 1 neighbor, got 0")
-					}
-					for _, n := range neighbors {
-						if n.ConfiguredConnectTime > 0 {
-							baselineConnect = n.ConfiguredConnectTime
-							return nil
-						}
-					}
-					return fmt.Errorf("connect retry timer not populated yet")
-				}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
-				expectConnectTimeOnSpeakers(speakerPods, baselineConnect)
-
-				ginkgo.By("Updating BGP peer connect time to 10 seconds")
-				resources.Peers = metallb.PeersForContainers(FRRContainers, ipfamily.IPv4, func(p *metallbv1beta2.BGPPeer) {
-					p.Spec.ConnectTime = ptr.To(metav1.Duration{Duration: 10 * time.Second})
-				})
-				err = ConfigUpdater.Update(resources)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectConnectTimeOnSpeakers(speakerPods, 10)
+				}, 2*connectTime, time.Second).ShouldNot(HaveOccurred())
 			})
 		})
 	})
@@ -2147,6 +2115,37 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		for _, c := range FRRContainers {
 			validateFRRPeeredWithAllNodes(cs, c, pairingIPFamily)
+		}
+	},
+		ginkgo.Entry("IPV4", ipfamily.IPv4),
+		ginkgo.Entry("IPV6", ipfamily.IPv6),
+	)
+	ginkgo.DescribeTable("FRR does not establish connections with wrong dynamic ASN mode", func(pairingIPFamily ipfamily.Family) {
+		resources := config.Resources{
+			Peers: metallb.PeersForContainers(FRRContainers, pairingIPFamily, func(p *metallbv1beta2.BGPPeer) {
+				// Use the opposite dynamicASN mode: External when peer is internal, Internal when peer is external
+				wrongDynamicASN := metallbv1beta2.ExternalASNMode
+				if p.Spec.ASN != p.Spec.MyASN {
+					wrongDynamicASN = metallbv1beta2.InternalASNMode
+				}
+				p.Spec.ASN = 0
+				p.Spec.DynamicASN = wrongDynamicASN
+			}),
+		}
+
+		for _, c := range FRRContainers {
+			err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, c := range FRRContainers {
+			validateFRRNotPeeredWithNodes(allNodes.Items, c, pairingIPFamily)
 		}
 	},
 		ginkgo.Entry("IPV4", ipfamily.IPv4),

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -64,6 +64,7 @@ const (
 	v6PoolAddresses       = "fc00:f853:0ccd:e799::/124"
 	CommunityNoAdv        = "65535:65282" // 0xFFFFFF02: NO_ADVERTISE
 	CommunityGracefulShut = "65535:0"     // GRACEFUL_SHUTDOWN
+	CustomCommunity       = "123:456"     // custom community for BGP advertisement update tests
 	SpeakerContainerName  = "speaker"
 
 	GracefulRestartEnabled  = true
@@ -1277,6 +1278,140 @@ var _ = ginkgo.Describe("BGP", func() {
 				ipfamily.IPv6,
 				[]metallbv1beta1.Community{}))
 	})
+
+	ginkgo.DescribeTable("BGP advertisement updates of communities and localpref and aggregation length", func(pairingIPFamily ipfamily.Family, poolAddresses []string) {
+		bgpAdv := metallbv1beta1.BGPAdvertisement{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "adv-updates",
+				Namespace: ConfigUpdater.Namespace(),
+			},
+			Spec: metallbv1beta1.BGPAdvertisementSpec{
+				Communities:    []string{CommunityNoAdv},
+				LocalPref:      100,
+				IPAddressPools: []string{"bgp-test"},
+			},
+		}
+
+		resources := config.Resources{
+			Pools: []metallbv1beta1.IPAddressPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "bgp-test"},
+					Spec: metallbv1beta1.IPAddressPoolSpec{
+						Addresses: poolAddresses,
+					},
+				},
+			},
+			Peers:   metallb.PeersForContainers(FRRContainers, pairingIPFamily),
+			BGPAdvs: []metallbv1beta1.BGPAdvertisement{bgpAdv},
+		}
+
+		for _, c := range FRRContainers {
+			err := frrcontainer.PairWithNodes(cs, c, pairingIPFamily)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, c := range FRRContainers {
+			validateFRRPeeredWithAllNodes(cs, c, pairingIPFamily)
+		}
+
+		serviceIP, err := config.GetIPFromRangeByIndex(poolAddresses[0], 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		svc, _ := testservice.CreateWithBackend(cs, testNamespace, "bgp-adv-updates-svc", func(svc *corev1.Service) {
+			svc.Spec.LoadBalancerIP = serviceIP
+		}, testservice.TrafficPolicyCluster)
+		defer testservice.Delete(cs, svc)
+
+		allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Validating BGP route prefix")
+		for _, c := range FRRContainers {
+			validateService(svc, allNodes.Items, c)
+		}
+
+		ginkgo.By("Validate BGP Community is received on the FRR containers")
+		for _, c := range FRRContainers {
+			Eventually(func() (map[string]frr.Route, error) {
+				return frr.RoutesForCommunity(c, CommunityNoAdv, pairingIPFamily)
+			}, time.Minute, time.Second).Should(
+				HaveKey(serviceIP),
+				"BGP routes should contain service IP for community %s",
+				CommunityNoAdv,
+			)
+		}
+
+		ginkgo.By("Validate BGP Local Preference received on FRR containers")
+		for _, c := range FRRContainers {
+			if strings.Contains(c.Name, "ibgp") {
+				Eventually(func() (uint32, error) {
+					return frr.LocalPrefForPrefix(c, serviceIP, pairingIPFamily)
+				}, time.Minute, time.Second).Should(Equal(uint32(100)))
+			}
+		}
+
+		ginkgo.By("Update BGP Advertisements")
+		err = ConfigUpdater.Client().Get(context.TODO(), types.NamespacedName{Namespace: bgpAdv.Namespace, Name: bgpAdv.Name}, &bgpAdv)
+		Expect(err).NotTo(HaveOccurred())
+
+		switch pairingIPFamily {
+		case ipfamily.IPv4:
+			bgpAdv.Spec.LocalPref = 200
+			bgpAdv.Spec.AggregationLength = ptr.To(int32(28))
+			bgpAdv.Spec.Communities = []string{CustomCommunity}
+		case ipfamily.IPv6:
+			bgpAdv.Spec.LocalPref = 200
+			bgpAdv.Spec.AggregationLengthV6 = ptr.To(int32(124))
+			bgpAdv.Spec.Communities = []string{CustomCommunity}
+		default:
+			ginkgo.Fail("unsupported family for BGP advertisement updates test")
+		}
+		err = ConfigUpdater.Client().Update(context.TODO(), &bgpAdv)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Validating updated BGP route prefix (aggregated)")
+		ip := net.ParseIP(serviceIP)
+		Expect(ip).NotTo(BeNil())
+		var subnet *net.IPNet
+		if pairingIPFamily == ipfamily.IPv4 {
+			subnet = &net.IPNet{IP: ip.Mask(net.CIDRMask(28, 32)), Mask: net.CIDRMask(28, 32)}
+		} else {
+			subnet = &net.IPNet{IP: ip.Mask(net.CIDRMask(124, 128)), Mask: net.CIDRMask(124, 128)}
+		}
+		// ParseRoutes indexes maps by destination IP string (see frr.ParseRoutes), not full CIDR.
+		aggregatedRouteKey := subnet.IP.String()
+
+		for _, c := range FRRContainers {
+			Eventually(func() (map[string]frr.Route, error) {
+				return frr.RoutesForFamily(c, pairingIPFamily)
+			}, time.Minute, time.Second).Should(HaveKey(aggregatedRouteKey))
+		}
+
+		ginkgo.By("Validate BGP Community received on FRR containers")
+		for _, c := range FRRContainers {
+			Eventually(func() (map[string]frr.Route, error) {
+				return frr.RoutesForCommunity(c, CustomCommunity, pairingIPFamily)
+			}, time.Minute, time.Second).Should(
+				HaveKey(aggregatedRouteKey),
+				"BGP routes should contain aggregated subnet for community %s",
+				CustomCommunity,
+			)
+		}
+
+		ginkgo.By("Validate BGP Local Preference on FRR containers")
+		for _, c := range FRRContainers {
+			if strings.Contains(c.Name, "ibgp") {
+				Eventually(func() (uint32, error) {
+					return frr.LocalPrefForPrefix(c, aggregatedRouteKey, pairingIPFamily)
+				}, time.Minute, time.Second).Should(Equal(uint32(200)))
+			}
+		}
+	},
+		ginkgo.Entry("IPV4", ipfamily.IPv4, []string{v4PoolAddresses}),
+		ginkgo.Entry("IPV6", ipfamily.IPv6, []string{v6PoolAddresses}))
 
 	ginkgo.Context("MetalLB FRR rejects", func() {
 		ginkgo.DescribeTable("any routes advertised by any neighbor", func(addressesRange, toInject string, pairingIPFamily ipfamily.Family) {

--- a/e2etest/pkg/frr/parse.go
+++ b/e2etest/pkg/frr/parse.go
@@ -15,23 +15,25 @@ import (
 type Neighbor struct {
 	// ID is the key that vtysh returns for the neighbor,
 	// it can be either IP or interface name if unnumbered.
-	ID                      string
-	VRF                     string
-	Connected               bool
-	LocalAS                 string
-	RemoteAS                string
-	PrefixSent              int
-	Port                    int
-	RemoteRouterID          string
-	GRInfo                  GracefulRestartInfo
-	BFDInfo                 PeerBFDInfo
-	MsgStats                MessageStats
-	ConfiguredHoldTime      int
-	ConfiguredKeepAliveTime int
-	ConfiguredConnectTime   int
-	AddressFamilies         []string
-	ConnectionsDropped      int
-	BGPNeighborAddr         string
+	ID                          string
+	VRF                         string
+	Connected                   bool
+	LocalAS                     string
+	RemoteAS                    string
+	PrefixSent                  int
+	Port                        int
+	RemoteRouterID              string
+	GRInfo                      GracefulRestartInfo
+	BFDInfo                     PeerBFDInfo
+	MsgStats                    MessageStats
+	ConfiguredHoldTime          int
+	ConfiguredKeepAliveTime     int
+	ConfiguredConnectTime       int
+	AddressFamilies             []string
+	ConnectionsDropped          int
+	BGPNeighborAddr             string
+	NegotiatedHoldTime          int
+	NegotiatedKeepAliveInterval int
 }
 
 type Route struct {
@@ -62,7 +64,9 @@ type FRRNeighbor struct {
 	AddressFamilyInfo            map[string]struct {
 		SentPrefixCounter int `json:"sentPrefixCounter"`
 	} `json:"addressFamilyInfo"`
-	ConnectionsDropped int `json:"connectionsDropped"`
+	ConnectionsDropped             int `json:"connectionsDropped"`
+	BgpTimerHoldTimeMsecs          int `json:"bgpTimerHoldTimeMsecs"`
+	BgpTimerKeepAliveIntervalMsecs int `json:"bgpTimerKeepAliveIntervalMsecs"`
 }
 
 type PeerBFDInfo struct {
@@ -180,18 +184,20 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		return &Neighbor{
-			ID:                      k,
-			Connected:               connected,
-			LocalAS:                 strconv.Itoa(n.LocalAs),
-			RemoteAS:                strconv.Itoa(n.RemoteAs),
-			PrefixSent:              prefixSent,
-			Port:                    n.PortForeign,
-			RemoteRouterID:          n.RemoteRouterID,
-			MsgStats:                n.MsgStats,
-			ConfiguredKeepAliveTime: n.ConfiguredKeepAliveTimeMSecs,
-			ConfiguredHoldTime:      n.ConfiguredHoldTimeMSecs,
-			ConnectionsDropped:      n.ConnectionsDropped,
-			BGPNeighborAddr:         n.BGPNeighborAddr,
+			ID:                          k,
+			Connected:                   connected,
+			LocalAS:                     strconv.Itoa(n.LocalAs),
+			RemoteAS:                    strconv.Itoa(n.RemoteAs),
+			PrefixSent:                  prefixSent,
+			Port:                        n.PortForeign,
+			RemoteRouterID:              n.RemoteRouterID,
+			MsgStats:                    n.MsgStats,
+			ConfiguredKeepAliveTime:     n.ConfiguredKeepAliveTimeMSecs,
+			ConfiguredHoldTime:          n.ConfiguredHoldTimeMSecs,
+			ConnectionsDropped:          n.ConnectionsDropped,
+			BGPNeighborAddr:             n.BGPNeighborAddr,
+			NegotiatedHoldTime:          n.BgpTimerHoldTimeMsecs,
+			NegotiatedKeepAliveInterval: n.BgpTimerKeepAliveIntervalMsecs,
 		}, nil
 	}
 	return nil, errors.New("no peers were returned")
@@ -219,22 +225,24 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			addressFamilies = append(addressFamilies, family)
 		}
 		res = append(res, &Neighbor{
-			ID:                      k,
-			Connected:               connected,
-			LocalAS:                 strconv.Itoa(n.LocalAs),
-			RemoteAS:                strconv.Itoa(n.RemoteAs),
-			PrefixSent:              prefixSent,
-			Port:                    n.PortForeign,
-			RemoteRouterID:          n.RemoteRouterID,
-			MsgStats:                n.MsgStats,
-			GRInfo:                  n.GRInfo,
-			BFDInfo:                 n.PeerBFDInfo,
-			ConfiguredKeepAliveTime: n.ConfiguredKeepAliveTimeMSecs,
-			ConfiguredHoldTime:      n.ConfiguredHoldTimeMSecs,
-			ConfiguredConnectTime:   n.ConnectRetryTimer,
-			AddressFamilies:         addressFamilies,
-			ConnectionsDropped:      n.ConnectionsDropped,
-			BGPNeighborAddr:         n.BGPNeighborAddr,
+			ID:                          k,
+			Connected:                   connected,
+			LocalAS:                     strconv.Itoa(n.LocalAs),
+			RemoteAS:                    strconv.Itoa(n.RemoteAs),
+			PrefixSent:                  prefixSent,
+			Port:                        n.PortForeign,
+			RemoteRouterID:              n.RemoteRouterID,
+			MsgStats:                    n.MsgStats,
+			GRInfo:                      n.GRInfo,
+			BFDInfo:                     n.PeerBFDInfo,
+			ConfiguredKeepAliveTime:     n.ConfiguredKeepAliveTimeMSecs,
+			ConfiguredHoldTime:          n.ConfiguredHoldTimeMSecs,
+			ConfiguredConnectTime:       n.ConnectRetryTimer,
+			AddressFamilies:             addressFamilies,
+			ConnectionsDropped:          n.ConnectionsDropped,
+			BGPNeighborAddr:             n.BGPNeighborAddr,
+			NegotiatedHoldTime:          n.BgpTimerHoldTimeMsecs,
+			NegotiatedKeepAliveInterval: n.BgpTimerKeepAliveIntervalMsecs,
 		})
 	}
 	return res, nil

--- a/e2etest/pkg/frr/parse_test.go
+++ b/e2etest/pkg/frr/parse_test.go
@@ -110,6 +110,8 @@ func TestNeighbour(t *testing.T) {
 		ipv4PrefixSent int
 		ipv6PrefixSent int
 		port           int
+		holdTimer      int
+		keepaliveTimer int
 		expectedError  string
 	}{
 		{
@@ -121,6 +123,8 @@ func TestNeighbour(t *testing.T) {
 			1,
 			0,
 			179,
+			180000,
+			60000,
 			"",
 		},
 		{
@@ -132,6 +136,8 @@ func TestNeighbour(t *testing.T) {
 			0,
 			0,
 			180,
+			180000,
+			60000,
 			"",
 		},
 		{
@@ -143,6 +149,8 @@ func TestNeighbour(t *testing.T) {
 			2,
 			1,
 			181,
+			180000,
+			60000,
 			"",
 		},
 	}
@@ -188,6 +196,12 @@ func TestNeighbour(t *testing.T) {
 			}
 			if n.ConnectionsDropped != 2 {
 				t.Fatal("unexpected connections dropped", n.ConnectionsDropped)
+			}
+			if n.NegotiatedHoldTime != tt.holdTimer {
+				t.Fatal("unexpected negotiated hold timer", n.NegotiatedHoldTime)
+			}
+			if n.NegotiatedKeepAliveInterval != tt.keepaliveTimer {
+				t.Fatal("unexpected negotiated keepalive timer", n.NegotiatedKeepAliveInterval)
 			}
 		})
 	}
@@ -526,6 +540,29 @@ func TestNeighbours(t *testing.T) {
 	for i, n := range nn {
 		if !cmp.Equal(expectedStats, n.MsgStats) {
 			t.Fatal("unexpected BGP messages stats for neightbor", i, "(-want +got)\n", cmp.Diff(expectedStats, n.MsgStats))
+		}
+	}
+
+	expectedTimersByNeighbor := map[string]struct {
+		holdTime  int
+		keepalive int
+	}{
+		"172.18.0.2":           {holdTime: 180000, keepalive: 60000},
+		"172.18.0.3":           {holdTime: 180000, keepalive: 60000},
+		"172.18.0.4":           {holdTime: 180000, keepalive: 60000},
+		"fc00:f853:ccd:e793::4": {holdTime: 90000, keepalive: 30000},
+	}
+
+	for _, n := range nn {
+		expectedTimers, ok := expectedTimersByNeighbor[n.ID]
+		if !ok {
+			t.Fatalf("missing expected timers for %s", n.ID)
+		}
+		if n.NegotiatedHoldTime != expectedTimers.holdTime {
+			t.Fatalf("unexpected negotiated hold timer for %s, got %d", n.ID, n.NegotiatedHoldTime)
+		}
+		if n.NegotiatedKeepAliveInterval != expectedTimers.keepalive {
+			t.Fatalf("unexpected negotiated keepalive timer for %s, got %d", n.ID, n.NegotiatedKeepAliveInterval)
 		}
 	}
 }


### PR DESCRIPTION
### New e2e tests:
**Advertisement updates (IPv4/IPv6)**: After changing a BGPAdvertisement (communities, local preference, aggregation length), asserts FRR sees the updated community, local pref, and aggregated prefix.
**BGP timers Update**: Updates peer hold/keepalive, checks speaker FRR running-config, clears BGP on test FRR, then checks neighbors report the new timer values.
**BGP connect time**: Covers reconnect within the configured connect time after a session reset, and lowering connect time on an already-established session (default → 10s) with checks on speaker neighbor state.
**DynamicASN**: Negative test to cover the scenario where BGP establishment fails with incorrect dynamicASN configuration

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**: New e2etests to expand coverage of bgptests to address BGPAdvertisement and BGPPeer updates. Also adding new tests to validate connect time feature and a negative test case for dynamicASN feature.

> Uncomment only one, leave it on its own line:
>
> /kind bug
 /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**: Expand test coverage of bgptests


**Special notes for your reviewer**: Adds 5 new bgptests with negative scenario and CR updates.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
