### PR TITLE
fix: avoid stale resourceVersion errors in ServiceL2Status and ServiceBGPStatus reconcile

### DIFF
--- a/internal/k8s/controllers/bgp_status_controller.go
+++ b/internal/k8s/controllers/bgp_status_controller.go
@@ -111,8 +111,17 @@ func (r *ServiceBGPStatusReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		},
 	}
 
+	var observedStatus v1beta1.MetalLBServiceBGPStatus
 	if len(serviceBGPStatuses.Items) > 0 {
-		state = &serviceBGPStatuses.Items[0]
+		// avoid carrying a stale resourceVersion into CreateOrPatch
+		existing := &serviceBGPStatuses.Items[0]
+		observedStatus = existing.Status
+		state = &v1beta1.ServiceBGPStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      existing.Name,
+				Namespace: existing.Namespace,
+			},
+		}
 	}
 
 	desiredStatus := v1beta1.MetalLBServiceBGPStatus{
@@ -122,7 +131,7 @@ func (r *ServiceBGPStatusReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Peers:            sets.List(peers),
 	}
 
-	if reflect.DeepEqual(state.Status, desiredStatus) {
+	if reflect.DeepEqual(observedStatus, desiredStatus) {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/k8s/controllers/bgp_status_controller_test.go
+++ b/internal/k8s/controllers/bgp_status_controller_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1 "go.universe.tf/metallb/api/v1beta1"
+)
+
+// deleteOnListBGPClient is the ServiceBGPStatus counterpart of deleteOnListClient.
+type deleteOnListBGPClient struct {
+	client.Client
+	serviceKey   string
+	deleteOnList bool
+}
+
+func (c *deleteOnListBGPClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	sl, ok := list.(*v1beta1.ServiceBGPStatusList)
+	if !ok {
+		return c.Client.List(ctx, list, opts...)
+	}
+
+	// opts reference a field index that does not exist here, so re-resolve by label.
+	all := &v1beta1.ServiceBGPStatusList{}
+	if err := c.Client.List(ctx, all); err != nil {
+		return err
+	}
+	for i := range all.Items {
+		item := all.Items[i]
+		key := types.NamespacedName{
+			Namespace: item.Labels[LabelServiceNamespace],
+			Name:      item.Labels[LabelServiceName],
+		}.String()
+		if key == c.serviceKey {
+			sl.Items = append(sl.Items, item)
+		}
+	}
+
+	if c.deleteOnList {
+		c.deleteOnList = false
+		for i := range sl.Items {
+			if err := c.Delete(ctx, sl.Items[i].DeepCopy()); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+var _ = Describe("ServiceBGPStatusReconciler stale resourceVersion", func() {
+	const (
+		raceNode = "race-bgp-node"
+		raceSvc  = "race-bgp-svc"
+		raceNS   = "race-bgp-ns"
+	)
+
+	cleanup := func() {
+		_ = k8sClient.DeleteAllOf(ctx, &v1beta1.ServiceBGPStatus{},
+			client.InNamespace(speakerNamespace),
+			client.MatchingLabels{LabelServiceName: raceSvc})
+	}
+
+	AfterEach(cleanup)
+
+	It("recovers without a stale resourceVersion error when the owned status is deleted concurrently mid-reconcile", func() {
+		inject := &deleteOnListBGPClient{
+			Client:     k8sClient,
+			serviceKey: types.NamespacedName{Namespace: raceNS, Name: raceSvc}.String(),
+		}
+		r := &ServiceBGPStatusReconciler{
+			Client:     inject,
+			Logger:     log.NewNopLogger(),
+			NodeName:   raceNode,
+			Namespace:  speakerNamespace,
+			SpeakerPod: speakerPod,
+			PeersFetcher: func(string) sets.Set[string] {
+				return sets.New[string]("peer-a")
+			},
+		}
+
+		existing := &v1beta1.ServiceBGPStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "bgp-",
+				Namespace:    speakerNamespace,
+				Labels: map[string]string{
+					LabelAnnounceNode:     raceNode,
+					LabelServiceName:      raceSvc,
+					LabelServiceNamespace: raceNS,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+		Expect(existing.ResourceVersion).ToNot(BeEmpty())
+
+		inject.deleteOnList = true
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: raceNS, Name: raceSvc}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		// A second reconcile (no concurrent delete) fills in the status subresource.
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		var list v1beta1.ServiceBGPStatusList
+		Expect(k8sClient.List(ctx, &list, client.MatchingLabels{
+			LabelServiceName:      raceSvc,
+			LabelServiceNamespace: raceNS,
+			LabelAnnounceNode:     raceNode,
+		})).To(Succeed())
+		Expect(list.Items).To(HaveLen(1))
+		Expect(list.Items[0].Status.Node).To(Equal(raceNode))
+	})
+})

--- a/internal/k8s/controllers/layer2_status_controller.go
+++ b/internal/k8s/controllers/layer2_status_controller.go
@@ -96,9 +96,17 @@ func (r *Layer2StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// We are the (sole) leader for this service.
 	var state *v1beta1.ServiceL2Status
+	var observedStatus v1beta1.MetalLBServiceL2Status
 	for _, item := range serviceL2statuses.Items {
 		if item.Labels[LabelAnnounceNode] == r.NodeName && state == nil {
-			state = &item
+			// avoid carrying a stale resourceVersion into CreateOrPatch
+			observedStatus = item.Status
+			state = &v1beta1.ServiceL2Status{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      item.Name,
+					Namespace: item.Namespace,
+				},
+			}
 			continue
 		}
 		// Delete statuses from other nodes / redundant statuses belonging to our node
@@ -120,7 +128,7 @@ func (r *Layer2StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	desiredStatus := r.buildDesiredStatus(ipAdvS, serviceName, serviceNamespace)
-	if reflect.DeepEqual(state.Status, desiredStatus) {
+	if reflect.DeepEqual(observedStatus, desiredStatus) {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/k8s/controllers/layer2_status_controller_test.go
+++ b/internal/k8s/controllers/layer2_status_controller_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"net"
+
+	"github.com/go-kit/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1 "go.universe.tf/metallb/api/v1beta1"
+	"go.universe.tf/metallb/internal/layer2"
+)
+
+// deleteOnListClient emulates the manager field index the reconciler lists by and,
+// when armed, deletes the listed statuses right after returning them.
+type deleteOnListClient struct {
+	client.Client
+	serviceKey   string
+	deleteOnList bool
+}
+
+func (c *deleteOnListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	sl, ok := list.(*v1beta1.ServiceL2StatusList)
+	if !ok {
+		return c.Client.List(ctx, list, opts...)
+	}
+
+	// opts reference a field index that does not exist here, so re-resolve by label.
+	all := &v1beta1.ServiceL2StatusList{}
+	if err := c.Client.List(ctx, all); err != nil {
+		return err
+	}
+	for i := range all.Items {
+		item := all.Items[i]
+		key := types.NamespacedName{
+			Namespace: item.Labels[LabelServiceNamespace],
+			Name:      item.Labels[LabelServiceName],
+		}.String()
+		if key == c.serviceKey {
+			sl.Items = append(sl.Items, item)
+		}
+	}
+
+	if c.deleteOnList {
+		c.deleteOnList = false
+		for i := range sl.Items {
+			if err := c.Delete(ctx, sl.Items[i].DeepCopy()); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+var _ = Describe("Layer2StatusReconciler stale resourceVersion", func() {
+	const (
+		raceNode = "race-node"
+		raceSvc  = "race-svc"
+		raceNS   = "race-ns"
+	)
+
+	cleanup := func() {
+		_ = k8sClient.DeleteAllOf(ctx, &v1beta1.ServiceL2Status{},
+			client.InNamespace(speakerNamespace),
+			client.MatchingLabels{LabelServiceName: raceSvc})
+	}
+
+	AfterEach(cleanup)
+
+	It("recovers without a stale resourceVersion error when the owned status is deleted concurrently mid-reconcile", func() {
+		inject := &deleteOnListClient{
+			Client:     k8sClient,
+			serviceKey: types.NamespacedName{Namespace: raceNS, Name: raceSvc}.String(),
+		}
+		r := &Layer2StatusReconciler{
+			Client:     inject,
+			Logger:     log.NewNopLogger(),
+			NodeName:   raceNode,
+			Namespace:  speakerNamespace,
+			SpeakerPod: speakerPod,
+			StatusFetcher: func(types.NamespacedName) []layer2.IPAdvertisement {
+				return []layer2.IPAdvertisement{
+					layer2.NewIPAdvertisement(net.IP("127.0.0.9"), true, sets.Set[string]{}),
+				}
+			},
+		}
+
+		existing := &v1beta1.ServiceL2Status{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "l2-",
+				Namespace:    speakerNamespace,
+				Labels: map[string]string{
+					LabelAnnounceNode:     raceNode,
+					LabelServiceName:      raceSvc,
+					LabelServiceNamespace: raceNS,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+		Expect(existing.ResourceVersion).ToNot(BeEmpty())
+
+		inject.deleteOnList = true
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: raceNS, Name: raceSvc}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		// A second reconcile (no concurrent delete) fills in the status subresource.
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		var list v1beta1.ServiceL2StatusList
+		Expect(k8sClient.List(ctx, &list, client.MatchingLabels{
+			LabelServiceName:      raceSvc,
+			LabelServiceNamespace: raceNS,
+			LabelAnnounceNode:     raceNode,
+		})).To(Succeed())
+		Expect(list.Items).To(HaveLen(1))
+		Expect(list.Items[0].Status.Node).To(Equal(raceNode))
+	})
+})


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Both status controllers reuse the object returned by the `List` as the write target for `controllerutil.CreateOrPatch`:

```go
state = &item                         // layer2_status_controller.go
state = &serviceBGPStatuses.Items[0]  // bgp_status_controller.go
```

That object carries the `resourceVersion` it had when it was listed. If the status is deleted between the `List` and the `CreateOrPatch` — for example by another speaker that briefly became leader and deletes other nodes' statuses — `CreateOrPatch` takes the `Get → NotFound → Create` path with that stale `resourceVersion` still set, and the API server rejects the create:

```
resourceVersion should not be set on objects to be created
```

So the reconcile returns an error instead of re-creating the status. Each such event produces several unnecessary errors before the state settles, rather than recovering in a single pass.

Fix: build the write target from identity only (`Name` + `Namespace`, no `resourceVersion`). The create path then runs with nothing stale set and succeeds on the first pass. `CreateOrPatch` re-populates the object via `Get` before patching, so the non-racy path is unchanged. The observed status is captured separately as `observedStatus` because the steady-state no-op short-circuit previously read it from `state.Status`; without that, the `DeepEqual` comparison would never match and every reconcile would write.

The leader-manages behavior (deleting other nodes' / redundant statuses) is untouched.

**Special notes for your reviewer**:

Scope: this is only about handling stale resourceVersions. It deliberately does not claim to explain or fix everything reported in #3063 — that discussion is unresolved and this PR no longer asserts a root cause for it. Related to #3063.

Added a deterministic regression test per controller. Each wraps the client to (1) emulate the manager field index the reconciler lists by, which envtest's direct client does not provide, and (2) delete the owned status right after the `List`, reproducing the window between `List` and `CreateOrPatch`.

Verified locally (envtest, k8s 1.34.1):

- `go test -short ./internal/k8s/controllers/...` — 10/10 specs pass, 0 skipped.
- Reverting only the two controller `.go` files to `main` and re-running makes both new specs fail with exactly `resourceVersion should not be set on objects to be created`, so the tests do pin this bug rather than passing vacuously.
- `gofmt` clean, `go vet` clean.
- `golangci-lint run ./internal/k8s/controllers/...` — 0 issues. Note: run with 2.12.2; the repo pins 2.11.4 in `tasks.py` and I could not run the pinned container locally, so CI is the authority on that one.

Rebased onto current `main`.

**Release note**:

```release-note
Fixed the ServiceL2Status and ServiceBGPStatus controllers returning "resourceVersion should not be set on objects to be created" instead of re-creating the status when it was deleted while a reconcile was in flight.
```
