### PR TITLE
fix: return a copy of the advertisement list from GetStatus

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -326,7 +326,10 @@ func (a *Announce) AnnounceName(name string) bool {
 func (a *Announce) GetStatus(meta types.NamespacedName) []IPAdvertisement {
 	a.RLock()
 	defer a.RUnlock()
-	return a.ips[meta.String()]
+	advs := a.ips[meta.String()]
+	status := make([]IPAdvertisement, len(advs))
+	copy(status, advs)
+	return status
 }
 
 // GetInterfaces returns current interfaces list.

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -4,8 +4,10 @@ package layer2
 
 import (
 	"net"
+	"sync"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -61,4 +63,44 @@ func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 	if announce.ipRefcnt["192.168.1.20"] != 2 {
 		t.Fatalf("ip 192.168.1.20 has not 2 refcnt: %d", announce.ipRefcnt["192.168.1.20"])
 	}
+}
+
+func Test_GetStatus_ConcurrentSetBalancer(t *testing.T) {
+	const iterations = 2000
+	announce := &Announce{
+		ips:      map[string][]IPAdvertisement{},
+		ipRefcnt: map[string]int{},
+		spamCh:   make(chan IPAdvertisement, 2*iterations+16),
+	}
+
+	name := types.NamespacedName{Namespace: "ns", Name: "svc"}
+	announce.SetBalancer(name.String(), IPAdvertisement{
+		ip:            net.IPv4(192, 168, 1, 20),
+		interfaces:    sets.New("eth0"),
+		allInterfaces: false,
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Same IP so SetBalancer overrides the existing advertisement in place.
+			announce.SetBalancer(name.String(), IPAdvertisement{
+				ip:            net.IPv4(192, 168, 1, 20),
+				interfaces:    sets.New("eth1"),
+				allInterfaces: false,
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			for _, adv := range announce.GetStatus(name) {
+				_ = adv.interfaces.Len()
+				_ = adv.ip.String()
+			}
+		}
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

GetStatus hands the caller the internal a.ips slice for a service and returns after the read lock is already released, so the layer2 status reconciler reads those advertisements without holding the announce lock. SetBalancer overwrites a.ips[name][i] in place under the write lock when a service re-announces the same ip, which races with that read on the shared backing array (the ip and interfaces fields). GetInterfaces already copies before returning for the same reason, so this makes GetStatus return a copy of the slice too.

**Special notes for your reviewer**:

the added test fails under -race on the current code (write in SetBalancer at announcer.go:269, read from the slice returned by GetStatus) and passes once the copy is in place.

**Release note**:

```release-note
Fix a data race in the layer2 announcer between service status reporting and announcement updates.
```
