### PR TITLE
helm: fix frr-k8s subchart values to prevent nil pointer errors

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -59,10 +59,10 @@ Kubernetes: `>= 1.19.0-0`
 | controller.webhookMode | string | `"enabled"` |  |
 | crds.enabled | bool | `true` |  |
 | crds.validationFailurePolicy | string | `"Fail"` |  |
-| frr-k8s.prometheus | string | `nil` |  |
-| frrk8s.enabled | bool | `true` |  |
-| frrk8s.external | bool | `false` |  |
-| frrk8s.namespace | string | `""` |  |
+| frr-k8s.prometheus.serviceMonitor.enabled | bool | `false` | Enable Prometheus ServiceMonitor for frr-k8s metrics. |
+| frrk8s.enabled | bool | `true` | If set, enables frrk8s as a backend. This is mutually exclusive to frr mode. |
+| frrk8s.external | bool | `false` | If true, uses an external frr-k8s installation instead of the bundled subchart. |
+| frrk8s.namespace | string | `""` | Namespace where external frr-k8s is installed (only used when external=true). |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | loadBalancerClass | string | `""` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -362,29 +362,34 @@ crds:
 # This allows configuring additional frr parameters in combination to those
 # applied by MetalLB.
 frrk8s:
-  # if set, enables frrk8s as a backend. This is mutually exclusive to frr
-  # mode.
+  # -- If set, enables frrk8s as a backend. This is mutually exclusive to frr mode.
   enabled: true
+  # -- If true, uses an external frr-k8s installation instead of the bundled subchart.
   external: false
+  # -- Namespace where external frr-k8s is installed (only used when external=true).
   namespace: ""
 
+# Values passed to the frr-k8s subchart (note the hyphen in "frr-k8s").
+# For all available options, see:
+# https://github.com/metallb/frr-k8s/blob/main/charts/frr-k8s/values.yaml
 frr-k8s:
   prometheus:
-    # The FRR-K8s BGP/BFD metrics are exposed with the "frrk8s_" prefix
-    # (e.g. frrk8s_bgp_session_up, frrk8s_bfd_session_up).
-    # To rename them to the legacy "metallb_" prefix for backward compatibility
-    # with existing dashboards or alerts, uncomment section below.
-    # serviceMonitor:
-    #   enabled: true
-    #   metricRelabelings:
-    #   - sourceLabels: [__name__]
-    #     regex: "frrk8s_bgp_(.*)"
-    #     targetLabel: "__name__"
-    #     replacement: "metallb_bgp_$1"
-    #   - sourceLabels: [__name__]
-    #     regex: "frrk8s_bfd_(.*)"
-    #     targetLabel: "__name__"
-    #     replacement: "metallb_bfd_$1"
+    serviceMonitor:
+      # -- Enable Prometheus ServiceMonitor for frr-k8s metrics.
+      enabled: false
+      # The FRR-K8s BGP/BFD metrics are exposed with the "frrk8s_" prefix
+      # (e.g. frrk8s_bgp_session_up, frrk8s_bfd_session_up).
+      # To rename them to the legacy "metallb_" prefix for backward compatibility
+      # with existing dashboards or alerts, enable and configure metric relabelings:
+      # metricRelabelings:
+      # - sourceLabels: [__name__]
+      #   regex: "frrk8s_bgp_(.*)"
+      #   targetLabel: "__name__"
+      #   replacement: "metallb_bgp_$1"
+      # - sourceLabels: [__name__]
+      #   regex: "frrk8s_bfd_(.*)"
+      #   targetLabel: "__name__"
+      #   replacement: "metallb_bfd_$1"
 
 # networkpolicies
 networkpolicies:


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

The frr-k8s.prometheus section in values.yaml contained only comments, which YAML parses as 'prometheus: null'. This overrode the frr-k8s subchart's default values, causing "nil pointer evaluating interface {}.serviceMonitor" errors when rendering templates.

Additionally, the naming was confusing: frrk8s.enabled (no hyphen) controls whether the subchart is installed, while frr-k8s.* (with hyphen) passes values to the subchart. Added clear documentation to explain this distinction.

Changes:
- Provide explicit serviceMonitor.enabled: false in frr-k8s.prometheus instead of comments-only (which became null)

This fixes both issues where chart rendering failed with default values.

Fixes: #3053
Fixes: #3056


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix helm chart rendering issue when default values are provided.
```
