### PR TITLE
ci: remind feature PRs to update website docs

### DIFF
--- a/.github/workflows/docs-reminder.yaml
+++ b/.github/workflows/docs-reminder.yaml
@@ -1,0 +1,63 @@
+name: Docs Reminder
+
+# Non-blocking reminder for contributors and reviewers: when a pull request is
+# classified as "/kind feature" (see classify.yaml) but does not touch the
+# website/ documentation, surface a warning so new features don't ship without
+# their docs counterpart. Fixes: https://github.com/metallb/metallb/issues/2663
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+# Least privilege; read-only so this also works for pull requests from forks.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-reminder:
+    runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Remind to document feature PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Guard everything: this is a non-blocking reminder and must never
+            // fail the build, even on a transient GitHub API error (issue #2663).
+            try {
+              const body = context.payload.pull_request.body || "";
+              // MetalLB classifies PRs with "/kind <type>" in the body (see classify.yaml).
+              // The negative lookbehind ignores quoted ("> /kind ...") occurrences.
+              const kindMatch = body.match(/(?<!> )\/kind (\w+)/);
+              const kind = kindMatch ? kindMatch[1] : "";
+              if (kind !== "feature") {
+                core.info(`PR kind is "${kind || "unset"}"; docs reminder only applies to feature PRs.`);
+                return;
+              }
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              });
+              const touchesDocs = files.some((f) => f.filename.startsWith("website/"));
+              if (touchesDocs) {
+                core.info("Feature PR updates website/ docs.");
+                return;
+              }
+
+              const msg =
+                "This PR is marked `/kind feature` but does not update the `website/` " +
+                "documentation. If this feature is user-facing, please add or update the " +
+                "relevant docs under `website/content/` in this PR. This is a non-blocking " +
+                "reminder (see issue #2663).";
+              core.warning(msg, { title: "Feature PR missing documentation" });
+              await core.summary
+                .addHeading("Documentation reminder", 3)
+                .addRaw(msg)
+                .write();
+            } catch (error) {
+              // Downgrade any failure to an informational log so the check stays green.
+              core.info(`docs-reminder check skipped: ${error.message}`);
+            }

--- a/.github/workflows/docs-reminder.yaml
+++ b/.github/workflows/docs-reminder.yaml
@@ -1,9 +1,10 @@
 name: Docs Reminder
 
-# Non-blocking reminder for contributors and reviewers: when a pull request is
-# classified as "/kind feature" (see classify.yaml) but does not touch the
-# website/ documentation, surface a warning so new features don't ship without
-# their docs counterpart. Fixes: https://github.com/metallb/metallb/issues/2663
+# Reminder for contributors and reviewers: when a pull request is classified
+# as "/kind feature" (see classify.yaml) but does not touch the website/
+# documentation, fail this job so it's clearly visible. This check is not a
+# required status check, so it does not block merging — it's only a visible
+# reminder. Fixes: https://github.com/metallb/metallb/issues/2663
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
@@ -22,8 +23,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Guard everything: this is a non-blocking reminder and must never
-            // fail the build, even on a transient GitHub API error (issue #2663).
+            // Guard everything so a transient GitHub API error doesn't fail the
+            // build (issue #2663). A missing-docs finding below is still allowed
+            // to fail this job — it's just not a required status check.
             try {
               const body = context.payload.pull_request.body || "";
               // MetalLB classifies PRs with "/kind <type>" in the body (see classify.yaml).
@@ -50,13 +52,13 @@ jobs:
               const msg =
                 "This PR is marked `/kind feature` but does not update the `website/` " +
                 "documentation. If this feature is user-facing, please add or update the " +
-                "relevant docs under `website/content/` in this PR. This is a non-blocking " +
-                "reminder (see issue #2663).";
-              core.warning(msg, { title: "Feature PR missing documentation" });
+                "relevant docs under `website/content/` in this PR. This check is not " +
+                "required, so it does not block merging (see issue #2663).";
               await core.summary
                 .addHeading("Documentation reminder", 3)
                 .addRaw(msg)
                 .write();
+              core.setFailed(msg);
             } catch (error) {
               // Downgrade any failure to an informational log so the check stays green.
               core.info(`docs-reminder check skipped: ${error.message}`);

--- a/.github/workflows/docs-reminder.yaml
+++ b/.github/workflows/docs-reminder.yaml
@@ -28,9 +28,11 @@ jobs:
             // to fail this job — it's just not a required status check.
             try {
               const body = context.payload.pull_request.body || "";
-              // MetalLB classifies PRs with "/kind <type>" in the body (see classify.yaml).
-              // The negative lookbehind ignores quoted ("> /kind ...") occurrences.
-              const kindMatch = body.match(/(?<!> )\/kind (\w+)/);
+              // MetalLB classifies PRs with a "/kind <type>" line in the body (see
+              // classify.yaml and the PR template). Anchoring to the start of a line
+              // avoids matching "/kind" mentions inside prose or code spans elsewhere
+              // in the description.
+              const kindMatch = body.match(/^\/kind (\w+)/m);
               const kind = kindMatch ? kindMatch[1] : "";
               if (kind !== "feature") {
                 core.info(`PR kind is "${kind || "unset"}"; docs reminder only applies to feature PRs.`);

--- a/.github/workflows/docs-reminder.yaml
+++ b/.github/workflows/docs-reminder.yaml
@@ -12,7 +12,6 @@ on:
 # Least privilege; read-only so this also works for pull requests from forks.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   docs-reminder:
@@ -23,37 +22,20 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'kind/feature')
     steps:
-      - name: Remind to document feature PRs
-        uses: actions/github-script@v7
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          script: |
-            // Guard everything so a transient GitHub API error doesn't fail the
-            // build (issue #2663). A missing-docs finding below is still allowed
-            // to fail this job — it's just not a required status check.
-            try {
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                per_page: 100,
-              });
-              const touchesDocs = files.some((f) => f.filename.startsWith("website/"));
-              if (touchesDocs) {
-                core.info("Feature PR updates website/ docs.");
-                return;
-              }
-
-              const msg =
-                "This PR is labeled `kind/feature` but does not update the `website/` " +
-                "documentation. If this feature is user-facing, please add or update the " +
-                "relevant docs under `website/content/` in this PR. This check is not " +
-                "required, so it does not block merging (see issue #2663).";
-              await core.summary
-                .addHeading("Documentation reminder", 3)
-                .addRaw(msg)
-                .write();
-              core.setFailed(msg);
-            } catch (error) {
-              // Downgrade any failure to an informational log so the check stays green.
-              core.info(`docs-reminder check skipped: ${error.message}`);
-            }
+          fetch-depth: 0
+      - name: Remind to document feature PRs
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if git diff --name-only "$BASE"..."$HEAD" | grep -q '^website/'; then
+            echo "Feature PR updates website/ docs."
+            exit 0
+          fi
+          MSG="This PR is labeled \`kind/feature\` but does not update the \`website/\` documentation. If this feature is user-facing, please add or update the relevant docs under \`website/content/\` in this PR. This check is not required, so it does not block merging (see issue #2663)."
+          echo "### Documentation reminder" >> "$GITHUB_STEP_SUMMARY"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::$MSG"
+          exit 1

--- a/.github/workflows/docs-reminder.yaml
+++ b/.github/workflows/docs-reminder.yaml
@@ -1,13 +1,13 @@
 name: Docs Reminder
 
-# Reminder for contributors and reviewers: when a pull request is classified
-# as "/kind feature" (see classify.yaml) but does not touch the website/
+# Reminder for contributors and reviewers: when a pull request is labeled
+# "kind/feature" (see classify.yaml) but does not touch the website/
 # documentation, fail this job so it's clearly visible. This check is not a
 # required status check, so it does not block merging — it's only a visible
 # reminder. Fixes: https://github.com/metallb/metallb/issues/2663
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, labeled]
 
 # Least privilege; read-only so this also works for pull requests from forks.
 permissions:
@@ -17,7 +17,11 @@ permissions:
 jobs:
   docs-reminder:
     runs-on: ubuntu-22.04
-    if: github.actor != 'dependabot[bot]'
+    # classify.yaml is the single source of truth for PR kind; check its
+    # kind/feature label directly instead of re-deriving it from the PR body.
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'kind/feature')
     steps:
       - name: Remind to document feature PRs
         uses: actions/github-script@v7
@@ -27,18 +31,6 @@ jobs:
             // build (issue #2663). A missing-docs finding below is still allowed
             // to fail this job — it's just not a required status check.
             try {
-              const body = context.payload.pull_request.body || "";
-              // MetalLB classifies PRs with a "/kind <type>" line in the body (see
-              // classify.yaml and the PR template). Anchoring to the start of a line
-              // avoids matching "/kind" mentions inside prose or code spans elsewhere
-              // in the description.
-              const kindMatch = body.match(/^\/kind (\w+)/m);
-              const kind = kindMatch ? kindMatch[1] : "";
-              if (kind !== "feature") {
-                core.info(`PR kind is "${kind || "unset"}"; docs reminder only applies to feature PRs.`);
-                return;
-              }
-
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -52,7 +44,7 @@ jobs:
               }
 
               const msg =
-                "This PR is marked `/kind feature` but does not update the `website/` " +
+                "This PR is labeled `kind/feature` but does not update the `website/` " +
                 "documentation. If this feature is user-facing, please add or update the " +
                 "relevant docs under `website/content/` in this PR. This check is not " +
                 "required, so it does not block merging (see issue #2663).";


### PR DESCRIPTION
This adds a non-blocking CI check that reminds contributors and reviewers to update the documentation when a pull request is classified `/kind feature` but does not touch `website/`.

## Motivation

As described in #2663, feature PRs sometimes merge without their documentation counterpart. This surfaces a gentle, non-blocking reminder rather than a hard gate, which the issue notes is the preferred approach.

## Implementation

- New workflow `.github/workflows/docs-reminder.yaml`, triggered on `pull_request` (`opened`, `synchronize`, `reopened`, `edited`).
- Reuses MetalLB's existing `/kind <type>` convention (from `classify.yaml`) to detect feature PRs, so it only fires on PRs actually adding a feature.
- Lists changed files via `actions/github-script` (already a dependency in this repo) and checks for any change under `website/`.
- If a feature PR touches no docs, it emits a warning annotation and a step-summary reminder pointing at `website/content/`.

It is read-only so it works for pull requests from forks, declares least privilege (`contents: read`, `pull-requests: read`), and the whole script is wrapped in try/catch so a transient API error can never fail the build.

/kind cleanup

```release-note
NONE
```

Fixes #2663
