### PR TITLE
Fix L2 speaker election ignoring service selectors

### DIFF
--- a/e2etest/l2tests/service_selector.go
+++ b/e2etest/l2tests/service_selector.go
@@ -4,6 +4,7 @@ package l2tests
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -15,6 +16,7 @@ import (
 	"go.universe.tf/e2etest/pkg/status"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 
+	corev1 "k8s.io/api/core/v1"
 	pkgerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -174,6 +176,167 @@ var _ = ginkgo.Describe("L2-ServiceSelector", func() {
 				_, err := status.L2ForService(ConfigUpdater.Client(), svcPoolA)
 				return err
 			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred(), "Service matching both selectors should be advertised again")
+		})
+	})
+
+	ginkgo.Context("Service selector filters election candidate nodes", func() {
+		ginkgo.It("should announce from exactly one node when both advertisements match the service", func() {
+			ginkgo.By("Getting the list of nodes")
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(allNodes.Items) < 2 {
+				ginkgo.Skip("Not enough nodes, need at least 2")
+			}
+
+			node0 := allNodes.Items[0]
+			node1 := allNodes.Items[1]
+
+			poolV4, err := config.GetIPFromRangeByIndex(IPV4ServiceRange, 0)
+			Expect(err).NotTo(HaveOccurred())
+			poolV6, err := config.GetIPFromRangeByIndex(IPV6ServiceRange, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Setting up a pool with two L2 advertisements targeting different nodes but the same service")
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "l2-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{poolV4 + "/32", poolV6 + "/128"},
+						},
+					},
+				},
+				L2Advs: []metallbv1beta1.L2Advertisement{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv-for-node0",
+						},
+						Spec: metallbv1beta1.L2AdvertisementSpec{
+							NodeSelectors: k8s.SelectorsForNodes([]corev1.Node{node0}),
+							ServiceSelectors: []metav1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"app": "test"},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv-for-node1",
+						},
+						Spec: metallbv1beta1.L2AdvertisementSpec{
+							NodeSelectors: k8s.SelectorsForNodes([]corev1.Node{node1}),
+							ServiceSelectors: []metav1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"app": "test"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Creating a service matching both advertisements' service selector")
+			svc, _ := service.CreateWithBackend(cs, testNamespace, "svc-test", service.TrafficPolicyCluster,
+				service.WithLabels(map[string]string{"app": "test"}))
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ginkgo.By("Checking that exactly one of the two candidate nodes announces the service")
+			Eventually(func() string {
+				l2Status, err := status.L2ForService(ConfigUpdater.Client(), svc)
+				if err != nil {
+					return fmt.Sprintf("error getting L2 status: %v", err)
+				}
+				return l2Status.Status.Node
+			}, 30*time.Second, 1*time.Second).Should(BeElementOf(node0.Name, node1.Name),
+				"Service should be announced by exactly one of the two candidate nodes")
+		})
+
+		ginkgo.It("should not announce when no advertisement matches both service and node", func() {
+			poolV4, err := config.GetIPFromRangeByIndex(IPV4ServiceRange, 0)
+			Expect(err).NotTo(HaveOccurred())
+			poolV6, err := config.GetIPFromRangeByIndex(IPV6ServiceRange, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Setting up a pool with two L2 advertisements: one matches all nodes but wrong service, one matches our service but non-existing node")
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "l2-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{poolV4 + "/32", poolV6 + "/128"},
+						},
+					},
+				},
+				L2Advs: []metallbv1beta1.L2Advertisement{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv-all-nodes-wrong-svc",
+						},
+						Spec: metallbv1beta1.L2AdvertisementSpec{
+							ServiceSelectors: []metav1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"app": "other"},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv-right-svc-ghost-node",
+						},
+						Spec: metallbv1beta1.L2AdvertisementSpec{
+							NodeSelectors: []metav1.LabelSelector{
+								{
+									MatchLabels: map[string]string{
+										"kubernetes.io/hostname": "non-existing-node",
+									},
+								},
+							},
+							ServiceSelectors: []metav1.LabelSelector{
+								{
+									MatchLabels: map[string]string{"app": "web"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err = ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Creating a service matching only the ghost-node advertisement's service selector")
+			svc, _ := service.CreateWithBackend(cs, testNamespace, "svc-web", service.TrafficPolicyCluster,
+				service.WithLabels(map[string]string{"app": "web"}))
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ginkgo.By("Checking that no node announces the service")
+			Consistently(func() error {
+				l2Status, err := status.L2ForService(ConfigUpdater.Client(), svc)
+				if pkgerr.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return fmt.Errorf("unexpected error getting L2 status: %v", err)
+				}
+				return fmt.Errorf("service is being announced by node %q but should not be", l2Status.Status.Node)
+			}, 10*time.Second, 1*time.Second).Should(Succeed(),
+				"Service should not be announced when no advertisement matches both service and node")
+
 		})
 	})
 

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -86,19 +86,15 @@ func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce 
 		return "notOwner"
 	}
 
-	if !poolMatchesNodeL2(pool, c.myNode) {
-		level.Debug(l).Log("event", "skipping should announce l2", "service", name, "reason", "pool not matching my node")
-		return "notOwner"
-	}
-
-	adsForService := l2AdsForService(pool.L2Advertisements, c.myNode, svc)
-	serviceHasL2Adv := len(adsForService) > 0
-	if !serviceHasL2Adv {
+	adsForService := l2AdsForService(pool.L2Advertisements, svc)
+	if !adsMatchNodeL2(adsForService, c.myNode) {
 		level.Debug(l).Log("event", "skipping should announce l2", "service", name, "reason", "no advertisement matching service on my node")
 		return "noMatchingAdvertisement"
 	}
 
-	speakerMap := c.speakersForPool(l, name, pool, nodes)
+	// All service-matching ads (not filtered by node) so every speaker
+	// evaluates the same candidate set and the election is deterministic.
+	speakerMap := c.speakersForAds(l, name, adsForService, nodes)
 	availableNodes := nodesWithActiveSpeakers(speakerMap)
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
 		availableNodes = nodesWithEndpoint(eps, speakerMap)
@@ -135,9 +131,10 @@ func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce 
 func (c *layer2Controller) SetBalancer(l log.Logger, name string, lbIPs []net.IP, pool *config.Pool, client service, svc *v1.Service) error {
 	ifs := c.announcer.GetInterfaces()
 	updateStatus := false
-	adsForService := l2AdsForService(pool.L2Advertisements, c.myNode, svc)
+	allAdsForService := l2AdsForService(pool.L2Advertisements, svc)
+	myAdsForService := l2AdsForNode(allAdsForService, c.myNode)
 	for _, lbIP := range lbIPs {
-		ipAdv := ipAdvertisementFor(lbIP, adsForService)
+		ipAdv := ipAdvertisementFor(lbIP, myAdsForService)
 		if !ipAdv.MatchInterfaces(ifs...) {
 			level.Warn(l).Log("op", "SetBalancer", "protocol", "layer2", "service", name, "IPAdvertisement", ipAdv,
 				"localIfs", ifs, "msg", "the specified interfaces used to announce LB IP don't exist")
@@ -213,24 +210,20 @@ func activeEndpointExists(eps []discovery.EndpointSlice) bool {
 	return false
 }
 
-func poolMatchesNodeL2(pool *config.Pool, node string) bool {
-	for _, adv := range pool.L2Advertisements {
-		if adv.Nodes[node] {
+func adsMatchNodeL2(ads []*config.L2Advertisement, node string) bool {
+	for _, ad := range ads {
+		if ad.Nodes[node] {
 			return true
 		}
 	}
 	return false
 }
 
-// l2AdvsForService returns the L2 advertisements matching the service on the given node.
-func l2AdsForService(ads []*config.L2Advertisement, node string, svc *v1.Service) []*config.L2Advertisement {
+// l2AdsForService returns the L2 advertisements matching the service.
+func l2AdsForService(ads []*config.L2Advertisement, svc *v1.Service) []*config.L2Advertisement {
 	var result []*config.L2Advertisement
 	svcLabels := labels.Set(svc.Labels)
 	for _, ad := range ads {
-		if !ad.Nodes[node] {
-			continue
-		}
-
 		if len(ad.ServiceSelectors) == 0 {
 			result = append(result, ad)
 			continue
@@ -246,7 +239,18 @@ func l2AdsForService(ads []*config.L2Advertisement, node string, svc *v1.Service
 	return result
 }
 
-func (c *layer2Controller) speakersForPool(l log.Logger, name string, pool *config.Pool, nodes map[string]*v1.Node) map[string]bool {
+// l2AdsForNode returns the subset of ads that match the given node.
+func l2AdsForNode(ads []*config.L2Advertisement, node string) []*config.L2Advertisement {
+	var result []*config.L2Advertisement
+	for _, ad := range ads {
+		if ad.Nodes[node] {
+			result = append(result, ad)
+		}
+	}
+	return result
+}
+
+func (c *layer2Controller) speakersForAds(l log.Logger, name string, ads []*config.L2Advertisement, nodes map[string]*v1.Node) map[string]bool {
 	sl := c.sList.UsableSpeakers()
 	eligibleNodes := maps.Keys(sl.Nodes)
 	if sl.Disabled {
@@ -266,7 +270,7 @@ func (c *layer2Controller) speakersForPool(l log.Logger, name string, pool *conf
 			continue
 		}
 
-		if poolMatchesNodeL2(pool, s) {
+		if adsMatchNodeL2(ads, s) {
 			res[s] = true
 		}
 	}

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -1358,7 +1358,7 @@ func TestShouldAnnounceFromNodes(t *testing.T) {
 				"10.20.30.1": "",
 			},
 			c2ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noMatchingAdvertisement",
 			},
 		},
 		{
@@ -1397,7 +1397,7 @@ func TestShouldAnnounceFromNodes(t *testing.T) {
 				"10.20.30.1": "",
 			},
 			c2ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noMatchingAdvertisement",
 			},
 		},
 		{
@@ -1407,7 +1407,7 @@ func TestShouldAnnounceFromNodes(t *testing.T) {
 			L2Advertisements: advertisementOnIris2,
 			trafficPolicy:    v1.ServiceExternalTrafficPolicyTypeLocal,
 			c1ExpectedResult: map[string]string{
-				"10.20.30.1": "notOwner",
+				"10.20.30.1": "noMatchingAdvertisement",
 			},
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
@@ -1860,42 +1860,36 @@ func TestL2AdsForService(t *testing.T) {
 	tests := []struct {
 		desc     string
 		ads      []*config.L2Advertisement
-		node     string
 		svc      *v1.Service
 		expected []*config.L2Advertisement
 	}{
 		{
 			desc:     "Empty selectors match all",
 			ads:      []*config.L2Advertisement{ad1},
-			node:     "nodeA",
 			svc:      &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}}},
 			expected: []*config.L2Advertisement{ad1},
 		},
 		{
 			desc:     "Matching selector",
 			ads:      []*config.L2Advertisement{ad2},
-			node:     "nodeA",
 			svc:      &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}}},
 			expected: []*config.L2Advertisement{ad2},
 		},
 		{
 			desc:     "Non-matching selector",
 			ads:      []*config.L2Advertisement{ad3},
-			node:     "nodeA",
 			svc:      &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}}},
 			expected: []*config.L2Advertisement{},
 		},
 		{
-			desc:     "Wrong node",
+			desc:     "Ad with no matching selector is still returned (node filtering is separate)",
 			ads:      []*config.L2Advertisement{ad4},
-			node:     "nodeA",
 			svc:      &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}}},
-			expected: []*config.L2Advertisement{},
+			expected: []*config.L2Advertisement{ad4},
 		},
 		{
-			desc:     "Multiple ads - some match",
+			desc:     "Multiple ads - some match by service selector",
 			ads:      []*config.L2Advertisement{ad3, ad2, ad1}, // apache selector, nginx selector, empty (matches all)
-			node:     "nodeA",
 			svc:      &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}}},
 			expected: []*config.L2Advertisement{ad2, ad1}, // nginx match + empty match
 		},
@@ -1903,7 +1897,7 @@ func TestL2AdsForService(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			result := l2AdsForService(test.ads, test.node, test.svc)
+			result := l2AdsForService(test.ads, test.svc)
 			if len(result) != len(test.expected) {
 				t.Errorf("expected %d ads, got %d", len(test.expected), len(result))
 				return
@@ -1923,6 +1917,357 @@ func selector(s string) labels.Selector {
 		panic(err)
 	}
 	return ret
+}
+
+func TestL2ElectionConsistentButAdsPerNode(t *testing.T) {
+	// Two ads target the same service but different nodes with different
+	// interfaces. The election must be identical on both nodes (same candidate
+	// set), but each node must announce using only its own interface.
+	fakeSL := &fakeSpeakerList{
+		speakers: map[string]bool{
+			"iris1": true,
+			"iris2": true,
+		},
+	}
+
+	l2Advertisements := []*config.L2Advertisement{
+		{
+			Nodes:            map[string]bool{"iris1": true},
+			Interfaces:       []string{"eth0"},
+			ServiceSelectors: []labels.Selector{selector("app=web")},
+		},
+		{
+			Nodes:            map[string]bool{"iris2": true},
+			Interfaces:       []string{"eth1"},
+			ServiceSelectors: []labels.Selector{selector("app=web")},
+		},
+	}
+
+	cfg := &config.Config{
+		Pools: &config.Pools{ByName: map[string]*config.Pool{
+			"default": {
+				CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
+				L2Advertisements: l2Advertisements,
+			},
+		}},
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "svc-web",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+		Status: statusAssigned("10.20.30.1"),
+	}
+
+	eps := []discovery.EndpointSlice{
+		{
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses:  []string{"2.3.4.5"},
+					NodeName:   ptr.To("iris1"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+				{
+					Addresses:  []string{"2.3.4.15"},
+					NodeName:   ptr.To("iris2"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	}
+
+	l := log.NewNopLogger()
+	lbIP := net.ParseIP("10.20.30.1")
+	pool := cfg.Pools.ByName["default"]
+
+	c1, err := newController(controllerConfig{
+		MyNode:  "iris1",
+		Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:   fakeSL,
+		bgpType: bgpNative,
+	})
+	if err != nil {
+		t.Fatalf("creating controller: %s", err)
+	}
+	c1.client = &testK8S{t: t}
+
+	c2, err := newController(controllerConfig{
+		MyNode:  "iris2",
+		Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:   fakeSL,
+		bgpType: bgpNative,
+	})
+	if err != nil {
+		t.Fatalf("creating controller: %s", err)
+	}
+	c2.client = &testK8S{t: t}
+
+	if c1.SetConfig(l, cfg) == controllers.SyncStateError {
+		t.Fatal("c1 SetConfig failed")
+	}
+	if c2.SetConfig(l, cfg) == controllers.SyncStateError {
+		t.Fatal("c2 SetConfig failed")
+	}
+
+	// Exactly one node must win the election.
+	r1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, pool, svc, eps, nil)
+	r2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, pool, svc, eps, nil)
+
+	if (r1 == "") == (r2 == "") {
+		t.Fatalf("expected exactly one winner, got c1=%q c2=%q", r1, r2)
+	}
+
+	// Each node's IPAdvertisement must use only its own interface.
+	adsForSvc := l2AdsForService(pool.L2Advertisements, svc)
+	ipAdv1 := ipAdvertisementFor(lbIP, l2AdsForNode(adsForSvc, "iris1"))
+	ipAdv2 := ipAdvertisementFor(lbIP, l2AdsForNode(adsForSvc, "iris2"))
+
+	expected1 := layer2.NewIPAdvertisement(lbIP, false, sets.New("eth0"))
+	expected2 := layer2.NewIPAdvertisement(lbIP, false, sets.New("eth1"))
+
+	if !ipAdv1.Equal(&expected1) {
+		t.Errorf("iris1 should use eth0, got %v", ipAdv1)
+	}
+	if !ipAdv2.Equal(&expected2) {
+		t.Errorf("iris2 should use eth1, got %v", ipAdv2)
+	}
+}
+
+func TestL2NoMatchingAdForServiceAndNode(t *testing.T) {
+	// One ad matches all nodes but targets a different service.
+	// Another ad matches our service but targets a non-existing node.
+	// No node should announce.
+	fakeSL := &fakeSpeakerList{
+		speakers: map[string]bool{
+			"iris1": true,
+			"iris2": true,
+		},
+	}
+
+	l2Advertisements := []*config.L2Advertisement{
+		{
+			Nodes:            map[string]bool{"iris1": true, "iris2": true},
+			AllInterfaces:    true,
+			ServiceSelectors: []labels.Selector{selector("app=other")},
+		},
+		{
+			Nodes:            map[string]bool{"ghost": true},
+			AllInterfaces:    true,
+			ServiceSelectors: []labels.Selector{selector("app=web")},
+		},
+	}
+
+	cfg := &config.Config{
+		Pools: &config.Pools{ByName: map[string]*config.Pool{
+			"default": {
+				CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
+				L2Advertisements: l2Advertisements,
+			},
+		}},
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "svc-web",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+		Status: statusAssigned("10.20.30.1"),
+	}
+
+	eps := []discovery.EndpointSlice{
+		{
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses:  []string{"2.3.4.5"},
+					NodeName:   ptr.To("iris1"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+				{
+					Addresses:  []string{"2.3.4.15"},
+					NodeName:   ptr.To("iris2"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	}
+
+	l := log.NewNopLogger()
+	lbIP := net.ParseIP("10.20.30.1")
+	pool := cfg.Pools.ByName["default"]
+
+	for _, node := range []string{"iris1", "iris2"} {
+		c, err := newController(controllerConfig{
+			MyNode:  node,
+			Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+			SList:   fakeSL,
+			bgpType: bgpNative,
+		})
+		if err != nil {
+			t.Fatalf("creating controller for %s: %s", node, err)
+		}
+		c.client = &testK8S{t: t}
+
+		if c.SetConfig(l, cfg) == controllers.SyncStateError {
+			t.Fatalf("%s SetConfig failed", node)
+		}
+
+		r := c.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, pool, svc, eps, nil)
+		if r != "noMatchingAdvertisement" {
+			t.Errorf("%s: expected %q, got %q", node, "noMatchingAdvertisement", r)
+		}
+	}
+}
+
+func TestL2ServiceSelectorFiltersCandidateNodes(t *testing.T) {
+	// when two L2 advertisements target different nodes with
+	// different service selectors, the election set must only include nodes whose
+	// advertisement actually matches the service. Otherwise a node that wins the
+	// election but has no matching advertisement causes the service to go unannounced.
+	fakeSL := &fakeSpeakerList{
+		speakers: map[string]bool{
+			"iris1": true,
+			"iris2": true,
+		},
+	}
+
+	l2Advertisements := []*config.L2Advertisement{
+		{
+			Nodes:            map[string]bool{"iris1": true},
+			AllInterfaces:    true,
+			ServiceSelectors: []labels.Selector{selector("app=foo")},
+		},
+		{
+			Nodes:            map[string]bool{"iris2": true},
+			AllInterfaces:    true,
+			ServiceSelectors: []labels.Selector{selector("app=bar")},
+		},
+	}
+
+	cfg := &config.Config{
+		Pools: &config.Pools{ByName: map[string]*config.Pool{
+			"default": {
+				CIDR:             []*net.IPNet{ipnet("10.20.30.0/24")},
+				L2Advertisements: l2Advertisements,
+			},
+		}},
+	}
+
+	l := log.NewNopLogger()
+
+	svcFoo := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "svc-foo",
+			Labels: map[string]string{"app": "foo"},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+		Status: statusAssigned("10.20.30.1"),
+	}
+
+	svcBar := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "svc-bar",
+			Labels: map[string]string{"app": "bar"},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+		Status: statusAssigned("10.20.30.1"),
+	}
+
+	eps := []discovery.EndpointSlice{
+		{
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses:  []string{"2.3.4.5"},
+					NodeName:   ptr.To("iris1"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+				{
+					Addresses:  []string{"2.3.4.15"},
+					NodeName:   ptr.To("iris2"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	}
+
+	lbIP := net.ParseIP("10.20.30.1")
+
+	tests := []struct {
+		desc             string
+		svc              *v1.Service
+		c1ExpectedResult string
+		c2ExpectedResult string
+	}{
+		{
+			desc:             "svc-foo matches only iris1's adv, iris1 must announce",
+			svc:              svcFoo,
+			c1ExpectedResult: "",
+			c2ExpectedResult: "noMatchingAdvertisement",
+		},
+		{
+			desc:             "svc-bar matches only iris2's adv, iris2 must announce",
+			svc:              svcBar,
+			c1ExpectedResult: "noMatchingAdvertisement",
+			c2ExpectedResult: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			c1, err := newController(controllerConfig{
+				MyNode:  "iris1",
+				Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+				SList:   fakeSL,
+				bgpType: bgpNative,
+			})
+			if err != nil {
+				t.Fatalf("creating controller: %s", err)
+			}
+			c1.client = &testK8S{t: t}
+
+			c2, err := newController(controllerConfig{
+				MyNode:  "iris2",
+				Logger:  log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+				SList:   fakeSL,
+				bgpType: bgpNative,
+			})
+			if err != nil {
+				t.Fatalf("creating controller: %s", err)
+			}
+			c2.client = &testK8S{t: t}
+
+			if c1.SetConfig(l, cfg) == controllers.SyncStateError {
+				t.Fatal("c1 SetConfig failed")
+			}
+			if c2.SetConfig(l, cfg) == controllers.SyncStateError {
+				t.Fatal("c2 SetConfig failed")
+			}
+
+			r1 := c1.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], test.svc, eps, nil)
+			r2 := c2.protocolHandlers[config.Layer2].ShouldAnnounce(l, "test1", []net.IP{lbIP}, cfg.Pools.ByName["default"], test.svc, eps, nil)
+
+			if r1 != test.c1ExpectedResult {
+				t.Errorf("c1 (iris1): expected %q, got %q", test.c1ExpectedResult, r1)
+			}
+			if r2 != test.c2ExpectedResult {
+				t.Errorf("c2 (iris2): expected %q, got %q", test.c2ExpectedResult, r2)
+			}
+		})
+	}
 }
 
 func TestIPAdvertisementFor(t *testing.T) {


### PR DESCRIPTION
The L2 leader election used all ads of the pool to build the candidate set, completely ignoring service selectors.
This meant a node whose advertisement targeted a different service could win the election, causing the service to not be announced.
Here we change this so that all ads relevant to the specific service are evaluated for the candidate set, ensuring both:
1) only nodes that are relevant are evaluated
2) the election is consistent across all nodes

Assisted-by: Cursor

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix L2 speaker election ignoring service selectors, making sure only the relevant L2Advertisements for the service are considered.
```
