### PR TITLE
ConfigState: Add OwnerRef to resources

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -84,6 +84,10 @@ spec:
         - --metrics-cert-dir=/etc/metrics
         {{- end }}
         env:
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         {{- if and .Values.speaker.enabled .Values.speaker.memberlist.enabled }}
         - name: METALLB_ML_SECRET_NAME
           value: {{ include "metallb.secretName" . }}

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -205,6 +205,8 @@ roleRef:
   name: {{ include "metallb.fullname" . }}-pod-lister
 subjects:
 - kind: ServiceAccount
+  name: {{ template "metallb.controller.serviceAccountName" . }}
+- kind: ServiceAccount
   name: {{ include "metallb.speaker.serviceAccountName" . }}
 {{- end }}
 ---

--- a/config/controllers/controller.yaml
+++ b/config/controllers/controller.yaml
@@ -25,6 +25,10 @@ spec:
         - --port=9120
         - --log-level=info
         env:
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -2993,6 +2993,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -3317,6 +3320,10 @@ spec:
         env:
         - name: METALLB_BGP_TYPE
           value: frr-k8s
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -2952,6 +2952,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -3222,6 +3225,10 @@ spec:
         env:
         - name: METALLB_BGP_TYPE
           value: frr-k8s
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2064,6 +2064,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -2309,6 +2312,10 @@ spec:
         env:
         - name: METALLB_BGP_TYPE
           value: frr
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2023,6 +2023,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -2211,6 +2214,10 @@ spec:
         env:
         - name: METALLB_BGP_TYPE
           value: frr
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -2064,6 +2064,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -2206,6 +2209,10 @@ spec:
         - --port=9120
         - --log-level=info
         env:
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -2023,6 +2023,9 @@ roleRef:
   name: pod-lister
 subjects:
 - kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+- kind: ServiceAccount
   name: speaker
   namespace: metallb-system
 ---
@@ -2111,6 +2114,10 @@ spec:
         - --port=9120
         - --log-level=info
         env:
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -375,6 +375,8 @@ roleRef:
   name: pod-lister
 subjects:
   - kind: ServiceAccount
+    name: controller
+  - kind: ServiceAccount
     name: speaker
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/controller/main.go
+++ b/controller/main.go
@@ -170,6 +170,7 @@ func main() {
 		loadBalancerClass   = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
 		webhookMode         = flag.String("webhook-mode", "enabled", "webhook mode: can be enabled, disabled or only webhook if we want the controller to act as webhook endpoint only")
 		webhookSecretName   = flag.String("webhook-secret", "metallb-webhook-cert", "webhook secret: the name of webhook secret, default is metallb-webhook-cert")
+		myPod               = flag.String("pod-name", os.Getenv("METALLB_POD_NAME"), "name of this MetalLB controller pod")
 		webhookHTTP2        = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
 		tlsMinVersion       = flag.String("tls-min-version", "", "Minimum TLS version (VersionTLS12 or VersionTLS13). If empty, defaults to VersionTLS13.")
 		tlsCipherSuites     = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS cipher suites. Only applies to TLS 1.2. If empty, uses Go defaults.")
@@ -223,6 +224,7 @@ func main() {
 
 	cfg := &k8s.Config{
 		ProcessName:      "metallb-controller",
+		PodName:          *myPod,
 		MetricsPort:      *port,
 		PprofBindAddress: *pprofBindAddress,
 		Logger:           logger,

--- a/e2etest/configurationstatetests/configurationstate.go
+++ b/e2etest/configurationstatetests/configurationstate.go
@@ -562,7 +562,7 @@ func allStatesExist(allNodes *corev1.NodeList) error {
 	}
 
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "UID", "CreationTimestamp", "Generation", "ManagedFields"),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "UID", "CreationTimestamp", "Generation", "ManagedFields", "OwnerReferences"),
 		cmpopts.IgnoreFields(metallbv1beta1.ConfigurationState{}, "TypeMeta"),
 		cmpopts.IgnoreFields(metallbv1beta1.ConfigurationStateStatus{}, "Conditions"),
 		cmpopts.SortSlices(func(a, b metallbv1beta1.ConfigurationState) bool {

--- a/internal/k8s/controllers/configuration_state_controller.go
+++ b/internal/k8s/controllers/configuration_state_controller.go
@@ -4,11 +4,13 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,6 +29,7 @@ type ConfigurationStateReconciler struct {
 	Namespace         string
 	ConfigStateName   string
 	ConfigStateLabels map[string]string
+	OwnerPod          *v1.Pod
 }
 
 func (r *ConfigurationStateReconciler) String() string {
@@ -46,6 +49,9 @@ func (r *ConfigurationStateReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, configState, func() error {
 		configState.Labels = r.ConfigStateLabels
+		if err := controllerutil.SetOwnerReference(r.OwnerPod, configState, r.Scheme); err != nil {
+			return err
+		}
 
 		result := metallbv1beta1.ConfigurationResultUnknown
 		if len(configState.Status.Conditions) > 0 {
@@ -68,14 +74,7 @@ func (r *ConfigurationStateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		level.Error(r.Logger).Log("controller", r, "error", "failed to create or patch ConfigurationState", "error", err)
 		return ctrl.Result{}, err
 	}
-	if opResult == controllerutil.OperationResultCreated {
-		// According to https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#CreateOrPatch
-		// If the object is created, we have to patch it again to ensure the status is created.
-		// This will happen when we reconcile the creation event.
-		level.Info(r.Logger).Log("controller", r, "event", "ConfigurationState created", "name", r.ConfigStateName)
-		return ctrl.Result{}, nil
-	}
-	level.Info(r.Logger).Log("controller", r, "event", "ConfigurationState updated", "name", r.ConfigStateName)
+	level.Info(r.Logger).Log("controller", r, "event", fmt.Sprintf("ConfigurationState %s", opResult), "name", r.ConfigStateName)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/k8s/controllers/configuration_state_controller.go
+++ b/internal/k8s/controllers/configuration_state_controller.go
@@ -9,11 +9,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -37,48 +37,45 @@ func (r *ConfigurationStateReconciler) Reconcile(ctx context.Context, req ctrl.R
 	level.Info(r.Logger).Log("controller", r, "start reconcile", req.String())
 	defer level.Info(r.Logger).Log("controller", r, "end reconcile", req.String())
 
-	var configStatus metallbv1beta1.ConfigurationState
-	err := r.Get(ctx, req.NamespacedName, &configStatus)
-	if apierrors.IsNotFound(err) {
-		configState := &metallbv1beta1.ConfigurationState{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      r.ConfigStateName,
-				Namespace: r.Namespace,
-				Labels:    r.ConfigStateLabels,
-			},
-		}
-		if err := r.Create(ctx, configState); err != nil {
-			level.Error(r.Logger).Log("controller", r, "error", "failed to create ConfigurationState", "error", err)
-			return ctrl.Result{}, err
+	configState := &metallbv1beta1.ConfigurationState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.ConfigStateName,
+			Namespace: r.Namespace,
+		},
+	}
+
+	opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, configState, func() error {
+		configState.Labels = r.ConfigStateLabels
+
+		result := metallbv1beta1.ConfigurationResultUnknown
+		if len(configState.Status.Conditions) > 0 {
+			result = metallbv1beta1.ConfigurationResultValid
 		}
 
+		var errorMessages []string
+		for _, cond := range configState.Status.Conditions {
+			if cond.Status == metav1.ConditionFalse && cond.Reason == ErrorTypeConfiguration {
+				result = metallbv1beta1.ConfigurationResultInvalid
+				errorMessages = append(errorMessages, cond.Message)
+			}
+		}
+
+		configState.Status.Result = result
+		configState.Status.ErrorSummary = strings.Join(errorMessages, "\n")
+		return nil
+	})
+	if err != nil {
+		level.Error(r.Logger).Log("controller", r, "error", "failed to create or patch ConfigurationState", "error", err)
+		return ctrl.Result{}, err
+	}
+	if opResult == controllerutil.OperationResultCreated {
+		// According to https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#CreateOrPatch
+		// If the object is created, we have to patch it again to ensure the status is created.
+		// This will happen when we reconcile the creation event.
 		level.Info(r.Logger).Log("controller", r, "event", "ConfigurationState created", "name", r.ConfigStateName)
 		return ctrl.Result{}, nil
 	}
-	if err != nil {
-		level.Error(r.Logger).Log("controller", r, "error", "failed to get ConfigurationState", "error", err)
-		return ctrl.Result{}, err
-	}
-
-	result := metallbv1beta1.ConfigurationResultUnknown
-	if len(configStatus.Status.Conditions) > 0 {
-		result = metallbv1beta1.ConfigurationResultValid
-	}
-
-	var errorMessages []string
-	for _, cond := range configStatus.Status.Conditions {
-		if cond.Status == metav1.ConditionFalse && cond.Reason == ErrorTypeConfiguration {
-			result = metallbv1beta1.ConfigurationResultInvalid
-			errorMessages = append(errorMessages, cond.Message)
-		}
-	}
-
-	configStatus.Status.Result = result
-	configStatus.Status.ErrorSummary = strings.Join(errorMessages, "\n")
-	if err := r.Client.Status().Update(ctx, &configStatus); err != nil {
-		level.Error(r.Logger).Log("controller", r, "error", "failed to update status", "result", result, "error", err)
-		return ctrl.Result{}, err
-	}
+	level.Info(r.Logger).Log("controller", r, "event", "ConfigurationState updated", "name", r.ConfigStateName)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/k8s/controllers/configuration_state_controller_test.go
+++ b/internal/k8s/controllers/configuration_state_controller_test.go
@@ -37,6 +37,10 @@ func TestConfigurationStateReconciler(t *testing.T) {
 			before: nil,
 			want: &metallbv1beta1.ConfigurationState{
 				ObjectMeta: configStateObjectMeta,
+				Status: metallbv1beta1.ConfigurationStateStatus{
+					Result:       metallbv1beta1.ConfigurationResultUnknown,
+					ErrorSummary: "",
+				},
 			},
 		},
 		"no conditions reported": {

--- a/internal/k8s/controllers/configuration_state_controller_test.go
+++ b/internal/k8s/controllers/configuration_state_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,9 +25,30 @@ func TestConfigurationStateReconciler(t *testing.T) {
 		configStateNamespace = "metallb-system"
 	)
 
+	ownerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metallb-speaker-abc123",
+			Namespace: configStateNamespace,
+			UID:       "pod-uid-12345",
+		},
+	}
+
 	configStateObjectMeta := metav1.ObjectMeta{
 		Name:      configStateName,
 		Namespace: configStateNamespace,
+	}
+
+	wantObjectMeta := metav1.ObjectMeta{
+		Name:      configStateName,
+		Namespace: configStateNamespace,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       ownerPod.Name,
+				UID:        ownerPod.UID,
+			},
+		},
 	}
 
 	tests := map[string]struct {
@@ -36,7 +58,7 @@ func TestConfigurationStateReconciler(t *testing.T) {
 		"create resource if not found": {
 			before: nil,
 			want: &metallbv1beta1.ConfigurationState{
-				ObjectMeta: configStateObjectMeta,
+				ObjectMeta: wantObjectMeta,
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Result:       metallbv1beta1.ConfigurationResultUnknown,
 					ErrorSummary: "",
@@ -48,7 +70,7 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				ObjectMeta: configStateObjectMeta,
 			},
 			want: &metallbv1beta1.ConfigurationState{
-				ObjectMeta: configStateObjectMeta,
+				ObjectMeta: wantObjectMeta,
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Result:       metallbv1beta1.ConfigurationResultUnknown,
 					ErrorSummary: "",
@@ -76,7 +98,7 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				},
 			},
 			want: &metallbv1beta1.ConfigurationState{
-				ObjectMeta: configStateObjectMeta,
+				ObjectMeta: wantObjectMeta,
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Result:       metallbv1beta1.ConfigurationResultValid,
 					ErrorSummary: "",
@@ -104,7 +126,7 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				},
 			},
 			want: &metallbv1beta1.ConfigurationState{
-				ObjectMeta: configStateObjectMeta,
+				ObjectMeta: wantObjectMeta,
 				Status: metallbv1beta1.ConfigurationStateStatus{
 					Result:       metallbv1beta1.ConfigurationResultInvalid,
 					ErrorSummary: "peer peer1 referencing non existing bfd profile",
@@ -117,6 +139,9 @@ func TestConfigurationStateReconciler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 			if err := metallbv1beta1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add scheme: %v", err)
+			}
+			if err := corev1.AddToScheme(scheme); err != nil {
 				t.Fatalf("failed to add scheme: %v", err)
 			}
 
@@ -132,6 +157,7 @@ func TestConfigurationStateReconciler(t *testing.T) {
 				Scheme:          scheme,
 				Namespace:       configStateNamespace,
 				ConfigStateName: configStateName,
+				OwnerPod:        ownerPod,
 			}
 
 			req := reconcile.Request{

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -189,6 +189,12 @@ func New(cfg *Config) (*Client, error) {
 		ForceSync:      reload,
 	}
 
+	selfPod, err := clientset.CoreV1().Pods(cfg.Namespace).Get(context.TODO(), cfg.PodName, metav1.GetOptions{})
+	if err != nil {
+		level.Error(cfg.Logger).Log("op", "startup", "error", err, "msg", "unable to get own pod for owner references")
+		return nil, err
+	}
+
 	configStateName := "controller"
 	configStateLabels := map[string]string{
 		"metallb.io/component-type": "controller",
@@ -303,6 +309,7 @@ func New(cfg *Config) (*Client, error) {
 		ConfigStateLabels: configStateLabels,
 		Logger:            cfg.Logger,
 		Scheme:            mgr.GetScheme(),
+		OwnerPod:          selfPod.DeepCopy(),
 	}
 	if err := cc.SetupWithManager(mgr); err != nil {
 		level.Error(c.logger).Log("error", err, "unable to create controller", "configurationstatus")
@@ -326,11 +333,6 @@ func New(cfg *Config) (*Client, error) {
 
 	// metallb controller doesn't need this reconciler
 	if cfg.Layer2StatusChan != nil {
-		selfPod, err := clientset.CoreV1().Pods(cfg.Namespace).Get(context.TODO(), cfg.PodName, metav1.GetOptions{})
-		if err != nil {
-			level.Error(c.logger).Log("unable to get speaker pod itself", err)
-			return nil, err
-		}
 		if err = (&controllers.Layer2StatusReconciler{
 			Client:        mgr.GetClient(),
 			Logger:        cfg.Logger,
@@ -345,11 +347,6 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	if cfg.BGPStatusChan != nil {
-		selfPod, err := clientset.CoreV1().Pods(cfg.Namespace).Get(context.TODO(), cfg.PodName, metav1.GetOptions{})
-		if err != nil {
-			level.Error(c.logger).Log("unable to get speaker pod itself", err)
-			return nil, err
-		}
 		if err = (&controllers.ServiceBGPStatusReconciler{
 			Client:        mgr.GetClient(),
 			Logger:        cfg.Logger,


### PR DESCRIPTION
We add owner refs to the generated resources, aligned with how we already assign them to the service(l2/bgp)status resources to get free cleanups.
Fixes #3015.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add OwnerRef to ConfigurationState resources, enabling cleanup by the k8s gc.
```
