### PR TITLE
fix(chart): emit prometheus.io/scheme=https across all annotation paths

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         {{- if .Values.prometheus.scrapeAnnotations }}
         prometheus.io/scrape: "true"
+        prometheus.io/scheme: "https"
         prometheus.io/port: "{{ .Values.prometheus.metricsPort }}"
         {{- end }}
         {{- with .Values.controller.podAnnotations }}

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -25,6 +25,7 @@ spec:
   podMetricsEndpoints:
   - port: monitoring
     path: /metrics
+    scheme: https
     {{- if .Values.prometheus.podMonitor.interval }}
     interval: {{ .Values.prometheus.podMonitor.interval }}
     {{- end }}
@@ -64,6 +65,7 @@ spec:
   podMetricsEndpoints:
   - port: monitoring
     path: /metrics
+    scheme: https
     {{- if .Values.prometheus.podMonitor.interval }}
     interval: {{ .Values.prometheus.podMonitor.interval }}
     {{- end }}

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -66,6 +66,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/scheme: "https"
   {{- if .Values.prometheus.serviceMonitor.speaker.annotations }}
 {{ toYaml .Values.prometheus.serviceMonitor.speaker.annotations | indent 4 }}
   {{- end }}
@@ -140,6 +141,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/scheme: "https"
   {{- if .Values.prometheus.serviceMonitor.controller.annotations }}
 {{ toYaml .Values.prometheus.serviceMonitor.controller.annotations | indent 4 }}
   {{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -145,6 +145,7 @@ spec:
         {{- if .Values.prometheus.scrapeAnnotations }}
         prometheus.io/scrape: "true"
         {{- if not .Values.speaker.frr.enabled }}
+        prometheus.io/scheme: "https"
         prometheus.io/port: "{{ .Values.prometheus.metricsPort }}"
         {{- end }}
         {{- end }}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Since v0.16.0 kube-rbac-proxy is gone and both controller and speaker serve `/metrics` directly over HTTPS on port 9120. Three different scrape-discovery surfaces in the chart still pointed at HTTP, all of which now fail with TLS handshake errors on the v0.16 endpoint:

1. **Pod-level `prometheus.io/scrape` annotations** on the controller Deployment and speaker DaemonSet. Annotation-based scrapers default to HTTP without an explicit `prometheus.io/scheme`.
2. **`PodMonitor.spec.podMetricsEndpoints`** for both controller and speaker in `templates/podmonitor.yaml`. PodMonitor endpoints default to HTTP when `scheme:` is unset.
3. **The annotation-only `Service` objects** bundled alongside the ServiceMonitors in `templates/servicemonitor.yaml` (`speaker-monitor-service` and `controller-monitor-service`). These services exist to be discovered via `prometheus.io/scrape` annotations by scrapers that do not use the Operator's ServiceMonitor CRD; they were missing the matching `prometheus.io/scheme` annotation.

Emit `prometheus.io/scheme: "https"` / `scheme: https` in each of those three paths.

The chart no longer exposes a knob to disable TLS on metrics (`tls.controllerMetricsTLSSecret` / `tls.speakerMetricsTLSSecret` are optional only in the sense that a self-signed cert is auto-generated when unset). The chart's own ServiceMonitor `spec.endpoints[].scheme` is already hardcoded to `"https"`, confirming the project's stance that the endpoint is HTTPS-only. The annotation and PodMonitor paths were simply out of sync.

The new `prometheus.io/scheme` annotation on the speaker pod template sits inside the existing `{{- if not .Values.speaker.frr.enabled }}` block, matching the guard already used for `prometheus.io/port` (legacy FRR mode runs multiple metrics endpoints and a single annotation pair cannot cover both — users on FRR mode are expected to use ServiceMonitor anyway).

**Special notes for your reviewer**:

Verified locally (helm v3.18, v3.21):

- Default mode (frr-k8s): controller and speaker pods both emit `scrape: true` + `scheme: https` + `port: 9120` annotations.
- Legacy FRR mode (`speaker.frr.enabled=true`, `frrk8s.enabled=false`): speaker emits only `scrape: true`; controller emits the full triple.
- `prometheus.podMonitor.enabled=true`: both PodMonitors render with `podMetricsEndpoints[].scheme: https`.
- `prometheus.serviceMonitor.enabled=true`: both monitor-services render with `prometheus.io/scrape: "true"` AND `prometheus.io/scheme: "https"`.
- Without `prometheus.scrapeAnnotations`: zero `prometheus.io/*` annotations on the pods.
- `helm lint` clean.

ServiceMonitor users are unaffected by the pod-annotation change (they declare `scheme: https` explicitly in the ServiceMonitor spec). The PodMonitor and Service-annotation changes round out the missing pieces in the same area.

**Release note**:

```release-note
Helm chart: pod-level `prometheus.io/scrape` annotations, the `PodMonitor` endpoints, and the annotation-only Service objects bundled with the ServiceMonitor now all emit `scheme: https` to match the HTTPS-only metrics endpoint introduced in v0.16.0. Annotation-based and PodMonitor-based Prometheus scrapers no longer fail with TLS handshake errors against the metrics port.
```
