### PR TITLE
make speaker hostNetwork configurable

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -134,6 +134,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.frr.metricsPort | int | `7473` |  |
 | speaker.frr.resources | object | `{}` |  |
 | speaker.frrMetrics.resources | object | `{}` |  |
+| speaker.hostNetwork | bool | `true` |  |
 | speaker.ignoreExcludeLB | bool | `false` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -168,7 +168,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
-      hostNetwork: true
+      hostNetwork: {{ .Values.speaker.hostNetwork }}
       {{- if .Values.speaker.securityContext }}
       securityContext:
         {{- toYaml .Values.speaker.securityContext | nindent 8 }}

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -339,6 +339,9 @@
             "tolerateMaster": {
               "type": "boolean"
             },
+            "hostNetwork": {
+              "type": "boolean"
+            },
             "memberlist": {
               "type": "object",
               "properties": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -265,6 +265,7 @@ speaker:
   # -- Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none`
   logLevel: info
   tolerateMaster: true
+  hostNetwork: true
   memberlist:
     # --  When enabled: false, the speaker pods must run on all nodes
     enabled: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
Fixed #3005 

make speaker `hostNetwork` configurable

Adds `speaker.hostNetwork` parameter to `values.yaml`, allowing users to disable host networking for the speaker daemonset. Defaults to true to preserve existing behavior.
**Special notes for your reviewer**:
N/A

**Testing**:
```
# default, existing behavior
helm template metallb . | grep -A 2 -B 2 "hostNetwork:"
      serviceAccountName: metallb-frr-k8s-controller
      terminationGracePeriodSeconds: 0
      hostNetwork: true
      volumes:
        - name: frr-sockets
--
      serviceAccountName: metallb-speaker
      terminationGracePeriodSeconds: 0
      hostNetwork: true
      volumes:
        - name: memberlist
--
      serviceAccountName: metallb-frr-k8s-controller
      terminationGracePeriodSeconds: 10
      hostNetwork: true
---

# speaker hostNetwork set to false
helm template metallb . --set speaker.hostNetwork=false | grep -A 2 -B 2 "hostNetwork:" | grep -A 2 -B 2 "hostNetwork:"
      serviceAccountName: metallb-frr-k8s-controller
      terminationGracePeriodSeconds: 0
      hostNetwork: true
      volumes:
        - name: frr-sockets
--
      serviceAccountName: metallb-speaker
      terminationGracePeriodSeconds: 0
      hostNetwork: false
      volumes:
        - name: memberlist
--
      serviceAccountName: metallb-frr-k8s-controller
      terminationGracePeriodSeconds: 10
      hostNetwork: true
---
```

**Release note**:
NONE
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
