### PR TITLE
helm: pass --health-probe-port to controller and speaker

### DIFF
--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -63,6 +63,7 @@ spec:
         {{- end }}
         args:
         - --port={{ .Values.prometheus.metricsPort }}
+        - --health-probe-port={{ .Values.controller.livenessProbe.port }}
         {{- with .Values.controller.logLevel }}
         - --log-level={{ . }}
         {{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -271,6 +271,7 @@ spec:
         {{- end }}
         args:
         - --port={{ .Values.prometheus.metricsPort }}
+        - --health-probe-port={{ .Values.speaker.livenessProbe.port }}
         {{- with .Values.speaker.logLevel }}
         - --log-level={{ . }}
         {{- end }}


### PR DESCRIPTION
Without this flag, overriding livenessProbe.port in values.yaml changes the probe target but the binary still listens on the compiled-in default, causing pods to CrashLoop.

introduced by https://github.com/metallb/metallb/pull/3062
/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
helm: pass --health-probe-port to controller and speaker
```
