### PR TITLE
bgp: add localASN field to BGPPeer for per-peer local-as override

### DIFF
--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -35,6 +35,16 @@ type BGPPeerSpec struct {
 	// +optional
 	ASN uint32 `json:"peerASN,omitempty"`
 
+	// LocalASN allows advertising a different AS number to the peer using BGP's
+	// local-as feature. When set, MetalLB will advertise this ASN to the peer
+	// via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+	// the router-level MyASN for this specific session.
+	// Not supported in native BGP mode.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
+	LocalASN uint32 `json:"localASN,omitempty"`
+
 	// DynamicASN detects the AS number to use for the remote end of the session
 	// without explicitly setting it via the ASN field. Limited to:
 	// internal - if the neighbor's ASN is different than MyASN connection is denied.

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -630,6 +630,17 @@ spec:
                 keepaliveTime:
                   description: Requested BGP keepalive time, per RFC4271.
                   type: string
+                localASN:
+                  description: |-
+                    LocalASN allows advertising a different AS number to the peer using BGP's
+                    local-as feature. When set, MetalLB will advertise this ASN to the peer
+                    via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                    the router-level MyASN for this specific session.
+                    Not supported in native BGP mode.
+                  format: int32
+                  maximum: 4294967295
+                  minimum: 1
+                  type: integer
                 myASN:
                   description: AS number to use for the local end of the session.
                   format: int32

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -242,6 +242,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -663,6 +663,17 @@ spec:
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -573,6 +573,46 @@ var _ = ginkgo.Describe("BGP", func() {
 		ginkgo.Entry("IPV4", ipfamily.IPv4),
 		ginkgo.Entry("IPV6", ipfamily.IPv6))
 
+	ginkgo.DescribeTable("FRR configure peers with localASN and validate session uses the local-as override", func(ipFamily ipfamily.Family) {
+		// localASN is a different ASN from metalLBASN. MetalLB will advertise
+		// this value to the peer via "neighbor <peer> local-as <localASN>
+		// no-prepend replace-as", so the external FRR container must expect
+		// localASN as MetalLB's remote-as for the session to come up.
+		localASN := uint32(64520)
+
+		ginkgo.By("configure peer with localASN")
+
+		resources := config.Resources{
+			Peers: metallb.PeersForContainers(FRRContainers, ipFamily, func(p *metallbv1beta2.BGPPeer) {
+				p.Spec.LocalASN = localASN
+			}),
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("pairing FRR containers expecting localASN as MetalLB's remote-as")
+		for _, c := range FRRContainers {
+			err = frrcontainer.PairWithNodes(cs, c, ipFamily, func(c *frrcontainer.FRR) {
+				c.NeighborConfig.ASN = localASN
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		ginkgo.By("validating sessions are established and peers report localASN as the remote AS")
+		for _, c := range FRRContainers {
+			validateFRRPeeredWithAllNodes(cs, c, ipFamily)
+			neighbors, err := frr.NeighborsInfo(c)
+			Expect(err).NotTo(HaveOccurred())
+			for _, n := range neighbors {
+				Expect(n.RemoteAS).To(Equal(fmt.Sprintf("%d", localASN)),
+					"expected MetalLB to advertise localASN %d to the peer", localASN)
+			}
+		}
+	},
+		ginkgo.Entry("FRR-MODE IPV4", ipfamily.IPv4),
+		ginkgo.Entry("FRR-MODE IPV6", ipfamily.IPv6))
+
 	ginkgo.DescribeTable("validate external containers are paired with nodes", func(ipFamily ipfamily.Family) {
 		ginkgo.By("configure peer")
 

--- a/e2etest/go.work.sum
+++ b/e2etest/go.work.sum
@@ -925,6 +925,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465 h1:KwWnWVWCNtNq/ewIX7HIKnELmEx2nDP42yskD/pi7QE=
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
@@ -975,6 +976,7 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
+github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -1163,6 +1165,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -1642,6 +1645,7 @@ golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2 h1:IRJeR9r1pYWsHKTRe/IInb7lYvbBVIqOgsX/u0mbOWY=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
@@ -1879,6 +1883,7 @@ google.golang.org/grpc v1.68.1/go.mod h1:+q1XYFJjShcqn0QZHvCyeR4CXPA+llXIeUIfIe0
 google.golang.org/grpc v1.70.0/go.mod h1:ofIJqVKDXx/JiXrwr2IG4/zwdH9txy3IlF40RmcJSQw=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20230224211313-3775f633ce20/go.mod h1:Nr5H8+MlGWr5+xX/STzdoEqJrO+YteqFbMyCsrb6mH0=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -84,6 +84,7 @@ type SessionParameters struct {
 	SessionName            string
 	DualStackAddressFamily bool
 	DisableMP              bool
+	LocalASN               uint32
 }
 type SessionManager interface {
 	NewSession(logger log.Logger, args SessionParameters) (Session, error)

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -83,6 +83,7 @@ type neighborConfig struct {
 	BFDProfile               string
 	GracefulRestart          bool
 	EBGPMultiHop             bool
+	LocalASN                 uint32
 	VRFName                  string
 	PrefixesV4               []string
 	PrefixesV6               []string

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -290,6 +290,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				BFDProfile:               s.BFDProfile,
 				GracefulRestart:          s.GracefulRestart,
 				EBGPMultiHop:             s.EBGPMultiHop,
+				LocalASN:                 s.LocalASN,
 				VRFName:                  s.VRFName,
 				PrefixesV4:               []string{},
 				PrefixesV6:               []string{},

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -322,6 +322,37 @@ func TestSingleSessionWithGracefulRestart(t *testing.T) {
 	})
 }
 
+func TestSingleSessionWithLocalASN(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		testSetup(t)
+
+		l := log.NewNopLogger()
+		sessionManager := mockNewSessionManager(l, logging.LevelInfo)
+		defer close(sessionManager.reloadConfig)
+		session, err := sessionManager.NewSession(l,
+			bgp.SessionParameters{
+				PeerAddress:   "10.2.2.254",
+				PeerPort:      179,
+				SourceAddress: net.ParseIP("10.1.1.254"),
+				MyASN:         100,
+				RouterID:      net.ParseIP("10.1.1.254"),
+				PeerASN:       200,
+				HoldTime:      ptr.To(time.Second),
+				KeepAliveTime: ptr.To(time.Second),
+				Password:      "password",
+				CurrentNode:   "hostname",
+				LocalASN:      65410,
+				SessionName:   "test-peer"})
+
+		if err != nil {
+			t.Fatalf("Could not create session: %s", err)
+		}
+		defer session.Close()
+
+		testCheckConfigFile(t)
+	})
+}
+
 func TestTwoSessions(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		testSetup(t)

--- a/internal/bgp/frr/templates/neighborsession.tmpl
+++ b/internal/bgp/frr/templates/neighborsession.tmpl
@@ -12,6 +12,9 @@
   {{- if .neighbor.EBGPMultiHop }}
   neighbor {{$peer}} ebgp-multihop
   {{- end }}
+  {{- if .neighbor.LocalASN }}
+  neighbor {{$peer}} local-as {{.neighbor.LocalASN}} no-prepend replace-as
+  {{- end }}
   {{ if .neighbor.Port -}}
   neighbor {{$peer}} port {{.neighbor.Port}}
   {{- end }}

--- a/internal/bgp/frr/testdata/TestSingleSessionWithLocalASN.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionWithLocalASN.golden
@@ -1,0 +1,39 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+
+ip prefix-list 10.2.2.254-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 10.2.2.254-allowed-ipv6 seq 1 deny any
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-allowed-ipv4
+
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-allowed-ipv6
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 local-as 65410 no-prepend replace-as
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,10 @@ type Peer struct {
 	DualStackAddressFamily bool
 	// Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
 	DisableMP bool
+	// LocalASN, if non-zero, will be advertised to the peer using
+	// "neighbor <peer> local-as <ASN> no-prepend replace-as".
+	// Supported for FRR mode only.
+	LocalASN uint32
 }
 
 // Pool is the configuration of an IP address pool.
@@ -492,6 +496,7 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 		VRF:                    p.Spec.VRFName,
 		DualStackAddressFamily: p.Spec.DualStackAddressFamily,
 		DisableMP:              p.Spec.DisableMP,
+		LocalASN:               p.Spec.LocalASN,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3667,6 +3667,38 @@ func TestParse(t *testing.T) {
 				BFDProfiles: map[string]*BFDProfile{},
 			},
 		},
+		{
+			desc: "peer with localASN field",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "peer1",
+						},
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:    100,
+							ASN:      200,
+							Address:  "1.2.3.4",
+							LocalASN: 65410,
+						},
+					},
+				},
+			},
+			want: &Config{
+				Peers: map[string]*Peer{
+					"peer1": {
+						Name:          "peer1",
+						MyASN:         100,
+						ASN:           200,
+						Addr:          net.ParseIP("1.2.3.4"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+						LocalASN:      65410,
+					},
+				},
+				Pools:       &Pools{ByName: map[string]*Pool{}},
+				BFDProfiles: map[string]*BFDProfile{},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -59,6 +59,9 @@ func DiscardFRROnly(c ClusterResources) error {
 		if p.Spec.Interface != "" {
 			return fmt.Errorf("peer %s has interface set on native bgp mode", p.Spec.Address)
 		}
+		if p.Spec.LocalASN != 0 {
+			return fmt.Errorf("peer %s has localASN set on native bgp mode", p.Spec.Address)
+		}
 	}
 	if len(c.BFDProfiles) > 0 {
 		return errors.New("bfd profiles section set")

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -221,6 +221,19 @@ func TestValidate(t *testing.T) {
 			mustFail: true,
 		},
 		{
+			desc: "localASN",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							LocalASN: 65410,
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
 			desc: "keepalive time",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -262,6 +262,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				VRFName:                p.cfg.VRF,
 				DualStackAddressFamily: p.cfg.DualStackAddressFamily,
 				DisableMP:              p.cfg.DisableMP, //nolint:staticcheck // SA1019: intentionally using deprecated field for translation
+				LocalASN:               p.cfg.LocalASN,
 			}
 			sessionParams.Password, sessionParams.PasswordRef = passwordForSession(p.cfg, c.bgpType, c.secretHandling)
 

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -485,6 +485,7 @@ _Appears in:_
 | `vrf` _string_ | To set if we want to peer with the BGPPeer using an interface belonging to<br />a host vrf |
 | `disableMP` _boolean_ | To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.<br />Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily. |
 | `dualStackAddressFamily` _boolean_ | To set if we want to enable the neighbor not only for the ipfamily related to its session,<br />but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa. |
+| `localASN` _integer_ | LocalASN allows advertising a different AS number to the peer using BGP's<br />local-as feature. When set, MetalLB will advertise this ASN to the peer<br />via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding<br />the router-level MyASN for this specific session. Supported for FRR mode only. |
 
 
 

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -467,6 +467,7 @@ _Appears in:_
 | --- | --- |
 | `myASN` _integer_ | AS number to use for the local end of the session. |
 | `peerASN` _integer_ | AS number to expect from the remote end of the session.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |
+| `localASN` _integer_ | LocalASN allows advertising a different AS number to the peer using BGP's<br />local-as feature. When set, MetalLB will advertise this ASN to the peer<br />via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding<br />the router-level MyASN for this specific session.<br />Not supported in native BGP mode. |
 | `dynamicASN` _[DynamicASNMode](#dynamicasnmode)_ | DynamicASN detects the AS number to use for the remote end of the session<br />without explicitly setting it via the ASN field. Limited to:<br />internal - if the neighbor's ASN is different than MyASN connection is denied.<br />external - if the neighbor's ASN is the same as MyASN the connection is denied.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |
 | `peerAddress` _string_ | Address to dial when establishing the session. |
 | `interface` _string_ | Interface is the node interface over which the unnumbered BGP peering will<br />be established. No API validation takes place as that string value<br />represents an interface name on the host and if user provides an invalid<br />value, only the actual BGP session will not be established.<br />Address and Interface are mutually exclusive and one of them must be specified. |
@@ -485,7 +486,6 @@ _Appears in:_
 | `vrf` _string_ | To set if we want to peer with the BGPPeer using an interface belonging to<br />a host vrf |
 | `disableMP` _boolean_ | To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.<br />Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily. |
 | `dualStackAddressFamily` _boolean_ | To set if we want to enable the neighbor not only for the ipfamily related to its session,<br />but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa. |
-| `localASN` _integer_ | LocalASN allows advertising a different AS number to the peer using BGP's<br />local-as feature. When set, MetalLB will advertise this ASN to the peer<br />via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding<br />the router-level MyASN for this specific session. Supported for FRR mode only. |
 
 
 

--- a/website/content/configuration/_advanced_bgp_configuration.md
+++ b/website/content/configuration/_advanced_bgp_configuration.md
@@ -497,3 +497,42 @@ According to the [RFC-5881/BFD Shares Fate with the Control
 Plane](https://datatracker.ietf.org/doc/html/rfc5882#section-4.3.2), BFD and
 Graceful Restart can work together, but is implementation specific. It is up to
 vendor's recommendation and needs to be tested.
+
+### Local AS override
+
+FRR supports presenting a different ASN to a specific peer without needing a
+separate `router bgp` instance, via `neighbor <peer> local-as <ASN>
+no-prepend replace-as`. MetalLB exposes this as the optional `localASN` field
+on `BGPPeer`.
+
+When `localASN` is set, MetalLB will advertise that ASN to the peer instead of
+`myASN`, while the router instance itself continues to use `myASN`. This is
+useful in multi-tenant or migration scenarios where peers on the same node need
+to see different ASNs and VRF separation is not desired or available.
+
+{{% notice note %}}
+`localASN` is supported in FRR mode only. Setting it in native BGP mode will
+be rejected by validation.
+{{% /notice %}}
+
+```yaml
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  myASN: 64512
+  peerASN: 64520
+  peerAddress: 172.30.0.3
+  localASN: 65410
+```
+
+This generates the following in `frr.conf`:
+
+```
+neighbor 172.30.0.3 remote-as 64520
+neighbor 172.30.0.3 local-as 65410 no-prepend replace-as
+```
+
+The peer at `172.30.0.3` will see MetalLB's ASN as `65410` rather than `64512`.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

Fixes part of https://github.com/metallb/metallb/issues/2367 




> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
Add an optional localASN field to the BGPPeer CRD that maps to FRR's `neighbor <peer> local-as <ASN> no-prepend replace-as` directive.

FRR supports presenting a different ASN to a specific peer via local-as without needing a separate router bgp block. MetalLB previously had no way to expose this `myASN` sets the router-level ASN and applies to all peers in that router instance. `localASN` allows individual peers on the same node to advertise different ASNs, which is useful in multi-tenant or migration scenarios where VRF separation is not desired or available.

The value flows through the full pipeline:

```
BGPPeer.spec.localASN (*uint32)
  → peerFromCR()        → config.Peer.LocalASN (uint32)
    → syncPeers()       → bgp.SessionParameters.LocalASN
      → createConfig()  → neighborConfig.LocalASN
        → template      → neighbor X.X.X.X local-as <ASN> no-prepend replace-as
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

Add `localASN` field to `BGPPeer` to allow per-peer local-AS override via FRR's `local-as <ASN> no-prepend replace-as`.

```
