### PR TITLE
e2etests: add ConfigurationState validation and recovery tests

### DIFF
--- a/e2etest/configurationstatetests/configurationstate.go
+++ b/e2etest/configurationstatetests/configurationstate.go
@@ -189,6 +189,322 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 		}, 60*time.Second, 5*time.Second).Should(Succeed())
 	})
 
+	ginkgo.It("speaker should have invalid result when valid BGPPeer BFD profile reference is broken at runtime", func() {
+		ginkgo.By("Deploying a valid BGPPeer with matching BFD profile")
+		resources := config.Resources{
+			Peers: []metallbv1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-bfd",
+					},
+					Spec: metallbv1beta2.BGPPeerSpec{
+						MyASN:      64512,
+						ASN:        64513,
+						Address:    "192.168.100.3",
+						BFDProfile: "bfd-profile",
+					},
+				},
+			},
+			BFDProfiles: []metallbv1beta1.BFDProfile{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bfd-profile",
+					},
+				},
+			},
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates report Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Breaking the BFD profile reference to a non-existent profile")
+		resources.Peers[0].Spec.BFDProfile = "new-bfd-profile"
+		err = ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		wantStatus := metallbv1beta1.ConfigurationStateStatus{
+			Result:       metallbv1beta1.ConfigurationResultInvalid,
+			ErrorSummary: "configuration error: peer bgp-bfd referencing non existing bfd profile new-bfd-profile",
+		}
+
+		ginkgo.By("Verifying all speaker ConfigurationStates update to Invalid")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantStatus)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Verifying controller ConfigurationState remains Valid")
+		Expect(stateMatches("controller", validStatus)).To(Succeed())
+	})
+
+	ginkgo.It("speaker should recover when missing community for BGPAdvertisement is created", func() {
+		ginkgo.By("Applying a BGPAdvertisement with an undefined community alias")
+		resources := config.Resources{
+			BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "advert-community-test",
+					},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						IPAddressPools: []string{"pool-community-test"},
+						Communities:    []string{"my-valid-alias"},
+					},
+				},
+			},
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		wantInvalid := metallbv1beta1.ConfigurationStateStatus{
+			Result:       metallbv1beta1.ConfigurationResultInvalid,
+			ErrorSummary: "configuration error: invalid community format: my-valid-alias\ninvalid community \"my-valid-alias\" in BGP advertisement",
+		}
+
+		ginkgo.By("Verifying all speaker ConfigurationStates are Invalid")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantInvalid)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Verifying controller ConfigurationState remains Valid")
+		Expect(stateMatches("controller", validStatus)).To(Succeed())
+
+		ginkgo.By("Creating the missing Community resource")
+		resources.Communities = []metallbv1beta1.Community{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "community-valid",
+				},
+				Spec: metallbv1beta1.CommunitySpec{
+					Communities: []metallbv1beta1.CommunityAlias{
+						{
+							Name:  "my-valid-alias",
+							Value: "64512:100",
+						},
+					},
+				},
+			},
+		}
+
+		err = ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates recover to Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+	})
+
+	ginkgo.It("FRR - speaker should cycle through errors as invalid BGPPeers are removed one by one", func() {
+		ginkgo.By("Creating two invalid BGPPeers: one with missing BFD profile, one with missing secret")
+		resources := config.Resources{
+			Peers: []metallbv1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-bfd",
+					},
+					Spec: metallbv1beta2.BGPPeerSpec{
+						MyASN:      64512,
+						ASN:        64513,
+						Address:    "192.168.100.3",
+						BFDProfile: "bfd-profile",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-secret-fail",
+					},
+					Spec: metallbv1beta2.BGPPeerSpec{
+						MyASN:   64512,
+						ASN:     64513,
+						Address: "192.168.200.5",
+						PasswordSecret: corev1.SecretReference{
+							Name: "bgp-secret-invalid",
+						},
+					},
+				},
+			},
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		wantBFDError := metallbv1beta1.ConfigurationStateStatus{
+			Result:       metallbv1beta1.ConfigurationResultInvalid,
+			ErrorSummary: "configuration error: peer bgp-bfd referencing non existing bfd profile bfd-profile",
+		}
+
+		ginkgo.By("Verifying speakers capture the BFD profile error")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantBFDError)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Verifying controller ConfigurationState remains Valid")
+		Expect(stateMatches("controller", validStatus)).To(Succeed())
+
+		ginkgo.By("Removing the BGPPeer with the BFD error")
+		toDelete := &metallbv1beta2.BGPPeer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bgp-bfd",
+				Namespace: metallb.Namespace,
+			},
+		}
+		err = ConfigUpdater.Client().Delete(context.Background(), toDelete)
+		Expect(err).NotTo(HaveOccurred())
+
+		wantSecretError := metallbv1beta1.ConfigurationStateStatus{
+			Result:       metallbv1beta1.ConfigurationResultInvalid,
+			ErrorSummary: "configuration error: parsing peer bgp-secret-fail secret ref not found for peer config \"metallb-system\"/\"bgp-secret-fail\"\nfailed to parse peer bgp-secret-fail password secret",
+		}
+
+		ginkgo.By("Verifying speakers update to the secret error")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantSecretError)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Removing the second BGPPeer")
+		toDelete = &metallbv1beta2.BGPPeer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bgp-secret-fail",
+				Namespace: metallb.Namespace,
+			},
+		}
+		err = ConfigUpdater.Client().Delete(context.Background(), toDelete)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates return to Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+	})
+
+	ginkgo.It("all ConfigurationStates should report valid with a valid BGP peer config", func() {
+		ginkgo.By("Creating secret with correct type for BGP peer authentication")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bgp-secret-valid",
+				Namespace: metallb.Namespace,
+			},
+			Type: corev1.SecretTypeBasicAuth,
+			StringData: map[string]string{
+				"password": "MySecurePassword123",
+			},
+		}
+		err := ConfigUpdater.Client().Create(context.Background(), secret)
+		Expect(err).NotTo(HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			ConfigUpdater.Client().Delete(context.Background(), secret)
+		})
+
+		ginkgo.By("Creating valid BGP peer referencing the secret")
+		resources := config.Resources{
+			Peers: []metallbv1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-valid",
+					},
+					Spec: metallbv1beta2.BGPPeerSpec{
+						MyASN:   64512,
+						ASN:     64513,
+						Address: "192.168.100.1",
+						PasswordSecret: corev1.SecretReference{
+							Name: "bgp-secret-valid",
+						},
+					},
+				},
+			},
+		}
+
+		err = ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates report Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+	})
+
+	ginkgo.It("FRR - should preserve invalid state after all ConfigurationStates are deleted and recreated", func() {
+		wantInvalid := metallbv1beta1.ConfigurationStateStatus{
+			Result:       metallbv1beta1.ConfigurationResultInvalid,
+			ErrorSummary: "configuration error: peer bgp-bfd referencing non existing bfd profile bfd-profile",
+		}
+
+		ginkgo.By("Applying a BGPPeer referencing a non-existent BFD profile")
+		resources := config.Resources{
+			Peers: []metallbv1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-bfd",
+					},
+					Spec: metallbv1beta2.BGPPeerSpec{
+						MyASN:      64512,
+						ASN:        64513,
+						Address:    "192.168.100.3",
+						BFDProfile: "bfd-profile",
+					},
+				},
+			},
+		}
+
+		err := ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all speaker ConfigurationStates are Invalid")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantInvalid)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Verifying controller ConfigurationState remains Valid")
+		Expect(stateMatches("controller", validStatus)).To(Succeed())
+
+		ginkgo.By("Deleting all ConfigurationState resources")
+		err = ConfigUpdater.Client().DeleteAllOf(context.Background(),
+			&metallbv1beta1.ConfigurationState{}, client.InNamespace(metallb.Namespace))
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying ConfigurationStates are recreated with Invalid status preserved")
+		Eventually(func() error {
+			return allSpeakersMatch(allNodes, wantInvalid)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Verifying controller ConfigurationState is recreated as Valid")
+		Eventually(func() error {
+			return stateMatches("controller", validStatus)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Creating the missing BFD profile to fix configuration")
+		resources.BFDProfiles = []metallbv1beta1.BFDProfile{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bfd-profile",
+				},
+			},
+		}
+
+		err = ConfigUpdater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates recover to Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("Deleting all ConfigurationState resources again")
+		err = ConfigUpdater.Client().DeleteAllOf(context.Background(),
+			&metallbv1beta1.ConfigurationState{}, client.InNamespace(metallb.Namespace))
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Verifying all ConfigurationStates are recreated as Valid")
+		Eventually(func() error {
+			return allStatesExist(allNodes)
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+	})
+
 	ginkgo.It("should self-heal after deletion", func() {
 		stateName := "speaker-" + allNodes.Items[0].Name
 
@@ -280,6 +596,16 @@ func allStatesExist(allNodes *corev1.NodeList) error {
 		}
 	}
 
+	return nil
+}
+
+func allSpeakersMatch(allNodes *corev1.NodeList, wantStatus metallbv1beta1.ConfigurationStateStatus) error {
+	for _, node := range allNodes.Items {
+		speakerStateName := "speaker-" + node.Name
+		if err := stateMatches(speakerStateName, wantStatus); err != nil {
+			return fmt.Errorf("node %q: %w", node.Name, err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cover additional ConfigurationState scenarios: valid BGP peer config, runtime BFD profile dependency break, BGPAdvertisement with missing community recovery, and status persistence after bulk deletion.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:

> /kind bug
> /kind cleanup
  /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Adds e2e tests for additional ConfigurationState scenarios:
- **Valid BGP peer config**: verifies all ConfigurationStates report Valid when a BGPPeer with a correctly-typed secret is applied.
- **Runtime dependency break**: deploys a valid BGPPeer+BFDProfile, then breaks the BFD profile reference and verifies speakers transition to Invalid.
- **BGPAdvertisement with missing community**: applies a BGPAdvertisement referencing an undefined community alias, verifies speakers go Invalid, then creates the Community resource and verifies recovery to Valid.
- **Status persistence after deletion**: verifies ConfigurationState resources are recreated with the correct status (both Invalid and Valid) after bulk deletion.
Also adds an `allSpeakersMatch` helper for asserting status across all speaker ConfigurationStates.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
