### PR TITLE
reject passwords and VRF names containing newlines in peer config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -468,12 +468,23 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 		return nil, fmt.Errorf("can not have both password and secret ref set in peer config %q/%q", p.Namespace, p.Name)
 	}
 
+	if strings.ContainsAny(p.Spec.Password, "\n\r") {
+		return nil, fmt.Errorf("password for peer %q/%q contains invalid characters", p.Namespace, p.Name)
+	}
+
 	secretPassword := ""
 	if p.Spec.PasswordSecret.Name != "" && !frrk8sSecretPassthrough {
 		secretPassword, err = passwordFromSecretForPeer(p, passwordSecrets)
 		if err != nil {
 			return nil, errors.Join(err, fmt.Errorf("failed to parse peer %s password secret", p.Name))
 		}
+		if strings.ContainsAny(secretPassword, "\n\r") {
+			return nil, fmt.Errorf("password secret for peer %q/%q contains invalid characters", p.Namespace, p.Name)
+		}
+	}
+
+	if strings.ContainsAny(p.Spec.VRFName, "\n\r") {
+		return nil, fmt.Errorf("VRF name for peer %q/%q contains invalid characters", p.Namespace, p.Name)
 	}
 
 	var connectTime *time.Duration


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

peerFromCR in internal/config/config.go passes the password field (from both spec.password and resolved secret references) and the VRF name directly into the FRR configuration template rendered by text/template. since FRR config is line-oriented and the template engine performs no escaping, a value containing a newline character breaks out of its intended directive and injects arbitrary FRR routing configuration. this adds validation in peerFromCR to reject passwords and VRF names that contain \n or \r before they reach the template.

**Special notes for your reviewer**:

the password arrives either from the BGPPeer spec.password field or from a referenced Secret (passwordFromSecretForPeer). neither path validated the content for line-breaking characters. the VRF name from spec.vrf is the same situation. all three checks are placed immediately after the respective values are resolved so the template engine never sees an unvalidated string.

**Release note**:

```release-note
Fixed FRR configuration injection via BGP peer password or VRF name fields containing newline characters.
```