### PR TITLE
fix(chart): preserve frr-k8s.prometheus subchart defaults

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -59,7 +59,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.webhookMode | string | `"enabled"` |  |
 | crds.enabled | bool | `true` |  |
 | crds.validationFailurePolicy | string | `"Fail"` |  |
-| frr-k8s.prometheus | string | `nil` |  |
+| frr-k8s | object | `{}` |  |
 | frrk8s.enabled | bool | `true` |  |
 | frrk8s.external | bool | `false` |  |
 | frrk8s.namespace | string | `""` |  |

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -368,23 +368,34 @@ frrk8s:
   external: false
   namespace: ""
 
-frr-k8s:
-  prometheus:
-    # The FRR-K8s BGP/BFD metrics are exposed with the "frrk8s_" prefix
-    # (e.g. frrk8s_bgp_session_up, frrk8s_bfd_session_up).
-    # To rename them to the legacy "metallb_" prefix for backward compatibility
-    # with existing dashboards or alerts, uncomment section below.
-    # serviceMonitor:
-    #   enabled: true
-    #   metricRelabelings:
-    #   - sourceLabels: [__name__]
-    #     regex: "frrk8s_bgp_(.*)"
-    #     targetLabel: "__name__"
-    #     replacement: "metallb_bgp_$1"
-    #   - sourceLabels: [__name__]
-    #     regex: "frrk8s_bfd_(.*)"
-    #     targetLabel: "__name__"
-    #     replacement: "metallb_bfd_$1"
+# The frr-k8s subchart inherits its `prometheus:` defaults from
+# charts/frr-k8s/values.yaml. The block below is an empty map on purpose:
+# previously this file declared `frr-k8s.prometheus:` with only commented
+# child keys, which parses as a null map and then nukes the frr-k8s
+# subchart's own `prometheus:` defaults via Helm's value deep-merge.
+# The next render of `frr-k8s/templates/service-monitor.yaml` aborted on a
+# nil dereference at `.Values.prometheus.serviceMonitor.enabled` and the
+# whole install failed.
+#
+# To rename frr-k8s BGP/BFD metrics from the "frrk8s_" prefix to the
+# legacy "metallb_" prefix (for backward compatibility with existing
+# dashboards or alerts), replace the `frr-k8s: {}` line below with the
+# block (note: no leading spaces, paste at the top level of this file):
+#
+# frr-k8s:
+#   prometheus:
+#     serviceMonitor:
+#       enabled: true
+#       metricRelabelings:
+#       - sourceLabels: [__name__]
+#         regex: "frrk8s_bgp_(.*)"
+#         targetLabel: "__name__"
+#         replacement: "metallb_bgp_$1"
+#       - sourceLabels: [__name__]
+#         regex: "frrk8s_bfd_(.*)"
+#         targetLabel: "__name__"
+#         replacement: "metallb_bfd_$1"
+frr-k8s: {}
 
 # networkpolicies
 networkpolicies:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

The parent chart's `frr-k8s.prometheus:` block in `charts/metallb/values.yaml` contained only commented child keys. YAML parses that as a `null` map. Helm's value deep-merge then writes that `null` over the frr-k8s subchart's own `prometheus:` map (which carries the schema-driving defaults for `serviceMonitor` / `podMonitor` / `secureMetricsPort`). On the next render of `charts/frr-k8s/templates/service-monitor.yaml`, the access at `.Values.prometheus.serviceMonitor.enabled` dereferences nil and aborts:

```
template: metallb/charts/frr-k8s/templates/service-monitor.yaml:1:14:
at <.Values.prometheus.serviceMonitor.enabled>:
nil pointer evaluating interface {}.serviceMonitor
```

Reproducible with helm v3.18 (the version Flux helm-controller embeds). helm v4 happens to be more forgiving about the same merge, which masks the bug for operators rendering with the CLI but breaks GitOps installs.

Fix: replace the empty-body `frr-k8s.prometheus:` placeholder with an explicit `frr-k8s: {}` empty map. The frr-k8s subchart's own `charts/frr-k8s/values.yaml` keeps providing the prometheus defaults (`serviceMonitor.enabled=false`, `podMonitor.enabled=false`, `secureMetricsPort=9140`, etc.) and no install-time dereference of nil can occur. The documentation comment that previously hosted the relabeling example is moved above the key so it stays visible to operators without introducing a null map.

`charts/metallb/README.md` is regenerated via helm-docs v1.10.0 (the version pinned by `.github/workflows/ci.yaml`): the `frr-k8s.prometheus` row becomes `frr-k8s | object | \`{}\``.

**Special notes for your reviewer**:

Verified locally (helm v3.18 and v3.21):

- `helm template metallb . --set crds.enabled=true` renders 42 documents cleanly (was: nil pointer).
- The documented override for legacy `metallb_` metric prefixes still renders the ServiceMonitor (`metallb-frr-k8s-frr-k8s-monitor`) when set under `frr-k8s.prometheus.serviceMonitor.enabled: true`.
- `helm lint` clean.
- helm-docs v1.10.0 re-run produces zero further diff.

**Release note**:

```release-note
Helm chart: fixed an install-time nil pointer in `frr-k8s/templates/service-monitor.yaml` when the chart is rendered with helm v3 (the version embedded in Flux helm-controller). The parent chart's `frr-k8s.prometheus:` placeholder block parsed as null and clobbered the subchart's prometheus defaults; it now contains an explicit empty map and the subchart defaults flow through.
```
