### PR TITLE
Bump FRR to 10.5.3

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -130,7 +130,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.frr.enabled | bool | `false` |  |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |
-| speaker.frr.image.tag | string | `"10.5.1"` |  |
+| speaker.frr.image.tag | string | `"10.5.3"` |  |
 | speaker.frr.metricsPort | int | `7473` |  |
 | speaker.frr.resources | object | `{}` |  |
 | speaker.frrMetrics.resources | object | `{}` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -341,7 +341,7 @@ speaker:
     enabled: false
     image:
       repository: quay.io/frrouting/frr
-      tag: 10.5.1
+      tag: 10.5.3
       pullPolicy:
     metricsPort: 7473
     resources: {}

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -35,7 +35,7 @@ spec:
           securityContext:
             runAsUser: 100
             runAsGroup: 101
-          image: quay.io/frrouting/frr:10.5.1
+          image: quay.io/frrouting/frr:10.5.3
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
           volumeMounts:
             - name: frr-startup
@@ -63,7 +63,7 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          image: quay.io/frrouting/frr:10.5.1
+          image: quay.io/frrouting/frr:10.5.3
           env:
             - name: TINI_SUBREAPER
               value: "true"
@@ -89,7 +89,7 @@ spec:
             failureThreshold: 30
             periodSeconds: 5
         - name: reloader
-          image: quay.io/frrouting/frr:10.5.1
+          image: quay.io/frrouting/frr:10.5.3
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -104,7 +104,7 @@ spec:
             - name: frr-log
               mountPath: /var/log/frr
         - name: frr-metrics
-          image: quay.io/frrouting/frr:10.5.1
+          image: quay.io/frrouting/frr:10.5.3
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2474,7 +2474,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -2504,7 +2504,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: reloader
         securityContext:
           allowPrivilegeEscalation: false
@@ -2525,7 +2525,7 @@ spec:
         env:
         - name: VTYSH_HISTFILE
           value: /dev/null
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -2621,7 +2621,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2296,7 +2296,7 @@ spec:
         env:
         - name: TINI_SUBREAPER
           value: "true"
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -2326,7 +2326,7 @@ spec:
           name: frr-conf
       - command:
         - /etc/frr_reloader/frr-reloader.sh
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: reloader
         securityContext:
           allowPrivilegeEscalation: false
@@ -2347,7 +2347,7 @@ spec:
         env:
         - name: VTYSH_HISTFILE
           value: /dev/null
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: frr-metrics
         ports:
         - containerPort: 7473
@@ -2443,7 +2443,7 @@ spec:
         - /bin/sh
         - -c
         - cp -rLf /tmp/frr/* /etc/frr/
-        image: quay.io/frrouting/frr:10.5.1
+        image: quay.io/frrouting/frr:10.5.3
         name: cp-frr-files
         securityContext:
           runAsGroup: 101

--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -77,7 +77,7 @@ func handleFlags() {
 	flag.StringVar(&reportPath, "report-path", "/tmp/report", "the path to be used to dump test failure information")
 	flag.StringVar(&prometheusNamespace, "prometheus-namespace", "monitoring", "the namespace prometheus is running in (if running)")
 	flag.StringVar(&externalContainers, "external-containers", "", "a comma separated list of external containers names to use for the test. (valid parameters are: ibgp-single-hop / ibgp-multi-hop / ebgp-single-hop / ebgp-multi-hop)")
-	flag.StringVar(&frrImage, "frr-image", "quay.io/frrouting/frr:10.5.1", "the image to use for the external frr containers")
+	flag.StringVar(&frrImage, "frr-image", "quay.io/frrouting/frr:10.5.3", "the image to use for the external frr containers")
 	flag.StringVar(&hostContainerMode, "host-bgp-mode", string(bgptests.IBGPMode), "tells whether to run the host container in ebgp or ibgp mode")
 	flag.BoolVar(&withVRF, "with-vrf", false, "runs the tests against containers reacheable via linux vrfs. More coverage, but might not work depending on the OS")
 	flag.StringVar(&bgpMode, "bgp-mode", "", "says which bgp mode we are testing against. valid options are: native, frr, frr-k8s, frr-k8s-external")

--- a/internal/bgp/frr/docker_test.go
+++ b/internal/bgp/frr/docker_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 const (
-	frrImageTag = "10.5.1"
+	frrImageTag = "10.5.3"
 )
 
 func TestMain(m *testing.M) {

--- a/tasks.py
+++ b/tasks.py
@@ -768,7 +768,7 @@ def bgp_dev_env(ip_family, frr_volume_dir):
     )
     run(
         "docker run -d --privileged --network kind --rm --ulimit core=-1 --name frr --volume %s:/etc/frr "
-        "quay.io/frrouting/frr:10.5.1" % frr_volume_dir,
+        "quay.io/frrouting/frr:10.5.3" % frr_volume_dir,
         echo=True,
     )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

This is to pick up some coredump fixes, from 10.5.2+, e.g.:
https://github.com/FRRouting/frr/pull/20496

While the immediate need (fixing coredumps we experience in
OVN-Kubernetes CI) is for 10.5.2, bumping here to the latest release.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use FRR version 10.5.3 for FRR-mode
```
