### PR TITLE
e2etests: add test for LB IP reachability inside cluster

### DIFF
--- a/e2etest/e2etest_suite_test.go
+++ b/e2etest/e2etest_suite_test.go
@@ -32,6 +32,7 @@ import (
 	"go.universe.tf/e2etest/configurationstatetests"
 	"go.universe.tf/e2etest/l2tests"
 	_ "go.universe.tf/e2etest/netpoltests"
+	"go.universe.tf/e2etest/servicetests"
 	testsconfig "go.universe.tf/e2etest/pkg/config"
 	"go.universe.tf/e2etest/pkg/executor"
 	frrprovider "go.universe.tf/e2etest/pkg/frr/provider"
@@ -190,12 +191,14 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	bgptests.ConfigUpdater = updater
 	l2tests.ConfigUpdater = updater
+	servicetests.ConfigUpdater = updater
 	webhookstests.ConfigUpdater = updater
 	webhookstests.ConfigUpdaterOtherNS = updaterOtherNS
 	configurationstatetests.ConfigUpdater = updater
 	bgptests.Reporter = reporter
 	bgptests.ReportPath = reportPath
 	l2tests.Reporter = reporter
+	servicetests.Reporter = reporter
 	webhookstests.Reporter = reporter
 	configurationstatetests.Reporter = reporter
 	bgptests.PrometheusNamespace = prometheusNamespace

--- a/e2etest/servicetests/loadbalancer_internal.go
+++ b/e2etest/servicetests/loadbalancer_internal.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package servicetests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/k8sreporter"
+	jigservice "go.universe.tf/e2etest/pkg/jigservice"
+	"go.universe.tf/e2etest/pkg/config"
+	"go.universe.tf/e2etest/pkg/executor"
+	"go.universe.tf/e2etest/pkg/ipfamily"
+	"go.universe.tf/e2etest/pkg/k8s"
+	"go.universe.tf/e2etest/pkg/k8sclient"
+	"go.universe.tf/e2etest/l2tests"
+	"go.universe.tf/e2etest/pkg/service"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// Same image as jigservice backends; upstream Dockerfile installs curl and defaults to `agnhost pause`.
+const clientAgnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+
+var (
+	ConfigUpdater config.Updater
+	Reporter      *k8sreporter.KubernetesReporter
+)
+
+// lbTestResources builds MetalLB CRs for the table entries (IPAddressPool only).
+func lbTestResources(addresses []string) config.Resources {
+	return config.Resources{
+		Pools: []metallbv1beta1.IPAddressPool{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "lb-int-pool",
+				},
+				Spec: metallbv1beta1.IPAddressPoolSpec{
+					Addresses: addresses,
+				},
+			},
+		},
+	}
+}
+
+func svcV4Local(svc *corev1.Service) {
+	service.ForceV4(svc)
+	service.TrafficPolicyLocal(svc)
+}
+
+func svcV6Local(svc *corev1.Service) {
+	service.ForceV6(svc)
+	service.TrafficPolicyLocal(svc)
+}
+
+func svcDualStackLocal(svc *corev1.Service) {
+	service.DualStack(svc)
+	service.TrafficPolicyLocal(svc)
+}
+
+func loadBalancerIngressReady(svc *corev1.Service, fam ipfamily.Family) bool {
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return false
+	}
+	var has4, has6 bool
+	for i := range svc.Status.LoadBalancer.Ingress {
+		ip := net.ParseIP(jigservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[i]))
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			has4 = true
+		} else {
+			has6 = true
+		}
+	}
+	switch fam {
+	case ipfamily.IPv4:
+		return has4
+	case ipfamily.IPv6:
+		return has6
+	case ipfamily.DualStack:
+		return has4 && has6
+	default:
+		return false
+	}
+}
+
+func ingressHostForFamily(svc *corev1.Service, fam ipfamily.Family) string {
+	for i := range svc.Status.LoadBalancer.Ingress {
+		h := jigservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[i])
+		ip := net.ParseIP(h)
+		if ip == nil {
+			continue
+		}
+		switch fam {
+		case ipfamily.IPv4:
+			if ip.To4() != nil {
+				return h
+			}
+		case ipfamily.IPv6:
+			if ip.To4() == nil {
+				return h
+			}
+		}
+	}
+	return ""
+}
+
+func podIPMatchingFamily(pod *corev1.Pod, fam ipfamily.Family) string {
+	for _, p := range pod.Status.PodIPs {
+		ip := net.ParseIP(p.IP)
+		if ip == nil {
+			continue
+		}
+		if fam == ipfamily.IPv4 && ip.To4() != nil {
+			return p.IP
+		}
+		if fam == ipfamily.IPv6 && ip.To4() == nil {
+			return p.IP
+		}
+	}
+	if pod.Status.PodIP != "" {
+		ip := net.ParseIP(pod.Status.PodIP)
+		if ip != nil {
+			if fam == ipfamily.IPv4 && ip.To4() != nil {
+				return pod.Status.PodIP
+			}
+			if fam == ipfamily.IPv6 && ip.To4() == nil {
+				return pod.Status.PodIP
+			}
+		}
+	}
+	return ""
+}
+
+var _ = ginkgo.Describe("LoadBalancer", func() {
+	var cs clientset.Interface
+	testNamespace := ""
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			k8s.DumpInfo(Reporter, ginkgo.CurrentSpecReport().LeafNodeText)
+		}
+		err := ConfigUpdater.Clean()
+		Expect(err).NotTo(HaveOccurred())
+		err = k8s.DeleteNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		cs = k8sclient.New()
+		testNamespace, err = k8s.CreateTestNamespace(cs, "svcint")
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Clearing any previous configuration")
+		err = ConfigUpdater.Clean()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	ginkgo.DescribeTable("external load balancer IP reachable from pods with correct client source",
+		func(diffNode bool, metallbRes config.Resources, svcTweak func(*corev1.Service)) {
+			ctx := context.Background()
+
+			ginkgo.By("Applying MetalLB resources from the table entry")
+			err := ConfigUpdater.Update(metallbRes)
+			Expect(err).NotTo(HaveOccurred())
+
+			nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if diffNode && len(nodes.Items) < 2 {
+				ginkgo.Skip("Need at least two nodes for different-node case")
+			}
+
+			backendNode := nodes.Items[0].Name
+			clientNode := backendNode
+			if diffNode {
+				clientNode = nodes.Items[1].Name
+			}
+
+			jig := jigservice.NewTestJig(cs, testNamespace, "metallb-lb")
+			svc, err := jig.CreateLoadBalancerService(ctx, svcTweak)
+			Expect(err).NotTo(HaveOccurred())
+
+			svcFam, err := ipfamily.ForService(svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jig.Run(ctx, func(rc *corev1.ReplicationController) {
+				rc.Spec.Template.Spec.Containers[0].Args = []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", service.TestServicePort),
+					fmt.Sprintf("--udp-port=%d", service.TestServicePort),
+				}
+				rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(service.TestServicePort)
+				rc.Spec.Template.Spec.NodeName = backendNode
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				svc, err = cs.CoreV1().Services(testNamespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return loadBalancerIngressReady(svc, svcFam)
+			}, 2*time.Minute, time.Second).Should(BeTrue(), "LoadBalancer ingress was not assigned for the service IP family")
+
+			selector := labels.Set(jig.Labels).AsSelector()
+			backendPods, err := cs.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(backendPods.Items).NotTo(BeEmpty())
+			backendPod := backendPods.Items[0]
+			Expect(backendPod.Status.PodIP).NotTo(BeEmpty())
+
+			client := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clientpod",
+					Namespace: testNamespace,
+				},
+				Spec: corev1.PodSpec{
+					NodeName: clientNode,
+					Containers: []corev1.Container{
+						{
+							Name:  "agnhost",
+							Image: clientAgnhostImage,
+							// Image ENTRYPOINT/CMD run `agnhost pause` — keep pod alive for kubectl exec + curl.
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			}
+			clientPod, err := k8s.CreatePod(cs, client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clientPod.Status.PodIP).NotTo(BeEmpty())
+
+			port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+
+			assertReachability := func(lbFam ipfamily.Family) {
+				lbHost := ingressHostForFamily(svc, lbFam)
+				Expect(lbHost).NotTo(BeEmpty(), "ingress IP for family %s", lbFam)
+				wantClientIP := podIPMatchingFamily(clientPod, lbFam)
+				if wantClientIP == "" {
+					ginkgo.Skip(fmt.Sprintf("client pod has no %s address", lbFam))
+				}
+
+				baseURL := fmt.Sprintf("http://%s/", net.JoinHostPort(lbHost, port))
+				clientExec := executor.ForPod(testNamespace, clientPod.Name, "agnhost")
+
+				ginkgo.By(fmt.Sprintf("Checking reachability via %s load balancer IP", lbFam))
+				hostOut, err := clientExec.Exec("curl", "-fsS", "--max-time", "10", baseURL+"hostName")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.TrimSpace(hostOut)).To(Equal(backendPod.Name),
+					"netexec /hostName should match the backend pod name (default pod hostname in Kubernetes)")
+
+				ginkgo.By(fmt.Sprintf("Checking client source IP seen by backend (%s)", lbFam))
+				clientOut, err := clientExec.Exec("curl", "-fsS", "--max-time", "10", baseURL+"clientip")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.TrimSpace(clientOut)).To(ContainSubstring(wantClientIP))
+			}
+
+			switch svcFam {
+			case ipfamily.IPv4:
+				assertReachability(ipfamily.IPv4)
+			case ipfamily.IPv6:
+				assertReachability(ipfamily.IPv6)
+			case ipfamily.DualStack:
+				assertReachability(ipfamily.IPv4)
+				assertReachability(ipfamily.IPv6)
+			default:
+				ginkgo.Fail(fmt.Sprintf("unsupported service IP family %q", svcFam))
+			}
+		},
+		ginkgo.Entry("IPV4, client on same node as backend", false, lbTestResources([]string{l2tests.IPV4ServiceRange}), svcV4Local),
+		ginkgo.Entry("IPV4, client on different node than backend", true, lbTestResources([]string{l2tests.IPV4ServiceRange}), svcV4Local),
+		ginkgo.Entry("IPV6, client on same node as backend", false, lbTestResources([]string{l2tests.IPV6ServiceRange}), svcV6Local),
+		ginkgo.Entry("IPV6, client on different node than backend", true, lbTestResources([]string{l2tests.IPV6ServiceRange}), svcV6Local),
+		ginkgo.Entry("DUALSTACK, client on same node as backend", false, lbTestResources([]string{l2tests.IPV4ServiceRange, l2tests.IPV6ServiceRange}), svcDualStackLocal),
+		ginkgo.Entry("DUALSTACK, client on different node than backend", true, lbTestResources([]string{l2tests.IPV4ServiceRange, l2tests.IPV6ServiceRange}), svcDualStackLocal),
+	)
+})


### PR DESCRIPTION
This adds an end-to-end check that a LoadBalancer service’s external IP is reachable from inside the cluster and that the backend sees the expected client address.

A new e2etest/servicetests package with a Ginkgo DescribeTable covering two placements of the client pod: on the same node as the backend, and on a different node (the latter is skipped when the cluster has fewer than two nodes).
A busybox client pod runs wget against the VIP: it checks that /hostName matches the backend pod name (default pod hostname in Kubernetes) and that /clientip includes the client pod’s PodIP.



<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**: adding new test to validate MetalLB assigned external IP of a service is accessible inside the cluster

> Uncomment only one, leave it on its own line:
>
> /kind bug
 /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**: Expanding test coverage for e2etests

**Special notes for your reviewer**: A new table test to validate external IP accessibility from inside the cluster.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
