### PR TITLE
e2etests: add l2 test with advertising node failover scenario

### DIFF
--- a/e2etest/l2tests/speaker_failover.go
+++ b/e2etest/l2tests/speaker_failover.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package l2tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.universe.tf/e2etest/pkg/config"
+	"go.universe.tf/e2etest/pkg/k8s"
+	"go.universe.tf/e2etest/pkg/k8sclient"
+	"go.universe.tf/e2etest/pkg/metallb"
+	"go.universe.tf/e2etest/pkg/service"
+	"go.universe.tf/e2etest/pkg/status"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+var _ = ginkgo.Describe("L2", func() {
+	var cs clientset.Interface
+	testNamespace := ""
+
+	emptyL2 := metallbv1beta1.L2Advertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "empty",
+		},
+	}
+
+	ginkgo.AfterEach(func() {
+		err := ConfigUpdater.Clean()
+		Expect(err).NotTo(HaveOccurred())
+
+		if ginkgo.CurrentSpecReport().Failed() {
+			k8s.DumpInfo(Reporter, ginkgo.CurrentSpecReport().LeafNodeText)
+		}
+		err = k8s.DeleteNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
+		err := ConfigUpdater.Clean()
+		Expect(err).NotTo(HaveOccurred())
+		cs = k8sclient.New()
+		testNamespace, err = k8s.CreateTestNamespace(cs, "l2spk")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	ginkgo.Context("speaker failover", func() {
+		ginkgo.BeforeEach(func() {
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "l2-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{
+								IPV4ServiceRange,
+								IPV6ServiceRange},
+						},
+					},
+				},
+				L2Advs: []metallbv1beta1.L2Advertisement{emptyL2},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		ginkgo.It("should move L2 advertisement when the announcing node stops running a ready speaker", func() {
+			nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(nodes.Items) < 2 {
+				ginkgo.Skip("requires at least two nodes")
+			}
+
+			svc, _ := service.CreateWithBackend(cs, testNamespace, "external-local-lb", service.TrafficPolicyCluster)
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			var announcing string
+			Eventually(func() error {
+				s, err := status.L2ForService(ConfigUpdater.Client(), svc)
+				if err != nil {
+					return err
+				}
+				announcing = s.Status.Node
+				return nil
+			}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+
+			originalName := announcing
+
+			ginkgo.By(fmt.Sprintf("adding a NoSchedule taint the speaker does not tolerate on node %s, then deleting its speaker pod", originalName))
+			err = addSpeakerFailoverNoScheduleTaint(cs, originalName)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := removeSpeakerFailoverNoScheduleTaint(cs, originalName)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			speakerPod, err := metallb.SpeakerPodInNode(cs, originalName)
+			Expect(err).NotTo(HaveOccurred())
+			err = cs.CoreV1().Pods(metallb.Namespace).Delete(context.TODO(), speakerPod.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("waiting until the node has no ready speaker (DaemonSet cannot replace the pod while the taint is present)")
+			Eventually(func() error {
+				has, err := metallb.HasSpeakerInNode(cs, originalName)
+				if err != nil {
+					return err
+				}
+				if has {
+					return fmt.Errorf("speaker still running and ready on %s", originalName)
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			ginkgo.By("expecting a different announcing node and working connectivity")
+			Eventually(func() error {
+				s, err := status.L2ForService(ConfigUpdater.Client(), svc)
+				if err != nil {
+					return err
+				}
+				if s.Status.Node == originalName {
+					return fmt.Errorf("announcement still on %s", originalName)
+				}
+				return nil
+			}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+
+			ginkgo.By("removing the speaker-failover taint so the speaker can run on the original node again")
+			err = removeSpeakerFailoverNoScheduleTaint(cs, originalName)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("expecting L2 announcement to return to the original node %s", originalName))
+			Eventually(func() error {
+				s, err := status.L2ForService(ConfigUpdater.Client(), svc)
+				if err != nil {
+					return err
+				}
+				if s.Status.Node != originalName {
+					return fmt.Errorf("announcement on %s, want %s", s.Status.Node, originalName)
+				}
+				return nil
+			}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+		})
+	})
+})
+
+// Taint used only in this test: the MetalLB speaker DaemonSet does not tolerate it, so the
+// speaker cannot be rescheduled onto the node after we delete its pod.
+const (
+	speakerFailoverTaintKey   = "metallb.e2e/speaker-failover-block"
+	speakerFailoverTaintValue = "true"
+)
+
+func addSpeakerFailoverNoScheduleTaint(cs clientset.Interface, nodeName string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, t := range node.Spec.Taints {
+			if t.Key == speakerFailoverTaintKey && t.Effect == corev1.TaintEffectNoSchedule {
+				return nil
+			}
+		}
+		taints := append([]corev1.Taint(nil), node.Spec.Taints...)
+		taints = append(taints, corev1.Taint{
+			Key:    speakerFailoverTaintKey,
+			Value:  speakerFailoverTaintValue,
+			Effect: corev1.TaintEffectNoSchedule,
+		})
+		node.Spec.Taints = taints
+		_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func removeSpeakerFailoverNoScheduleTaint(cs clientset.Interface, nodeName string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		var newTaints []corev1.Taint
+		found := false
+		for _, t := range node.Spec.Taints {
+			if t.Key == speakerFailoverTaintKey && t.Effect == corev1.TaintEffectNoSchedule {
+				found = true
+				continue
+			}
+			newTaints = append(newTaints, t)
+		}
+		if !found {
+			return nil
+		}
+		node.Spec.Taints = newTaints
+		_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return err
+	})
+}

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -80,7 +80,9 @@ func Create(configs map[string]Config) ([]*FRR, error) {
 				err = wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
 					daemons, err := frr.Daemons(c)
 					if err != nil {
-						return false, err
+						// vtysh can fail while watchfrr is still bringing daemons up; keep polling
+						// instead of aborting the whole wait on the first exec error.
+						return false, nil
 					}
 					for _, d := range daemons {
 						delete(toFind, d)

--- a/e2etest/pkg/frr/daemons.go
+++ b/e2etest/pkg/frr/daemons.go
@@ -15,7 +15,7 @@ import (
 func Daemons(exec executor.Executor) ([]string, error) {
 	res, err := exec.Exec("vtysh", "-c", "show daemons")
 	if err != nil {
-		return nil, errors.Join(err, errors.New("Failed to query neighbours"))
+		return nil, errors.Join(err, errors.New("failed to query FRR daemons (vtysh show daemons)"))
 	}
 	res = strings.TrimSuffix(res, "\n")
 	daemons := strings.Split(res, " ")

--- a/e2etest/pkg/frr/provider/provider.go
+++ b/e2etest/pkg/frr/provider/provider.go
@@ -82,7 +82,8 @@ func (f frrModeProvider) FRRK8sBased() bool {
 }
 
 type frrk8sModeProvider struct {
-	frrk8sPodForSpeakerPod map[string]*corev1.Pod
+	cl              *clientset.Clientset
+	frrk8sNamespace string
 }
 
 // NewFRRK8SMode returns a provider for a deployment using "frr-k8s" as its BGP mode.
@@ -93,50 +94,54 @@ func NewFRRK8SMode(r *rest.Config, namespace string) (Provider, error) {
 		return nil, err
 	}
 
-	speakerPods, err := metallb.SpeakerPods(cl)
+	return frrk8sModeProvider{cl: cl, frrk8sNamespace: namespace}, nil
+}
+
+// frrK8SPodForSpeaker resolves the frr-k8s pod that shares a node with the named speaker pod.
+func (f frrk8sModeProvider) frrK8SPodForSpeaker(speakerNS, speakerName string) (*corev1.Pod, error) {
+	speakerPods, err := metallb.SpeakerPods(f.cl)
 	if err != nil {
 		return nil, err
 	}
 
-	frrk8sPods, err := metallb.FRRK8SPods(cl, namespace)
+	var speaker *corev1.Pod
+	for _, p := range speakerPods {
+		if p.Namespace == speakerNS && p.Name == speakerName {
+			speaker = p
+			break
+		}
+	}
+	if speaker == nil {
+		return nil, fmt.Errorf("speaker %s/%s not found", speakerNS, speakerName)
+	}
+
+	frrk8sPods, err := metallb.FRRK8SPods(f.cl, f.frrk8sNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	frrK8SForSpeaker := map[string]*corev1.Pod{}
-	for _, s := range speakerPods {
-		found := false
-		for _, f := range frrk8sPods {
-			if s.Spec.NodeName == f.Spec.NodeName {
-				frrK8SForSpeaker[s.Name] = f
-				found = true
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("speaker %s/%s on node %s does not have a matching frr-k8s", s.Namespace, s.Name, s.Spec.NodeName)
+	for _, fp := range frrk8sPods {
+		if fp.Spec.NodeName == speaker.Spec.NodeName {
+			return fp, nil
 		}
 	}
 
-	res := frrk8sModeProvider{
-		frrk8sPodForSpeakerPod: frrK8SForSpeaker,
-	}
-
-	return res, nil
+	return nil, fmt.Errorf("speaker %s/%s on node %s does not have a matching frr-k8s", speaker.Namespace, speaker.Name, speaker.Spec.NodeName)
 }
 
 func (f frrk8sModeProvider) FRRExecutorFor(ns, name string) (executor.Executor, error) {
-	frrk8s, ok := f.frrk8sPodForSpeakerPod[name]
-	if !ok {
-		return nil, fmt.Errorf("speaker %s/%s does not have a matching frr-k8s", ns, name)
+	frrk8s, err := f.frrK8SPodForSpeaker(ns, name)
+	if err != nil {
+		return nil, err
 	}
 
 	return executor.ForPod(frrk8s.Namespace, frrk8s.Name, "frr"), nil
 }
 
 func (f frrk8sModeProvider) BGPMetricsPodFor(ns, name string) (*corev1.Pod, string, error) {
-	p, ok := f.frrk8sPodForSpeakerPod[name]
-	if !ok {
-		return nil, "", fmt.Errorf("speakers %s/%s not found in map %v", ns, name, f.frrk8sPodForSpeakerPod)
+	p, err := f.frrK8SPodForSpeaker(ns, name)
+	if err != nil {
+		return nil, "", err
 	}
 
 	return p, "frrk8s", nil

--- a/e2etest/pkg/metallb/metallb.go
+++ b/e2etest/pkg/metallb/metallb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -106,6 +107,22 @@ func SpeakerPodInNode(cs clientset.Interface, node string) (*corev1.Pod, error) 
 		}
 	}
 	return nil, fmt.Errorf("no speaker pod run in the node %s", node)
+}
+
+// HasSpeakerInNode reports whether the node has a running, ready MetalLB speaker pod.
+// When there is no speaker on the node, or the pod is not running or not ready, it returns (false, nil).
+func HasSpeakerInNode(cs clientset.Interface, node string) (bool, error) {
+	p, err := SpeakerPodInNode(cs, node)
+	if err != nil {
+		if strings.Contains(err.Error(), "no speaker pod run in the node") {
+			return false, nil
+		}
+		return false, err
+	}
+	if p.Status.Phase != corev1.PodRunning || !k8s.PodIsReady(p) {
+		return false, nil
+	}
+	return true, nil
 }
 
 // RestartController restarts metallb's controller pod and waits for it to be running and ready.


### PR DESCRIPTION
### e2etest

Adds e2etest/l2tests/speaker_failover.go with a spec that covers failover when the node currently announcing the LoadBalancer VIP no longer runs a healthy speaker: the test taints the announcing node, which is not tolerated by the speaker pod, asserts the service moves to another announcer. Later the taint is removed and the announcing node is expected to revert to original node.


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**: Adding new e2etest for L2Advertisement

> Uncomment only one, leave it on its own line:
>
> /kind bug
 /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**: Migrating a test from eco-gotests

**Special notes for your reviewer**: Consolidating tests from between eco-gotests and this repo

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
