### PR TITLE
fix(api): correct LocalASN OpenAPI format to int64

### DIFF
--- a/api/v1beta2/bgppeer_types.go
+++ b/api/v1beta2/bgppeer_types.go
@@ -45,6 +45,7 @@ type BGPPeerSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Format=int64
 	LocalASN uint32 `json:"localASN,omitempty"`
 
 	// DynamicASN detects the AS number to use for the remote end of the session

--- a/charts/metallb/charts/crds/templates/crds.yaml
+++ b/charts/metallb/charts/crds/templates/crds.yaml
@@ -637,7 +637,7 @@ spec:
                     via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                     the router-level MyASN for this specific session.
                     Not supported in native BGP mode.
-                  format: int32
+                  format: int64
                   maximum: 4294967295
                   minimum: 1
                   type: integer

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -249,7 +249,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -670,7 +670,7 @@ spec:
                   via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
                   the router-level MyASN for this specific session.
                   Not supported in native BGP mode.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

`BGPPeer.spec.localASN` (added in v0.16.0) declares `+kubebuilder:validation:Maximum=4294967295` but no `Format` annotation. controller-gen therefore emits `format: int32` in the generated CRD, which is internally inconsistent: int32's maximum is 2,147,483,647 — the schema's declared maximum (4,294,967,295) exceeds it.

The sibling fields `ASN` (peerASN) and `MyASN` on the same struct already carry `+kubebuilder:validation:Format=int64` for the same `uint32` Go type and the same Maximum. This PR aligns `LocalASN` with them.

Diff scope:

- `api/v1beta2/bgppeer_types.go`: one added annotation line (matches sibling-field pattern).
- `config/crd/bases/metallb.io_bgppeers.yaml`, `charts/metallb/charts/crds/templates/crds.yaml`, six `config/manifests/metallb-*.yaml`: regenerated by `inv generatemanifests`, each file changes a single `format: int32` → `format: int64` line for the `localASN` property.

No runtime change — internal Go types for `LocalASN` are already `uint32` end-to-end. Schema-only fix.

**Special notes for your reviewer**:

Reproduce the regeneration with [Python invoke](https://www.pyinvoke.org/) and the deps from `tasks.py`:

```sh
inv generatemanifests
```

**Release note**:

```release-note
Fixed BGPPeer v1beta2 schema: `localASN` now correctly declares `format: int64` (was `int32`, which cannot represent the declared `Maximum=4294967295`).
```
