### PR TITLE
Config controller: filter BGP resources by speaker node selectors

### DIFF
--- a/e2etest/configurationstatetests/configurationstate.go
+++ b/e2etest/configurationstatetests/configurationstate.go
@@ -5,6 +5,7 @@ package configurationstatetests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hostnameLabel = "kubernetes.io/hostname"
 )
 
 var (
@@ -49,7 +54,7 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 		cs := k8sclient.New()
 		allNodes, err = cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(allNodes.Items)).To(BeNumerically(">", 0))
+		Expect(len(allNodes.Items)).To(BeNumerically(">", 1))
 
 		ginkgo.By("Verifying all ConfigurationStates exist and are valid")
 		Eventually(func() error {
@@ -61,10 +66,20 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 		if ginkgo.CurrentSpecReport().Failed() {
 			k8s.DumpInfo(Reporter, ginkgo.CurrentSpecReport().LeafNodeText)
 		}
+		ginkgo.By("Clearing any configuration")
+		err := ConfigUpdater.Clean()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	ginkgo.It("speaker should have invalid result when BGPPeer references secret with wrong type", func() {
-		stateName := "speaker-" + allNodes.Items[0].Name
+	ginkgo.It("a single speaker should have invalid result when BGPPeer with nodeSelector references secret with wrong type", func() {
+		invalidNode := allNodes.Items[0]
+		invalidStateName := "speaker-" + invalidNode.Name
+		invalidNodeLabel := invalidNode.Labels[hostnameLabel]
+
+		validStateNames := make([]string, 0, len(allNodes.Items)-1)
+		for _, node := range allNodes.Items[1:] {
+			validStateNames = append(validStateNames, "speaker-"+node.Name)
+		}
 		wantStatus := metallbv1beta1.ConfigurationStateStatus{
 			Result:       metallbv1beta1.ConfigurationResultInvalid,
 			ErrorSummary: "configuration error: parsing peer peer1 secret type mismatch on \"metallb-system\"/\"bgp-password\", type \"kubernetes.io/basic-auth\" is expected \nfailed to parse peer peer1 password secret",
@@ -100,17 +115,28 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 						PasswordSecret: corev1.SecretReference{
 							Name: "bgp-password",
 						},
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									hostnameLabel: invalidNodeLabel,
+								},
+							},
+						},
 					},
 				},
 			},
 		}
-
 		err = ConfigUpdater.Update(resources)
 		Expect(err).NotTo(HaveOccurred())
 
-		ginkgo.By("Verifying status has invalid result with error message")
+		ginkgo.By("Verifying status has invalid result with error message on invalid node, and valid on others")
 		Eventually(func() error {
-			return stateMatches(stateName, wantStatus)
+			var errs []error
+			errs = append(errs, stateMatches(invalidStateName, wantStatus))
+			for _, stateName := range validStateNames {
+				errs = append(errs, stateMatches(stateName, validStatus))
+			}
+			return errors.Join(errs...)
 		}, 30*time.Second, 5*time.Second).Should(Succeed())
 
 		ginkgo.By("Recreating secret with correct type")
@@ -133,9 +159,14 @@ var _ = ginkgo.Describe("ConfigurationState", func() {
 		err = ConfigUpdater.Client().Create(context.Background(), secret)
 		Expect(err).NotTo(HaveOccurred())
 
-		ginkgo.By("Verifying status has valid result")
+		ginkgo.By("Verifying status for all nodes has valid result")
 		Eventually(func() error {
-			return stateMatches(stateName, validStatus)
+			var errs []error
+			errs = append(errs, stateMatches(invalidStateName, validStatus))
+			for _, stateName := range validStateNames {
+				errs = append(errs, stateMatches(stateName, validStatus))
+			}
+			return errors.Join(errs...)
 		}, 60*time.Second, 5*time.Second).Should(Succeed())
 	})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,9 +257,6 @@ func For(resources ClusterResources, validate Validate) (*Config, error) {
 	}
 
 	cfg.BGPExtras = bgpExtrasFor(resources)
-	if err != nil {
-		return nil, err
-	}
 
 	err = validateConfig(cfg)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -661,6 +661,10 @@ func bfdProfileFromCR(p metallbv1beta1.BFDProfile) (*BFDProfile, error) {
 	return res, nil
 }
 
+// setL2AdvertisementsToPools populates the L2Advertisements field of each pool
+// in ipPoolMap. It converts each L2Advertisement CR into an internal representation
+// (resolving node selectors) and assigns it to every matching pool.
+// The function is called for its side effects: the goal is to modify ipPoolMap in place.
 func setL2AdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, l2Advs []metallbv1beta1.L2Advertisement,
 	nodes []corev1.Node, ipPoolMap map[string]*Pool) error {
 	for _, l2Adv := range l2Advs {
@@ -692,6 +696,10 @@ func setL2AdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, l2Advs [
 	return nil
 }
 
+// setBGPAdvertisementsToPools populates the BGPAdvertisements field of each pool
+// in ipPoolMap. It converts each BGPAdvertisement CR into an internal representation
+// (resolving node selectors) and assigns it to every matching pool.
+// The function is called for its side effects: the goal is to modify ipPoolMap in place.
 func setBGPAdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, bgpAdvs []metallbv1beta1.BGPAdvertisement,
 	nodes []corev1.Node, ipPoolMap map[string]*Pool, communities map[string]community.BGPCommunity) error {
 	for _, bgpAdv := range bgpAdvs {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -672,7 +672,7 @@ func setL2AdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, l2Advs [
 		if err != nil {
 			return err
 		}
-		ipPoolsSelected, err := selectedPools(ipPools, l2Adv.Spec.IPAddressPoolSelectors)
+		ipPoolsSelected, err := filterPoolsWithLabelSelector(ipPools, l2Adv.Spec.IPAddressPoolSelectors)
 		if err != nil {
 			return err
 		}
@@ -685,7 +685,7 @@ func setL2AdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, l2Advs [
 			}
 			continue
 		}
-		for _, poolName := range append(l2Adv.Spec.IPAddressPools, ipPoolsSelected...) {
+		for _, poolName := range append(l2Adv.Spec.IPAddressPools, ipPoolsSelected.UnsortedList()...) {
 			if pool, ok := ipPoolMap[poolName]; ok {
 				if !containsAdvertisement(pool.L2Advertisements, adv) {
 					pool.L2Advertisements = append(pool.L2Advertisements, adv)
@@ -707,7 +707,7 @@ func setBGPAdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, bgpAdvs
 		if err != nil {
 			return err
 		}
-		ipPoolsSelected, err := selectedPools(ipPools, bgpAdv.Spec.IPAddressPoolSelectors)
+		ipPoolsSelected, err := filterPoolsWithLabelSelector(ipPools, bgpAdv.Spec.IPAddressPoolSelectors)
 		if err != nil {
 			return err
 		}
@@ -722,7 +722,7 @@ func setBGPAdvertisementsToPools(ipPools []metallbv1beta1.IPAddressPool, bgpAdvs
 			}
 			continue
 		}
-		for _, poolName := range append(bgpAdv.Spec.IPAddressPools, ipPoolsSelected...) {
+		for _, poolName := range append(bgpAdv.Spec.IPAddressPools, ipPoolsSelected.UnsortedList()...) {
 			if pool, ok := ipPoolMap[poolName]; ok {
 				err := validateBGPAdvPerPool(adv, pool)
 				if err != nil {
@@ -1138,54 +1138,13 @@ func parseSelectors(selectors []metav1.LabelSelector) ([]labels.Selector, error)
 	return result, nil
 }
 
-func selectedNodes(nodes []corev1.Node, selectors []metav1.LabelSelector) (map[string]bool, error) {
-	labelSelectors := []labels.Selector{}
-	for _, selector := range selectors {
-		l, err := metav1.LabelSelectorAsSelector(&selector)
-		if err != nil {
-			return nil, errors.Join(err, fmt.Errorf("invalid label selector %v", selector))
-		}
-		labelSelectors = append(labelSelectors, l)
+// selectedNodes returns a Set of node names that match any of the provided label selectors, or if no selectors are
+// specified extracts and return all node names.
+func selectedNodes(nodes []corev1.Node, selectors []metav1.LabelSelector) (Set, error) {
+	if len(selectors) == 0 {
+		return extractNodeNames(nodes), nil
 	}
-
-	res := make(map[string]bool)
-OUTER:
-	for _, node := range nodes {
-		if len(labelSelectors) == 0 { // no selector mean all nodes are valid
-			res[node.Name] = true
-		}
-		for _, s := range labelSelectors {
-			nodeLabels := labels.Set(node.Labels)
-			if s.Matches(nodeLabels) {
-				res[node.Name] = true
-				continue OUTER
-			}
-		}
-	}
-	return res, nil
-}
-
-func selectedPools(pools []metallbv1beta1.IPAddressPool, selectors []metav1.LabelSelector) ([]string, error) {
-	labelSelectors := []labels.Selector{}
-	for _, selector := range selectors {
-		l, err := metav1.LabelSelectorAsSelector(&selector)
-		if err != nil {
-			return nil, errors.Join(err, fmt.Errorf("invalid label selector %v", selector))
-		}
-		labelSelectors = append(labelSelectors, l)
-	}
-	var ipPools []string
-OUTER:
-	for _, pool := range pools {
-		for _, s := range labelSelectors {
-			poolLabels := labels.Set(pool.Labels)
-			if s.Matches(poolLabels) {
-				ipPools = append(ipPools, pool.Name)
-				continue OUTER
-			}
-		}
-	}
-	return ipPools, nil
+	return FilterNodesWithLabelSelector(nodes, selectors)
 }
 
 func validateLabelSelectorDuplicate(labelSelectors []metav1.LabelSelector, labelSelectorType string) error {
@@ -1232,4 +1191,72 @@ func validateDuplicate(strSlice []string, sliceType string) error {
 		}
 	}
 	return nil
+}
+
+// Set represents a set. It's similar to k8s Set but uses map[string]bool as its backing store for compatibility with
+// L2Advertisement's and BGPAdvertisement's `Nodes map[string]bool` field.
+type Set map[string]bool
+
+// UnsortedList returns an unsorted list from the set.
+func (s Set) UnsortedList() []string {
+	list := make([]string, 0, len(s))
+	for item := range s {
+		list = append(list, item)
+	}
+	return list
+}
+
+// FilterNodesWithLabelSelector returns a Set of nodes that match any of the provided label selectors.
+func FilterNodesWithLabelSelector(nodes []corev1.Node, selectors []metav1.LabelSelector) (Set, error) {
+	return filterWithLabelSelector(
+		nodes,
+		selectors,
+		func(p corev1.Node) map[string]string { return p.Labels },
+		func(p corev1.Node) string { return p.Name },
+	)
+}
+
+// filterPoolsWithLabelSelector returns a Set of IPAddressPools that match any of the provided label selectors.
+func filterPoolsWithLabelSelector(ipPools []metallbv1beta1.IPAddressPool, selectors []metav1.LabelSelector) (Set, error) {
+	return filterWithLabelSelector(
+		ipPools,
+		selectors,
+		func(p metallbv1beta1.IPAddressPool) map[string]string { return p.Labels },
+		func(p metallbv1beta1.IPAddressPool) string { return p.Name },
+	)
+}
+
+// filterWithLabelSelector implements the business logic for the more specific filter functions such as
+// FilterNodesWithLabelSelector.
+func filterWithLabelSelector[T any](toFilterSlice []T, selectors []metav1.LabelSelector,
+	getLabels func(T) map[string]string, getName func(T) string) (Set, error) {
+	labelSelectors := []labels.Selector{}
+	for _, selector := range selectors {
+		l, err := metav1.LabelSelectorAsSelector(&selector)
+		if err != nil {
+			return nil, errors.Join(err, fmt.Errorf("invalid label selector %v", selector))
+		}
+		labelSelectors = append(labelSelectors, l)
+	}
+	filteredSet := Set{}
+OUTER:
+	for _, obj := range toFilterSlice {
+		objLabels := labels.Set(getLabels(obj))
+		for _, s := range labelSelectors {
+			if s.Matches(objLabels) {
+				filteredSet[getName(obj)] = true
+				continue OUTER
+			}
+		}
+	}
+	return filteredSet, nil
+}
+
+// extractNodeNames iterates over the provided slice of Nodes and returns a set with their names.
+func extractNodeNames(nodes []corev1.Node) Set {
+	nodeNames := Set{}
+	for _, node := range nodes {
+		nodeNames[node.GetName()] = true
+	}
+	return nodeNames
 }

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -53,6 +53,7 @@ type ConfigReconciler struct {
 	BGPType         string
 	ConfigStateName string
 	currentConfig   *config.Config
+	NodeName        string
 }
 
 func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -136,12 +137,37 @@ var requestHandler = func(r *ConfigReconciler, ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// A BGP speaker should only care about the resources corresponding to it. Therefore, filter BGPAdvertisements,
+	// BGPPeers by the node name. If configuration is invalid, only the configurationstate for
+	// the concerned speaker will flag an error. In theory, it would be possible to filter IPPools, as well.
+	// However, this is cumbersome and the webhooks make it impossible for the user to push invalid configuration for
+	// pools, so the cost for filtering pools is not justified. We also deliberately do not filter L2Advertisements:
+	// the speakers need to know about all of the ads to build the proper candidate set for a service, therefore
+	// filtering would break this.
+	var node corev1.Node
+	key = client.ObjectKey{Name: r.NodeName}
+	if err := r.Get(ctx, key, &node); err != nil {
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to get node for "+r.NodeName, "error", err)
+		return ctrl.Result{}, err
+	}
+
+	bgpAdvs, err := filterBGPAdvertisementsByNode(bgpAdvertisements.Items, node)
+	if err != nil {
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to filter BGPAdvertisements", "error", err)
+		return ctrl.Result{}, err
+	}
+	peers, err := filterBGPPeersByNode(bgpPeers.Items, node)
+	if err != nil {
+		level.Error(r.Logger).Log("controller", "ConfigReconciler", "message", "failed to filter BGPPeers", "error", err)
+		return ctrl.Result{}, err
+	}
+
 	resources := config.ClusterResources{
 		Pools:           ipAddressPools.Items,
-		Peers:           bgpPeers.Items,
+		Peers:           peers,
 		BFDProfiles:     bfdProfiles.Items,
 		L2Advs:          l2Advertisements.Items,
-		BGPAdvs:         bgpAdvertisements.Items,
+		BGPAdvs:         bgpAdvs,
 		Communities:     communities.Items,
 		PasswordSecrets: secrets,
 		Nodes:           nodes.Items,
@@ -321,4 +347,46 @@ func (r *ConfigReconciler) reportCondition(ctx context.Context, conditionErr err
 	}
 
 	return nil
+}
+
+// filterBGPAdvertisementsByNode takes a slice of bgpAdvertisements and a node. It will return all
+// bgpAdvertisements that fulfill either condition:
+// - they have an empty nodeSelector
+// - their nodeSelector matches the provided node.
+func filterBGPAdvertisementsByNode(bgpAdvertisements []metallbv1beta1.BGPAdvertisement, node corev1.Node) ([]metallbv1beta1.BGPAdvertisement, error) {
+	return filterByNode(bgpAdvertisements, node, func(bgpAdv metallbv1beta1.BGPAdvertisement) []metav1.LabelSelector {
+		return bgpAdv.Spec.NodeSelectors
+	})
+}
+
+// filterBGPPeersByNode takes a slice of bgpPeers and a node. It will return all
+// bgpPeers that fulfill either condition:
+// - they have an empty nodeSelector
+// - their nodeSelector matches the provided node.
+func filterBGPPeersByNode(bgpPeers []metallbv1beta2.BGPPeer, node corev1.Node) ([]metallbv1beta2.BGPPeer, error) {
+	return filterByNode(bgpPeers, node, func(bgpPeer metallbv1beta2.BGPPeer) []metav1.LabelSelector {
+		return bgpPeer.Spec.NodeSelectors
+	})
+}
+
+// filterByNode implements the business logic for the more specific filter functions such as filterBGPPeersByNode.
+func filterByNode[T any](customResources []T, node corev1.Node, getNodeSelector func(T) []metav1.LabelSelector) ([]T, error) {
+	filteredCustomResources := make([]T, 0, len(customResources))
+	for _, customResource := range customResources {
+		ns := getNodeSelector(customResource)
+		// If the custom resource has no node selector, it matches all nodes.
+		if len(ns) == 0 {
+			filteredCustomResources = append(filteredCustomResources, customResource)
+			continue
+		}
+		// Otherwise, filter by label selector. If the label selector matches our node, append the custom resource.
+		nodes, err := config.FilterNodesWithLabelSelector([]corev1.Node{node}, ns)
+		if err != nil {
+			return nil, err
+		}
+		if len(nodes) > 0 {
+			filteredCustomResources = append(filteredCustomResources, customResource)
+		}
+	}
+	return filteredCustomResources, nil
 }

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -168,6 +168,7 @@ func TestConfigController(t *testing.T) {
 				Handler:         mockHandler,
 				ForceReload:     mockForceReload,
 				ConfigStateName: configStateRef.Name,
+				NodeName:        resources.Nodes[0].Name,
 			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -223,6 +224,7 @@ func TestSecretShouldntTrigger(t *testing.T) {
 		ValidateConfig: config.DontValidate,
 		Handler:        mockHandler,
 		ForceReload:    func() {},
+		NodeName:       configControllerValidResources.Nodes[0].Name,
 	}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -357,6 +359,13 @@ var (
 				},
 			},
 		},
+		Nodes: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker01",
+				},
+			},
+		},
 	}
 	configControllerInvalidResources = config.ClusterResources{
 		Peers: []v1beta2.BGPPeer{
@@ -364,6 +373,13 @@ var (
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "peer1",
 					Namespace: testNamespace,
+				},
+			},
+		},
+		Nodes: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker01",
 				},
 			},
 		},

--- a/internal/k8s/controllers/config_controller_test.go
+++ b/internal/k8s/controllers/config_controller_test.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -385,3 +387,251 @@ var (
 		},
 	}
 )
+
+func TestFilterBGPAdvertisementsByNode(t *testing.T) {
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				"node-name": "node1",
+			},
+		},
+	}
+
+	tcs := []struct {
+		name                      string
+		bgpAdvertisements         []v1beta1.BGPAdvertisement
+		filteredBGPAdvertisements []v1beta1.BGPAdvertisement
+		expectedError             string
+	}{
+		{
+			name: "filters matching BGPAdvertisements",
+			bgpAdvertisements: []v1beta1.BGPAdvertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node1",
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test2",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test3",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node2",
+								},
+							},
+						},
+					},
+				},
+			},
+			filteredBGPAdvertisements: []v1beta1.BGPAdvertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node1",
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test2",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{},
+				},
+			},
+		},
+		{
+			name: "reports errors",
+			bgpAdvertisements: []v1beta1.BGPAdvertisement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta1.BGPAdvertisementSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Operator: "invalid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "\"invalid\" is not a valid label selector operator\ninvalid label selector {map[] [{ invalid []}]}",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			bgpAdvertisements, err := filterBGPAdvertisementsByNode(tc.bgpAdvertisements, node)
+			switch err {
+			case nil:
+				if tc.expectedError != "" {
+					t.Fatalf("expected error %q but got no error", tc.expectedError)
+				}
+				if !reflect.DeepEqual(bgpAdvertisements, tc.filteredBGPAdvertisements) {
+					t.Fatalf("expected filtered BGP peers and actual filtered BGP peers do not match: "+
+						"expected: %+v, got: %+v", tc.filteredBGPAdvertisements, bgpAdvertisements)
+				}
+			default:
+				if tc.expectedError == "" {
+					t.Fatalf("expected no error, but got error %q", err)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error %q but got error %q", tc.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterBGPPeersByNode(t *testing.T) {
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				"node-name": "node1",
+			},
+		},
+	}
+
+	tcs := []struct {
+		name             string
+		bgpPeers         []v1beta2.BGPPeer
+		filteredBGPPeers []v1beta2.BGPPeer
+		expectedError    string
+	}{
+		{
+			name: "filters matching BGPPeers",
+			bgpPeers: []v1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta2.BGPPeerSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node1",
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test2",
+					},
+					Spec: v1beta2.BGPPeerSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test3",
+					},
+					Spec: v1beta2.BGPPeerSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node2",
+								},
+							},
+						},
+					},
+				},
+			},
+			filteredBGPPeers: []v1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta2.BGPPeerSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{
+									"node-name": "node1",
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test2",
+					},
+					Spec: v1beta2.BGPPeerSpec{},
+				},
+			},
+		},
+		{
+			name: "reports errors",
+			bgpPeers: []v1beta2.BGPPeer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: v1beta2.BGPPeerSpec{
+						NodeSelectors: []metav1.LabelSelector{
+							{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Operator: "invalid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "\"invalid\" is not a valid label selector operator\ninvalid label selector {map[] [{ invalid []}]}",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			bgpPeers, err := filterBGPPeersByNode(tc.bgpPeers, node)
+			switch err {
+			case nil:
+				if tc.expectedError != "" {
+					t.Fatalf("expected error %q but got no error", tc.expectedError)
+				}
+				if !reflect.DeepEqual(bgpPeers, tc.filteredBGPPeers) {
+					t.Fatalf("expected filtered BGP peers and actual filtered BGP peers do not match: "+
+						"expected: %+v, got: %+v", tc.filteredBGPPeers, bgpPeers)
+				}
+			default:
+				if tc.expectedError == "" {
+					t.Fatalf("expected no error, but got error %q", err)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error %q but got error %q", tc.expectedError, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/k8s/controllers/fakeclient_test.go
+++ b/internal/k8s/controllers/fakeclient_test.go
@@ -92,5 +92,9 @@ func objectsFromResources(r config.ClusterResources) []client.Object {
 		objects = append(objects, community.DeepCopy())
 	}
 
+	for _, node := range r.Nodes {
+		objects = append(objects, node.DeepCopy())
+	}
+
 	return objects
 }

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -218,6 +218,7 @@ func New(cfg *Config) (*Client, error) {
 			ValidateConfig:  cfg.ValidateConfig,
 			Handler:         cfg.ConfigHandler,
 			ForceReload:     reload,
+			NodeName:        cfg.NodeName,
 		}).SetupWithManager(mgr); err != nil {
 			level.Error(c.logger).Log("error", err, "unable to create controller", "config")
 			return nil, errors.Join(err, errors.New("unable to create controller for config"))


### PR DESCRIPTION
Fixes #2949

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Each MetalLB speaker currently parses **all** k8s resources (BGPPeers, L2/BGP Advertisements, IPAddressPools) regardless of node selectors. This means a faulty config targeting one node causes errors on all speakers via ConfigurationState.

This PR refines the config controller so each speaker only processes BGP resources relevant to it.

**Special notes for your reviewer**:

- This fixes https://github.com/metallb/metallb/issues/2949

**Release note**:

```release-note
Speakers now only parse BGP configuration resources (BGPPeers, BGPAdvertisements) that target them via node selectors, preventing unrelated misconfigurations from affecting other speakers.
```