### PR TITLE
fix chart service monitor scrape annotations

### DIFF
--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -64,11 +64,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if or .Values.prometheus.scrapeAnnotations .Values.prometheus.serviceMonitor.speaker.annotations }}
   annotations:
+    {{- if .Values.prometheus.scrapeAnnotations }}
     prometheus.io/scrape: "true"
     prometheus.io/scheme: "https"
-  {{- if .Values.prometheus.serviceMonitor.speaker.annotations }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.speaker.annotations }}
 {{ toYaml .Values.prometheus.serviceMonitor.speaker.annotations | indent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     name: {{ template "metallb.fullname" . }}-speaker-monitor-service
@@ -139,11 +143,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if or .Values.prometheus.scrapeAnnotations .Values.prometheus.serviceMonitor.controller.annotations }}
   annotations:
+    {{- if .Values.prometheus.scrapeAnnotations }}
     prometheus.io/scrape: "true"
     prometheus.io/scheme: "https"
-  {{- if .Values.prometheus.serviceMonitor.controller.annotations }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.controller.annotations }}
 {{ toYaml .Values.prometheus.serviceMonitor.controller.annotations | indent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     name: {{ template "metallb.fullname" . }}-controller-monitor-service

--- a/charts/metallb/templates/servicemonitor.yaml
+++ b/charts/metallb/templates/servicemonitor.yaml
@@ -71,7 +71,7 @@ metadata:
     prometheus.io/scheme: "https"
     {{- end }}
     {{- if .Values.prometheus.serviceMonitor.speaker.annotations }}
-{{ toYaml .Values.prometheus.serviceMonitor.speaker.annotations | indent 4 }}
+    {{- toYaml .Values.prometheus.serviceMonitor.speaker.annotations | nindent 4 }}
     {{- end }}
   {{- end }}
   labels:
@@ -150,7 +150,7 @@ metadata:
     prometheus.io/scheme: "https"
     {{- end }}
     {{- if .Values.prometheus.serviceMonitor.controller.annotations }}
-{{ toYaml .Values.prometheus.serviceMonitor.controller.annotations | indent 4 }}
+    {{- toYaml .Values.prometheus.serviceMonitor.controller.annotations | nindent 4 }}
     {{- end }}
   {{- end }}
   labels:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Fixed #3087 .

This PR makes the Prometheus scrape annotations on the Helm chart's generated
ServiceMonitor Services respect `prometheus.scrapeAnnotations`.

Before this change, enabling `prometheus.serviceMonitor.enabled=true` always
rendered `prometheus.io/scrape: "true"` and `prometheus.io/scheme: "https"` on:

- `metallb-speaker-monitor-service`
- `metallb-controller-monitor-service`

That happened even when `prometheus.scrapeAnnotations=false`.

In Prometheus environments that use both ServiceMonitor discovery and
annotation-based service discovery, those annotations can make Prometheus
discover the same MetalLB metrics endpoints through both paths and scrape them
twice.

The chart already uses `prometheus.scrapeAnnotations` to control Prometheus
auto-collection annotations on MetalLB pods. This PR applies the same switch to
the ServiceMonitor helper Services:

- `prometheus.scrapeAnnotations=false`: do not emit `prometheus.io/*` scrape
  annotations on the generated Services.
- `prometheus.scrapeAnnotations=true`: keep emitting the annotation-based scrape
  metadata for users who intentionally rely on it.

Existing `prometheus.serviceMonitor.speaker.annotations` and
`prometheus.serviceMonitor.controller.annotations` behavior is preserved.

**Special notes for your reviewer**:

Validated locally with:

```console
helm template metallb charts/metallb \
  --show-only templates/servicemonitor.yaml \
  --set prometheus.serviceMonitor.enabled=true \
  --set prometheus.rbacPrometheus=false \
  --set prometheus.scrapeAnnotations=false
```

The generated monitor Services do not include `prometheus.io/*` scrape
annotations.

```console
helm template metallb charts/metallb \
  --show-only templates/servicemonitor.yaml \
  --set prometheus.serviceMonitor.enabled=true \
  --set prometheus.rbacPrometheus=false \
  --set prometheus.scrapeAnnotations=true
```

The generated monitor Services include:

```yaml
prometheus.io/scrape: "true"
prometheus.io/scheme: "https"
```

Also ran:

```console
helm lint charts/metallb
helm lint charts/metallb --set prometheus.serviceMonitor.enabled=true --set prometheus.rbacPrometheus=false --set prometheus.scrapeAnnotations=false
helm lint charts/metallb --set prometheus.serviceMonitor.enabled=true --set prometheus.rbacPrometheus=false --set prometheus.scrapeAnnotations=true
git diff --check --cached
```

**Release note**:

```release-note
Helm chart: ServiceMonitor helper Services now emit prometheus.io scrape annotations only when prometheus.scrapeAnnotations is enabled, avoiding duplicate scraping when ServiceMonitor and annotation-based discovery are both configured.
```
