### PR TITLE
Fix 3061 Controller livenessProbe and readinessProbe

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -34,6 +34,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.livenessProbe.failureThreshold | int | `3` |  |
 | controller.livenessProbe.initialDelaySeconds | int | `10` |  |
 | controller.livenessProbe.periodSeconds | int | `10` |  |
+| controller.livenessProbe.port | int | `17472` |  |
 | controller.livenessProbe.successThreshold | int | `1` |  |
 | controller.livenessProbe.timeoutSeconds | int | `1` |  |
 | controller.logLevel | string | `"info"` | Controller log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
@@ -44,6 +45,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.readinessProbe.failureThreshold | int | `3` |  |
 | controller.readinessProbe.initialDelaySeconds | int | `10` |  |
 | controller.readinessProbe.periodSeconds | int | `10` |  |
+| controller.readinessProbe.port | int | `17472` |  |
 | controller.readinessProbe.successThreshold | int | `1` |  |
 | controller.readinessProbe.timeoutSeconds | int | `1` |  |
 | controller.resources | object | `{}` |  |
@@ -139,6 +141,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.livenessProbe.failureThreshold | int | `3` |  |
 | speaker.livenessProbe.initialDelaySeconds | int | `10` |  |
 | speaker.livenessProbe.periodSeconds | int | `10` |  |
+| speaker.livenessProbe.port | int | `17472` |  |
 | speaker.livenessProbe.successThreshold | int | `1` |  |
 | speaker.livenessProbe.timeoutSeconds | int | `1` |  |
 | speaker.logLevel | string | `"info"` | Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
@@ -153,6 +156,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.readinessProbe.failureThreshold | int | `3` |  |
 | speaker.readinessProbe.initialDelaySeconds | int | `10` |  |
 | speaker.readinessProbe.periodSeconds | int | `10` |  |
+| speaker.readinessProbe.port | int | `17472` |  |
 | speaker.readinessProbe.successThreshold | int | `1` |  |
 | speaker.readinessProbe.timeoutSeconds | int | `1` |  |
 | speaker.reloader.resources | object | `{}` |  |

--- a/charts/metallb/templates/_helpers.tpl
+++ b/charts/metallb/templates/_helpers.tpl
@@ -96,3 +96,4 @@ Create the name of the settings Secret to use.
 {{ .Values.speaker.frr.metricsPort }}
 {{- end }}
 
+

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -123,8 +123,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 17472
-            host: 127.0.0.1
+            port: {{ .Values.controller.livenessProbe.port }}
           initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
@@ -135,8 +134,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 17472
-            host: 127.0.0.1
+            port: {{ .Values.controller.readinessProbe.port }}
           initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -353,7 +353,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 17472
+            port: {{ .Values.speaker.livenessProbe.port }}
             host: 127.0.0.1
           initialDelaySeconds: {{ .Values.speaker.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.speaker.livenessProbe.periodSeconds }}
@@ -365,7 +365,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 17472
+            port: {{ .Values.speaker.readinessProbe.port }}
             host: 127.0.0.1
           initialDelaySeconds: {{ .Values.speaker.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.speaker.readinessProbe.periodSeconds }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -233,6 +233,7 @@ controller:
   labels: {}
   livenessProbe:
     enabled: true
+    port: 17472
     failureThreshold: 3
     initialDelaySeconds: 10
     periodSeconds: 10
@@ -240,6 +241,7 @@ controller:
     timeoutSeconds: 1
   readinessProbe:
     enabled: true
+    port: 17472
     failureThreshold: 3
     initialDelaySeconds: 10
     periodSeconds: 10
@@ -307,6 +309,7 @@ speaker:
   labels: {}
   livenessProbe:
     enabled: true
+    port: 17472
     failureThreshold: 3
     initialDelaySeconds: 10
     periodSeconds: 10
@@ -314,6 +317,7 @@ speaker:
     timeoutSeconds: 1
   readinessProbe:
     enabled: true
+    port: 17472
     failureThreshold: 3
     initialDelaySeconds: 10
     periodSeconds: 10

--- a/config/controllers/controller.yaml
+++ b/config/controllers/controller.yaml
@@ -45,7 +45,6 @@ spec:
           httpGet:
             path: /healthz
             port: 17472
-            host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 1
@@ -55,7 +54,6 @@ spec:
           httpGet:
             path: /readyz
             port: 17472
-            host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 1

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3355,7 +3355,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -3372,7 +3371,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -3260,7 +3260,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -3277,7 +3276,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2335,7 +2335,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -2352,7 +2351,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2237,7 +2237,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -2254,7 +2253,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -2232,7 +2232,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -2249,7 +2248,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -2137,7 +2137,6 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /healthz
             port: 17472
           initialDelaySeconds: 10
@@ -2154,7 +2153,6 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            host: 127.0.0.1
             path: /readyz
             port: 17472
           initialDelaySeconds: 10

--- a/controller/main.go
+++ b/controller/main.go
@@ -164,6 +164,7 @@ func main() {
 		deployName          = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")
 		logLevel            = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
 		pprofBindAddress    = flag.String("pprof-bind-address", "", "Bind address for pprof endpoint (e.g. 127.0.0.1:6060). Empty disables pprof.")
+		healthProbePort     = flag.Int("health-probe-port", k8s.DefaultHealthProbePort, "Port for health probe endpoint")
 		disableCertRotation = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")
 		certDir             = flag.String("cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory where certs are stored")
 		certServiceName     = flag.String("cert-service-name", "metallb-webhook-service", "The service name used to generate the TLS cert's hostname")
@@ -223,11 +224,12 @@ func main() {
 	validation := config.ValidationFor(bgpType)
 
 	cfg := &k8s.Config{
-		ProcessName:      "metallb-controller",
-		PodName:          *myPod,
-		MetricsPort:      *port,
-		PprofBindAddress: *pprofBindAddress,
-		Logger:           logger,
+		ProcessName:            "metallb-controller",
+		PodName:                *myPod,
+		MetricsPort:            *port,
+		PprofBindAddress:       *pprofBindAddress,
+		HealthProbeBindAddress: fmt.Sprintf(":%d", *healthProbePort),
+		Logger:                 logger,
 
 		Namespace: *namespace,
 		Listener: k8s.Listener{

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -49,6 +49,8 @@ import (
 )
 
 const (
+	DefaultHealthProbePort = 17472
+
 	caName          = "cert"
 	caOrganization  = "metallb"
 	MLSecretKeyName = "secretkey"
@@ -94,26 +96,27 @@ type Client struct {
 // Config specifies the configuration of the Kubernetes
 // client/watcher.
 type Config struct {
-	ProcessName         string
-	NodeName            string
-	PodName             string
-	MetricsPort         int
-	PprofBindAddress    string
-	ReadEndpoints       bool
-	Logger              log.Logger
-	Namespace           string
-	ValidateConfig      config.Validate
-	EnableWebhook       bool
-	TLSOpt              func(*tls.Config)
-	DisableCertRotation bool
-	MetricsCertDir      string
-	WebhookSecretName   string
-	CertDir             string
-	CertServiceName     string
-	LoadBalancerClass   string
-	WebhookWithHTTP2    bool
-	WithFRRK8s          bool
-	FRRK8sNamespace     string
+	ProcessName            string
+	NodeName               string
+	PodName                string
+	MetricsPort            int
+	PprofBindAddress       string
+	HealthProbeBindAddress string
+	ReadEndpoints          bool
+	Logger                 log.Logger
+	Namespace              string
+	ValidateConfig         config.Validate
+	EnableWebhook          bool
+	TLSOpt                 func(*tls.Config)
+	DisableCertRotation    bool
+	MetricsCertDir         string
+	WebhookSecretName      string
+	CertDir                string
+	CertServiceName        string
+	LoadBalancerClass      string
+	WebhookWithHTTP2       bool
+	WithFRRK8s             bool
+	FRRK8sNamespace        string
 	Listener
 	Layer2StatusChan    <-chan event.GenericEvent
 	Layer2StatusFetcher controllers.L2StatusFetcher
@@ -159,7 +162,7 @@ func New(cfg *Config) (*Client, error) {
 		Cache:                  cache.Options{ByObject: objectsPerNamespace},
 		WebhookServer:          webhookServer(cfg),
 		Metrics:                metricsOpts,
-		HealthProbeBindAddress: "127.0.0.1:17472",
+		HealthProbeBindAddress: cfg.HealthProbeBindAddress,
 		PprofBindAddress:       cfg.PprofBindAddress,
 	}
 

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package k8s
+
+import (
+	"testing"
+)
+
+func TestDefaultHealthProbePort(t *testing.T) {
+	if DefaultHealthProbePort <= 0 {
+		t.Errorf("DefaultHealthProbePort must be positive, got %d", DefaultHealthProbePort)
+	}
+}

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -94,6 +94,7 @@ func main() {
 		port                = flag.Int("port", 9120, "HTTPS metrics listening port")
 		logLevel            = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
 		pprofBindAddress    = flag.String("pprof-bind-address", "", "Bind address for pprof endpoint (e.g. 127.0.0.1:6060). Empty disables pprof.")
+		healthProbePort     = flag.Int("health-probe-port", k8s.DefaultHealthProbePort, "Port for health probe endpoint")
 		loadBalancerClass   = flag.String("lb-class", "", "load balancer class. When enabled, metallb will handle only services whose spec.loadBalancerClass matches the given lb class")
 		ignoreLBExclude     = flag.Bool("ignore-exclude-lb", false, "ignore the exclude-from-external-load-balancers label")
 		frrK8sNamespace     = flag.String("frrk8s-namespace", os.Getenv("FRRK8S_NAMESPACE"), "the namespace frr-k8s is being deployed on")
@@ -241,12 +242,13 @@ func main() {
 		PodName:     *myPod,
 		Logger:      logger,
 
-		MetricsPort:      *port,
-		PprofBindAddress: *pprofBindAddress,
-		TLSOpt:           tlsOpt,
-		MetricsCertDir:   *metricsCertDir,
-		ReadEndpoints:    true,
-		Namespace:        *namespace,
+		MetricsPort:            *port,
+		PprofBindAddress:       *pprofBindAddress,
+		HealthProbeBindAddress: fmt.Sprintf("127.0.0.1:%d", *healthProbePort),
+		TLSOpt:                 tlsOpt,
+		MetricsCertDir:         *metricsCertDir,
+		ReadEndpoints:          true,
+		Namespace:              *namespace,
 
 		Listener: k8s.Listener{
 			ServiceChanged: ctrl.SetBalancer,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
Bug Fix
Fixed #3061

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
  The MetalLB controller's health probe endpoint was hardcoded to bind on 127.0.0.1:17472. Because the kubelet connects to the pod's actual IP (not the loopback interface), liveness and readiness probes would fail in any deployment where the pod is not
  running with hostNetwork: true — causing the controller to be restarted or never reach Ready state.
  
  What changed:

  - The bind address is now configurable via --health-probe-bind-address (default: :17472, all interfaces), fixing the kubelet reachability issue.
  - The Helm chart exposes controller.healthProbeBindAddress as an optional override. When not set, the controller binary's own default is used and no extra argument is passed.
  - The liveness and readiness probe ports in the Helm chart are derived from healthProbeBindAddress when set, so they stay in sync automatically. They can still be overridden individually via controller.livenessProbe.port /
  controller.readinessProbe.port.
  - A regression test guards against reverting to a loopback-only default.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed controller health probes and the health bind address is now configurable and defaults to all interfaces
```
