### PR TITLE
fix(chart): tighten speaker.bgpDebounceTimeout schema to minimum 1

### DIFF
--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -361,7 +361,7 @@
             },
             "bgpDebounceTimeout": {
               "anyOf": [
-                { "type": "integer", "minimum": 0 },
+                { "type": "integer", "minimum": 1 },
                 { "type": "null" }
               ]
             },


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

`charts/metallb/values.schema.json:364` declared `speaker.bgpDebounceTimeout` as `anyOf: integer minimum 0 | null`, but the speaker binary rejects 0:

```go
// speaker/main.go:134
parsed, err := strconv.Atoi(*bgpDebounceTimeoutMs)
if err != nil || parsed <= 0 {
    level.Error(logger).Log("msg", "invalid BGP debounce timeout value, must be a positive integer value", ...)
    os.Exit(1)
}
```

An operator who set `speaker.bgpDebounceTimeout: 0` passed schema validation but the rendered speaker DaemonSet would crash on startup with `os.Exit(1)`. In current upstream, the template's truthy guard `{{- if .Values.speaker.bgpDebounceTimeout }}` happens to drop the flag for the falsy value 0, masking the schema miss with a silent fallback to the 3000 ms default — confusing UX either way.

Align the schema with the runtime contract: `minimum: 1`. After this change, `speaker.bgpDebounceTimeout: 0` is rejected at `helm install` with a clear error pointing at the field, instead of crashing the speaker later or silently ignoring the input.

The Helm template guard at `charts/metallb/templates/speaker.yaml:281` is intentionally untouched — its falsy-on-zero behavior is now unreachable from valid input (schema blocks 0 before render) and the falsy-on-`null` semantics are exactly what the default install needs.

**Special notes for your reviewer**:

Verification:

- `helm template ... --set speaker.bgpDebounceTimeout=0` rejected: `at '/speaker/bgpDebounceTimeout': minimum: got 0, want 1`.
- `helm template ... --set speaker.bgpDebounceTimeout=1` (boundary minimum) renders `--bgp-debounce-timeout=1`.
- `helm template ... --set speaker.bgpDebounceTimeout=3000` renders unchanged.
- Default (`null`) keeps the flag out of the args list (same as before).
- Negative values stay rejected.
- `helm lint` clean.

The env-var path (`METALLB_BGP_DEBOUNCE_TIMEOUT`) is unaffected — schema only constrains chart values; the binary's own `parsed <= 0` check still guards env-var input.

**Release note**:

```release-note
Helm chart: tightened `speaker.bgpDebounceTimeout` schema constraint from `minimum: 0` to `minimum: 1` to match the speaker binary, which rejects 0 with os.Exit(1). The value 0 is now rejected at `helm install` time with a clear schema error.
```
