### PR TITLE
feat: allow disabling the metrics endpoint

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -158,7 +158,7 @@ func (c *controller) SetPools(l log.Logger, pools *config.Pools) controllers.Syn
 
 func main() {
 	var (
-		port                = flag.Int("port", 9120, "HTTPS listening port for Prometheus metrics")
+		port                = flag.Int("port", 9120, "HTTPS listening port for Prometheus metrics; set to 0 to disable metrics")
 		namespace           = flag.String("namespace", os.Getenv("METALLB_NAMESPACE"), "config / memberlist secret namespace")
 		mlSecret            = flag.String("ml-secret-name", os.Getenv("METALLB_ML_SECRET_NAME"), "name of the memberlist secret to create")
 		deployName          = flag.String("deployment", os.Getenv("METALLB_DEPLOYMENT"), "name of the MetalLB controller Deployment")

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -80,6 +80,13 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func metricsBindAddress(port int) string {
+	if port == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("0.0.0.0:%d", port)
+}
+
 // Client watches a Kubernetes cluster and translates events into
 // Controller method calls.
 type Client struct {
@@ -150,7 +157,7 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	metricsOpts := metricsserver.Options{
-		BindAddress:    fmt.Sprintf("0.0.0.0:%d", cfg.MetricsPort),
+		BindAddress:    metricsBindAddress(cfg.MetricsPort),
 		SecureServing:  true,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 		CertDir:        cfg.MetricsCertDir,

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -11,3 +11,22 @@ func TestDefaultHealthProbePort(t *testing.T) {
 		t.Errorf("DefaultHealthProbePort must be positive, got %d", DefaultHealthProbePort)
 	}
 }
+
+func TestMetricsBindAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+		want string
+	}{
+		{name: "disabled", port: 0, want: "0"},
+		{name: "enabled", port: 9120, want: "0.0.0.0:9120"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := metricsBindAddress(test.port); got != test.want {
+				t.Fatalf("metricsBindAddress(%d) = %q, want %q", test.port, got, test.want)
+			}
+		})
+	}
+}

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -91,7 +91,7 @@ func main() {
 		mlWANConfig             = flag.Bool("ml-wan-config", false, "WAN network type for MemberList default config, bool")
 		myNode                  = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
 		myPod                   = flag.String("pod-name", os.Getenv("METALLB_POD_NAME"), "name of this MetalLB speaker pod")
-		port                    = flag.Int("port", 9120, "HTTPS metrics listening port")
+		port                    = flag.Int("port", 9120, "HTTPS metrics listening port; set to 0 to disable metrics")
 		logLevel                = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
 		pprofBindAddress        = flag.String("pprof-bind-address", "", "Bind address for pprof endpoint (e.g. 127.0.0.1:6060). Empty disables pprof.")
 		healthProbePort         = flag.Int("health-probe-port", k8s.DefaultHealthProbePort, "Port for health probe endpoint")


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Treats metrics port `0` as a disabled listener by passing address `0` to `http.ListenAndServe`. Non-zero ports keep the existing `0.0.0.0:<port>` behavior. The controller and speaker flag help document the disable behavior, and focused tests cover both cases.

Fixed #3095

**Special notes for your reviewer**:

`go test ./internal/k8s` passes.

**Release note**:

```release-note
Allow the controller and speaker metrics endpoints to be disabled by setting the metrics port to 0.
```
