### PR TITLE
bgp: fix bgppeer validation

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -10,6 +10,7 @@ import (
 	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
 	"go.universe.tf/metallb/internal/bgp/community"
 	"go.universe.tf/metallb/internal/ipfamily"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -161,15 +162,46 @@ func DiscardNativeOnly(c ClusterResources) error {
 			peerAddr[peerID] = true
 		}
 	}
-	for _, p := range c.Peers {
-		for _, p1 := range c.Peers[1:] {
+	for i := 0; i < len(c.Peers); i++ {
+		for j := i + 1; j < len(c.Peers); j++ {
+			p, p1 := c.Peers[i], c.Peers[j]
 			if p.Spec.MyASN != p1.Spec.MyASN &&
 				p.Spec.VRFName == p1.Spec.VRFName {
-				return fmt.Errorf("peer %s has myAsn different from %s, in FRR mode all myAsn must be equal for the same VRF", p.Spec.Address, p1.Spec.Address)
+				shares, err := peersMayShareNode(p, p1, c.Nodes)
+				if err != nil {
+					return err
+				}
+				if shares {
+					return fmt.Errorf("peer %s has myAsn different from %s, in FRR mode all myAsn must be equal for the same VRF",
+						p.Spec.Address, p1.Spec.Address)
+				}
 			}
 		}
 	}
 	return nil
+}
+
+// peersMayShareNode returns true if the two peers could be scheduled on the
+// same node. When no nodes are available the check is conservative and returns
+// true. Empty NodeSelectors mean the peer targets every node.
+func peersMayShareNode(p, p1 metallbv1beta2.BGPPeer, nodes []corev1.Node) (bool, error) {
+	if len(nodes) == 0 {
+		return true, nil
+	}
+	nodesForP, err := selectedNodes(nodes, p.Spec.NodeSelectors)
+	if err != nil {
+		return false, err
+	}
+	nodesForP1, err := selectedNodes(nodes, p1.Spec.NodeSelectors)
+	if err != nil {
+		return false, err
+	}
+	for nodeName := range nodesForP {
+		if nodesForP1[nodeName] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // validateConfig is meant to validate all the inter-dependencies of a parsed configuration.

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.universe.tf/metallb/api/v1beta1"
 	"go.universe.tf/metallb/api/v1beta2"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -496,6 +497,112 @@ func TestValidateFRR(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			desc: "myAsn different, same VRF, peers on disjoint nodes via nodeSelectors",
+			config: ClusterResources{
+				Nodes: []corev1.Node{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:   "node-a",
+							Labels: map[string]string{"role": "worker"},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:   "node-b",
+							Labels: map[string]string{"role": "infra"},
+						},
+					},
+				},
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							MyASN:   100,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "worker"}},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.5",
+							MyASN:   200,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "infra"}},
+							},
+						},
+					},
+				},
+			},
+			mustFail: false,
+		},
+		{
+			desc: "myAsn different, same VRF, peers overlap on shared node via nodeSelectors",
+			config: ClusterResources{
+				Nodes: []corev1.Node{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:   "node-a",
+							Labels: map[string]string{"role": "worker"},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:   "node-b",
+							Labels: map[string]string{"role": "worker"},
+						},
+					},
+				},
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							MyASN:   100,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "worker"}},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.5",
+							MyASN:   200,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "worker"}},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
+			desc: "myAsn different, same VRF, no nodes available (conservative: fail)",
+			config: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.4",
+							MyASN:   100,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "worker"}},
+							},
+						},
+					},
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							Address: "1.2.3.5",
+							MyASN:   200,
+							NodeSelectors: []v1.LabelSelector{
+								{MatchLabels: map[string]string{"role": "infra"}},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
 		},
 		{
 			desc: "duplicate bgp address",

--- a/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook.go
+++ b/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-kit/log/level"
 	"go.universe.tf/metallb/api/v1beta2"
 	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -110,8 +111,13 @@ func validatePeerCreate(bgpPeer *v1beta2.BGPPeer) (string, error) {
 		return "", err
 	}
 
+	nodes, err := GetExistingNodes()
+	if err != nil {
+		return "", err
+	}
+
 	toValidate := bgpPeerListWithUpdate(existingBGPPeers, bgpPeer)
-	err = Validator.Validate(toValidate)
+	err = Validator.Validate(toValidate, nodes)
 	if err != nil {
 		level.Error(Logger).Log("webhook", "bgppeer", "action", "create", "name", bgpPeer.Name, "namespace", bgpPeer.Namespace, "error", err)
 		return "", err
@@ -128,8 +134,13 @@ func validatePeerUpdate(bgpPeer *v1beta2.BGPPeer, _ *v1beta2.BGPPeer) error {
 		return err
 	}
 
+	nodes, err := GetExistingNodes()
+	if err != nil {
+		return err
+	}
+
 	toValidate := bgpPeerListWithUpdate(existingBGPPeers, bgpPeer)
-	err = Validator.Validate(toValidate)
+	err = Validator.Validate(toValidate, nodes)
 	if err != nil {
 		level.Error(Logger).Log("webhook", "bgppeer", "action", "update", "name", bgpPeer.Name, "namespace", bgpPeer.Namespace, "error", err)
 		return err
@@ -149,6 +160,15 @@ var GetExistingBGPPeers = func() (*v1beta2.BGPPeerList, error) {
 		return nil, errors.Join(err, errors.New("failed to get existing BGPPeer objects"))
 	}
 	return existingBGPPeerslList, nil
+}
+
+var GetExistingNodes = func() (*corev1.NodeList, error) {
+	existingNodeList := &corev1.NodeList{}
+	err := WebhookClient.List(context.Background(), existingNodeList)
+	if err != nil {
+		return nil, errors.Join(err, errors.New("failed to get existing Node objects"))
+	}
+	return existingNodeList, nil
 }
 
 func bgpPeerListWithUpdate(existing *v1beta2.BGPPeerList, toAdd *v1beta2.BGPPeer) *v1beta2.BGPPeerList {

--- a/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook_test.go
+++ b/internal/k8s/webhooks/webhookv1beta2/bgppeer_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/go-cmp/cmp"
 	"go.universe.tf/metallb/api/v1beta2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,8 +34,14 @@ func TestValidateBGPPeer(t *testing.T) {
 		}, nil
 	}
 
+	toRestoreNodes := GetExistingNodes
+	GetExistingNodes = func() (*corev1.NodeList, error) {
+		return &corev1.NodeList{}, nil
+	}
+
 	defer func() {
 		GetExistingBGPPeers = toRestore
+		GetExistingNodes = toRestoreNodes
 	}()
 
 	tests := []struct {

--- a/internal/k8s/webhooks/webhookv1beta2/mock_validator_test.go
+++ b/internal/k8s/webhooks/webhookv1beta2/mock_validator_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 
 	"go.universe.tf/metallb/api/v1beta2"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type mockValidator struct {
 	bgpPeers   *v1beta2.BGPPeerList
+	nodes      *corev1.NodeList
 	forceError bool
 }
 
@@ -19,6 +21,8 @@ func (m *mockValidator) Validate(objects ...client.ObjectList) error {
 		switch list := obj.(type) {
 		case *v1beta2.BGPPeerList:
 			m.bgpPeers = list
+		case *corev1.NodeList:
+			m.nodes = list
 		default:
 			panic("unexpected type")
 		}


### PR DESCRIPTION
Modify the validation to check whether two peers with different `myASN` in the same VRF target the same node, instead of blindly comparing all peers cluster-wide. So that the one-ASN-per-VRF constraint is preserved andit is enforced at the correct scope. The key insight is that two BGPPeers with different `myASN` in the same VRF are only a problem if they land on the same node. If `nodeSelectors` ensure they target different nodes, no single FRR instance ever sees both, the constraint is naturally satisfied. The fix replaces the cluster-wide check with one that resolves `nodeSelectors` against actual node labels to determine whether two peers can land on the same node.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
