### PR TITLE
fix(controller): remove deprecated annotations from services on upgrade

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -70,8 +70,14 @@ type testK8S struct {
 	t                   *testing.T
 }
 
+func (s *testK8S) Update(svc *v1.Service) error {
+	s.updateService = svc.DeepCopy()
+	return nil
+}
+
 func (s *testK8S) UpdateStatus(svc *v1.Service) error {
-	s.updateServiceStatus = &svc.Status
+	status := svc.Status
+	s.updateServiceStatus = &status
 	return nil
 }
 
@@ -1146,6 +1152,63 @@ func TestControllerMutation(t *testing.T) {
 			tests[x], tests[nx] = tests[nx], tests[x]
 		}
 		t.Logf("Shuffled test cases")
+	}
+}
+
+func TestControllerRemovesDeprecatedManagedAllocationAnnotation(t *testing.T) {
+	k := &testK8S{t: t}
+	c := &controller{
+		ips:    allocator.New(noopCallback),
+		client: k,
+	}
+	c.SetPools(log.NewNopLogger(), &config.Pools{
+		ByName: map[string]*config.Pool{
+			"pool1": {
+				Name:       "pool1",
+				AutoAssign: true,
+				CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
+			},
+		},
+	})
+
+	in := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				AnnotationIPAllocateFromPool:           "pool1",
+				DeprecatedAnnotationIPAllocateFromPool: "pool1",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIPs: []string{"1.2.3.4"},
+			Type:       "LoadBalancer",
+		},
+		Status: statusAssigned([]string{"1.2.3.0"}),
+	}
+	want := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				AnnotationIPAllocateFromPool: "pool1",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIPs: []string{"1.2.3.4"},
+			Type:       "LoadBalancer",
+		},
+		Status: statusAssigned([]string{"1.2.3.0"}),
+	}
+
+	if c.SetBalancer(log.NewNopLogger(), "test", in, []discovery.EndpointSlice{}) == controllers.SyncStateError {
+		t.Fatalf("SetBalancer returned error")
+	}
+	if !k.loggedWarning {
+		t.Fatal("expected deprecated annotation warning")
+	}
+	gotSvc := k.gotService(in)
+	if gotSvc == nil {
+		t.Fatal("expected service metadata update")
+	}
+	if diff := diffService(want, gotSvc); diff != "" {
+		t.Errorf("wrong service mutation (-want +got)\n%s", diff)
 	}
 }
 

--- a/controller/main.go
+++ b/controller/main.go
@@ -38,6 +38,7 @@ import (
 
 // Service offers methods to mutate a Kubernetes service object.
 type service interface {
+	Update(svc *v1.Service) error
 	UpdateStatus(svc *v1.Service) error
 	Infof(svc *v1.Service, desc, msg string, args ...interface{})
 	Errorf(svc *v1.Service, desc, msg string, args ...interface{})
@@ -92,6 +93,14 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		syncStateRes = controllers.SyncStateReprocessAll
 	}
 
+	cleanedDeprecatedManagedAnnotation := false
+	if hasDeprecatedManagedAnnotation(svcRo) && hasManagedAnnotation(svc) {
+		level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", DeprecatedAnnotationIPAllocateFromPool, "msg", "The used annotation is deprecated. Removing it.")
+		c.client.Errorf(svcRo, "deprecatedAnnotation", "Service uses deprecated annotation %s", DeprecatedAnnotationIPAllocateFromPool)
+		delete(svc.Annotations, DeprecatedAnnotationIPAllocateFromPool)
+		cleanedDeprecatedManagedAnnotation = true
+	}
+
 	if reflect.DeepEqual(svcRo, svc) {
 		level.Debug(l).Log("event", "noChange", "msg", "service converged, no change")
 		return syncStateRes
@@ -102,10 +111,12 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	// However, generating an event every time the svc is processed would be very noisy.
 	// Therefore, we check for deprecated annotations only, if there is something to do.
 	for key := range svcRo.Annotations {
+		if key == DeprecatedAnnotationIPAllocateFromPool && cleanedDeprecatedManagedAnnotation {
+			continue
+		}
 		if strings.HasPrefix(key, DeprecatedAnnotationPrefix) {
-			level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", key, "msg", "The used annotation is deprecated. Removing it.")
+			level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", key, "msg", "The used annotation is deprecated. Support might get removed in future versions")
 			c.client.Errorf(svcRo, "deprecatedAnnotation", "Service uses deprecated annotation %s", key)
-			delete(svc.Annotations, key)
 		}
 	}
 
@@ -120,26 +131,45 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 		}
 	}
 
-	toWrite := svcRo.DeepCopy()
-	if !reflect.DeepEqual(svcRo.Status, svc.Status) {
-		toWrite.Status = svc.Status
-	}
-
-	if !reflect.DeepEqual(svcRo.Annotations, svc.Annotations) {
+	if cleanedDeprecatedManagedAnnotation {
+		toWrite := svcRo.DeepCopy()
 		toWrite.Annotations = svc.Annotations
+		if err := c.client.Update(toWrite); err != nil {
+			level.Error(l).Log("op", "updateService", "error", err, "msg", "failed to update service")
+			return controllers.SyncStateError
+		}
 	}
 
-	if !reflect.DeepEqual(toWrite, svcRo) {
+	if !reflect.DeepEqual(svcRo.Status, svc.Status) {
 		if err := c.client.UpdateStatus(svc); err != nil {
 			level.Error(l).Log("op", "updateServiceStatus", "error", err, "msg", "failed to update service")
 			return controllers.SyncStateError
 		}
+	}
+
+	if cleanedDeprecatedManagedAnnotation || !reflect.DeepEqual(svcRo.Status, svc.Status) {
 		level.Info(l).Log("event", "serviceUpdated", "msg", "updated service object")
 		return syncStateRes
 	}
 
 	level.Info(l).Log("event", "serviceUpdated", "msg", "service is not updated")
 	return syncStateRes
+}
+
+func hasDeprecatedManagedAnnotation(svc *v1.Service) bool {
+	if svc == nil || svc.Annotations == nil {
+		return false
+	}
+	_, ok := svc.Annotations[DeprecatedAnnotationIPAllocateFromPool]
+	return ok
+}
+
+func hasManagedAnnotation(svc *v1.Service) bool {
+	if svc == nil || svc.Annotations == nil {
+		return false
+	}
+	_, ok := svc.Annotations[AnnotationIPAllocateFromPool]
+	return ok
 }
 
 func (c *controller) SetPools(l log.Logger, pools *config.Pools) controllers.SyncState {

--- a/controller/main.go
+++ b/controller/main.go
@@ -103,8 +103,9 @@ func (c *controller) SetBalancer(l log.Logger, name string, svcRo *v1.Service, _
 	// Therefore, we check for deprecated annotations only, if there is something to do.
 	for key := range svcRo.Annotations {
 		if strings.HasPrefix(key, DeprecatedAnnotationPrefix) {
-			level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", key, "msg", "The used annotation is deprecated. Support might get removed in future versions")
+			level.Warn(l).Log("event", "deprecatedAnnotation", "annotation", key, "msg", "The used annotation is deprecated. Removing it.")
 			c.client.Errorf(svcRo, "deprecatedAnnotation", "Service uses deprecated annotation %s", key)
+			delete(svc.Annotations, key)
 		}
 	}
 

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -477,6 +477,12 @@ func (c *Client) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
+// Update writes the service metadata and spec back into the Kubernetes cluster.
+func (c *Client) Update(svc *corev1.Service) error {
+	_, err := c.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{})
+	return err
+}
+
 // UpdateStatus writes the protected "status" field of svc back into
 // the Kubernetes cluster.
 func (c *Client) UpdateStatus(svc *corev1.Service) error {


### PR DESCRIPTION
## Summary
Fixes #2642. When a Service has both the deprecated MetalLB-managed allocation annotation (`metallb.universe.tf/ip-allocated-from-pool`) and the stable replacement (`metallb.io/ip-allocated-from-pool`), the controller now removes only the deprecated managed annotation.

This keeps user-provided deprecated annotations such as `address-pool`, `loadBalancerIPs`, and `allow-shared-ip` intact, avoiding configuration loss while cleaning up stale annotations left by older MetalLB versions.

## Changes
- `controller/main.go`: remove only the deprecated managed allocation annotation after the stable annotation is present
- `internal/k8s/k8s.go`: add a Service metadata update path so annotation cleanup is persisted separately from status updates
- `controller/controller_test.go`: cover cleanup of the deprecated managed allocation annotation

## Test plan
- `GOWORK=off go test ./controller`
- `GOWORK=off go test ./internal/k8s`
- `GOWORK=off go vet ./controller`

```release-note
Deprecated MetalLB-managed `metallb.universe.tf/ip-allocated-from-pool` annotations are removed from Services after the stable `metallb.io/ip-allocated-from-pool` annotation is present.
```

/kind bug