### PR TITLE
log unexpected read error in native consumeBGP

### DIFF
--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -430,7 +430,11 @@ func (s *session) consumeBGP(conn io.ReadCloser) {
 			Type             uint8
 		}{}
 		if err := binary.Read(conn, binary.BigEndian, &hdr); err != nil {
-			// TODO: log, or propagate the error somehow.
+			// io.EOF is the expected outcome when the session is closed, so
+			// only surface unexpected read errors.
+			if !errors.Is(err, io.EOF) {
+				level.Error(s.logger).Log("op", "readMessageHeader", "error", err, "msg", "failed to read BGP message header, closing session")
+			}
 			return
 		}
 		if hdr.Marker1 != 0xffffffffffffffff || hdr.Marker2 != 0xffffffffffffffff {

--- a/internal/bgp/native/native.go
+++ b/internal/bgp/native/native.go
@@ -430,9 +430,13 @@ func (s *session) consumeBGP(conn io.ReadCloser) {
 			Type             uint8
 		}{}
 		if err := binary.Read(conn, binary.BigEndian, &hdr); err != nil {
-			// io.EOF is the expected outcome when the session is closed, so
-			// only surface unexpected read errors.
-			if !errors.Is(err, io.EOF) {
+			// io.EOF is the expected outcome when the session is closed remotely.
+			// A locally closed session causes net.ErrClosed, which is also expected.
+			// Only log genuine unexpected read errors.
+			s.mu.Lock()
+			closed := s.closed
+			s.mu.Unlock()
+			if !closed && !errors.Is(err, io.EOF) {
 				level.Error(s.logger).Log("op", "readMessageHeader", "error", err, "msg", "failed to read BGP message header, closing session")
 			}
 			return


### PR DESCRIPTION
the header read in consumeBGP swallowed the error, there was a TODO sitting on it. on a clean session close thats just io.EOF so we dont want to spam logs, but any other read error was getting dropped silently which makes a dead session annoying to debug.

so it logs at error level unless its EOF, same style as the rest of the file. native mode is linux only so verified with GOOS=linux build + vet.
