### PR TITLE
helm: fix speaker.disabled configurations

### DIFF
--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -77,6 +77,7 @@ rules:
   resources: ["frrconfigurations"]
   verbs: ["get", "list", "watch","create","update","delete"]
 {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -115,7 +116,6 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["servicebgpstatuses","servicebgpstatuses/status"]
   verbs: ["*"]
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -192,6 +192,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "metallb.fullname" . }}:speaker
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -208,7 +209,6 @@ subjects:
   name: {{ template "metallb.controller.serviceAccountName" . }}
 - kind: ServiceAccount
   name: {{ include "metallb.speaker.serviceAccountName" . }}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -8,6 +8,10 @@
 {{- fail "frrk8s.enabled frrk8s.external are mutually exclusive!" }}
 {{- end }}
 
+{{- if and (or .Values.frrk8s.enabled .Values.frrk8s.external) (not .Values.speaker.enabled) }}
+{{- fail "frrk8s requires speaker to be enabled. Set frrk8s.enabled=false when disabling speaker." }}
+{{- end }}
+
 {{- if and (not .Values.speaker.memberlist.enabled) .Values.speaker.nodeSelector }}
 {{- fail "nodeSelector must be empty when memberlist is disabled" }}
 {{- end }}


### PR DESCRIPTION
Since both controller and speaker use the pod-lister, we remove the conditional.
This is useful when running controller only, using speaker.enabled=false.
In addition, put a fail-guard that forces frrk8s to be disabled when the speaker is (it is not possible to put AND condition on Chart.yaml)
Fixes https://github.com/metallb/metallb/issues/3068

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:
verified using
`helm install metallb --create-namespace .`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix controller CrashLoopBackOff when using speaker.enabled=false on helm charts.
```
