### PR TITLE
fix(chart): align PodMonitor with native TLS metrics endpoint

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -82,6 +82,7 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.podMonitor.jobLabel | string | `"app.kubernetes.io/name"` |  |
 | prometheus.podMonitor.metricRelabelings | list | `[]` |  |
 | prometheus.podMonitor.relabelings | list | `[]` |  |
+| prometheus.podMonitor.tlsConfig.insecureSkipVerify | bool | `true` |  |
 | prometheus.prometheusRule.additionalLabels | object | `{}` |  |
 | prometheus.prometheusRule.addressPoolExhausted.enabled | bool | `true` |  |
 | prometheus.prometheusRule.addressPoolExhausted.excludePools | string | `""` |  |

--- a/charts/metallb/templates/podmonitor.yaml
+++ b/charts/metallb/templates/podmonitor.yaml
@@ -23,12 +23,21 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   podMetricsEndpoints:
-  - port: monitoring
+  - port: {{ template "metrics.exposedportname" . }}
+    honorLabels: true
     path: /metrics
-    scheme: https
+    scheme: "https"
+    authorization:
+      credentials:
+        name: {{ template "metallb.fullname" . }}-metrics-token
+        key: token
     {{- if .Values.prometheus.podMonitor.interval }}
     interval: {{ .Values.prometheus.podMonitor.interval }}
     {{- end }}
+{{- if .Values.prometheus.podMonitor.tlsConfig }}
+    tlsConfig:
+{{- toYaml .Values.prometheus.podMonitor.tlsConfig | nindent 6 }}
+{{- end }}
 {{- if .Values.prometheus.podMonitor.metricRelabelings }}
     metricRelabelings:
 {{- toYaml .Values.prometheus.podMonitor.metricRelabelings | nindent 4 }}
@@ -63,12 +72,45 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   podMetricsEndpoints:
-  - port: monitoring
+  - port: {{ template "metrics.exposedportname" . }}
+    honorLabels: true
     path: /metrics
-    scheme: https
+    scheme: "https"
+    authorization:
+      credentials:
+        name: {{ template "metallb.fullname" . }}-metrics-token
+        key: token
     {{- if .Values.prometheus.podMonitor.interval }}
     interval: {{ .Values.prometheus.podMonitor.interval }}
     {{- end }}
+{{- if .Values.prometheus.podMonitor.tlsConfig }}
+    tlsConfig:
+{{- toYaml .Values.prometheus.podMonitor.tlsConfig | nindent 6 }}
+{{- end }}
+{{- if .Values.prometheus.podMonitor.metricRelabelings }}
+    metricRelabelings:
+{{- toYaml .Values.prometheus.podMonitor.metricRelabelings | nindent 4 }}
+{{- end }}
+{{- if .Values.prometheus.podMonitor.relabelings }}
+    relabelings:
+{{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
+{{- end }}
+{{- if .Values.speaker.frr.enabled }}
+  - port: {{ template "metrics.exposedfrrportname" . }}
+    honorLabels: true
+    path: /metrics
+    scheme: "https"
+    authorization:
+      credentials:
+        name: {{ template "metallb.fullname" . }}-metrics-token
+        key: token
+    {{- if .Values.prometheus.podMonitor.interval }}
+    interval: {{ .Values.prometheus.podMonitor.interval }}
+    {{- end }}
+{{- if .Values.prometheus.podMonitor.tlsConfig }}
+    tlsConfig:
+{{- toYaml .Values.prometheus.podMonitor.tlsConfig | nindent 6 }}
+{{- end }}
 {{- if .Values.prometheus.podMonitor.metricRelabelings }}
     metricRelabelings:
 {{- toYaml .Values.prometheus.podMonitor.metricRelabelings | nindent 4 }}
@@ -78,8 +120,56 @@ spec:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
 {{- end }}
+{{- end }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.fullname" . }}-metrics-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "metallb.labels" . | nindent 4 }}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metallb.fullname" . }}-metrics-token
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "metallb.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "metallb.fullname" . }}-metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}-metrics-reader
+  labels:
+    {{- include "metallb.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-metrics-reader
+  labels:
+    {{- include "metallb.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "metallb.fullname" . }}-metrics-reader
+    namespace: {{ .Release.Namespace }}
 {{- if .Values.prometheus.rbacPrometheus }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -206,7 +206,8 @@
               "items": {
                 "type": "object"
               }
-            }
+            },
+            "tlsConfig": { "type": "object" }
           }
         },
         "serviceMonitor": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -84,6 +84,10 @@ prometheus:
     #   replacement: $1
     #   action: replace
 
+    # optional tls configuration for the podMonitor endpoints.
+    tlsConfig:
+      insecureSkipVerify: true
+
   # Prometheus Operator ServiceMonitors. To be used as an alternative
   # to podMonitor, supports secure metrics.
   serviceMonitor:


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
fixes the metrics endpoint according to the new tls behaviour

**Special notes for your reviewer**:
verified it works by doing:
```bash
Kind create cluster

helm install prometheus prometheus-community/kube-prometheus-stack \
    -n monitoring --create-namespace --wait --timeout 5m

helm install metallb ./charts/metallb/ -n metallb-system --create-namespace \
    --set controller.image.tag=v0.16.1 \
    --set speaker.image.tag=v0.16.1 \
    --set speaker.frr.enabled=true \
    --set frrk8s.enabled=false \
    --set prometheus.podMonitor.enabled=true \
    --set prometheus.podMonitor.additionalLabels.release=prometheus \
    --set prometheus.serviceAccount=prometheus-kube-prometheus-prometheus \
    --set prometheus.namespace=monitoring

kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090
```
and looked on web to see no errors

**Release note**:
```release-note
Helm chart: the PodMonitor template now targets the correct HTTPS metrics port (metricshttps instead of the removed monitoring), includes tlsConfig with insecureSkipVerify: true, and authenticates via a dedicated ServiceAccount with a long-lived bearer token
```
fixes #3080 
