### PR TITLE
Allow sending periodic GARP / Unsolicited NDP requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,6 +233,7 @@ jobs:
           WITH_VRF="--with-vrf"
           FOCUS=""
           FRRK8S_NAMESPACE=""
+          if [ "${{ matrix.deployment }}" == "manifests" ]; then SKIP="$SKIP|periodic-gratuitous-arp"; fi
           if [ "${{ matrix.bgp-type }}" == "native" ]; then SKIP="$SKIP|FRR|FRR-MODE|FRRK8S-MODE|BFD|VRF|DUALSTACK"; WITH_VRF=""; fi
           if [ "${{ matrix.ip-family }}" == "ipv4" ]; then SKIP="$SKIP|IPV6|DUALSTACK"; fi
           if [ "${{ matrix.ip-family }}" == "dual" ]; then SKIP="$SKIP|IPV6"; fi

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -135,6 +135,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.frr.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_ADMIN","NET_RAW","SYS_ADMIN","NET_BIND_SERVICE"]},"readOnlyRootFilesystem":true}` | Security context for the FRR container. |
 | speaker.frr.tiniPath | string | `"/sbin/tini"` | Path to the tini binary inside the FRR container. Override this when using an FRR image (e.g. Docker Hardened Images) that places tini at a different location. |
 | speaker.frrMetrics.resources | object | `{}` |  |
+| speaker.gratuitousARPInterval | string | `nil` | Interval in seconds for periodic gratuitous ARP/NDP announcements. Unset or 0 (default) disables periodic announcements. |
 | speaker.ignoreExcludeLB | bool | `false` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -288,6 +288,9 @@ spec:
         {{- if .Values.speaker.bgpDebounceTimeout }}
         - --bgp-debounce-timeout={{ .Values.speaker.bgpDebounceTimeout }}
         {{- end }}
+        {{- if .Values.speaker.gratuitousARPInterval }}
+        - --gratuitous-arp-interval={{ .Values.speaker.gratuitousARPInterval }}
+        {{- end }}
         {{- if .Values.frrk8s.external }}
         - --frrk8s-namespace={{ required "namespace is required when frrk8s is external" .Values.frrk8s.namespace }}
         {{- if .Values.frrk8s.secretPassthrough }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -275,6 +275,8 @@ speaker:
   ignoreExcludeLB: false
   # --  BGP debounce timeout for FRR configuration reloads, in milliseconds. Only applies when BGP type is frr. Default (when unset) is 3000 ms. This feature is experimental
   bgpDebounceTimeout: null
+  # -- Interval in seconds for periodic gratuitous ARP/NDP announcements. Unset or 0 (default) disables periodic announcements.
+  gratuitousARPInterval: null
 
   image:
     repository: quay.io/metallb/speaker

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -788,6 +788,97 @@ var _ = ginkgo.Describe("L2", func() {
 		},
 			ginkgo.Entry("IPV4 - Checking service", "ipv4"),
 			ginkgo.Entry("IPV6 - Checking service", "ipv6"))
+
+		ginkgo.It("periodic-gratuitous-arp - should increase gratuitous sent counter over time", func() {
+			resources := config.Resources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "l2-periodic-garp-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: []string{
+								IPV4ServiceRange,
+								IPV6ServiceRange},
+						},
+					},
+				},
+				L2Advs: []metallbv1beta1.L2Advertisement{emptyL2Advertisement},
+			}
+
+			err := ConfigUpdater.Update(resources)
+			Expect(err).NotTo(HaveOccurred())
+
+			svc, _ := service.CreateWithBackend(cs, testNamespace, "periodic-garp-svc",
+				service.TrafficPolicyCluster)
+			defer func() {
+				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			allNodes, err := cs.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ingressIP := jigservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
+
+			Eventually(func() error {
+				return mac.RequestAddressResolution(ingressIP, executor.Host)
+			}, 2*time.Minute, 1*time.Second).Should(Not(HaveOccurred()))
+
+			ginkgo.By("checking connectivity to its external VIP")
+			Eventually(func() error {
+				return service.ValidateL2(svc)
+			}, 2*time.Minute, 1*time.Second).Should(Not(HaveOccurred()))
+
+			ginkgo.By("identifying the announcing speaker and taking an initial GARP counter reading")
+			var advSpeaker *corev1.Pod
+			var initialCount float64
+
+			Eventually(func() error {
+				advNode, err := advertisingNodeFromMAC(allNodes.Items, ingressIP, executor.Host)
+				if err != nil {
+					return err
+				}
+				sp, ok := speakerPods[advNode.Name]
+				if !ok {
+					return fmt.Errorf("could not find speaker pod on announcing node %s", advNode.Name)
+				}
+				advSpeaker = sp
+
+				speakerMetrics, err := metrics.ForPod(cs, promPod, advSpeaker, metallb.Namespace)
+				if err != nil {
+					return err
+				}
+				initialCount, err = metrics.CounterValue("metallb_layer2_gratuitous_sent",
+					map[string]string{"ip": ingressIP}, speakerMetrics)
+				if err != nil {
+					return err
+				}
+				if initialCount < 1 {
+					return fmt.Errorf("gratuitous_sent counter is %.0f, want >= 1", initialCount)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+
+			ginkgo.By("waiting for the periodic GARP counter to increase")
+			// The speaker is deployed with --gratuitous-arp-interval=5, so we
+			// wait long enough for at least one extra periodic tick.
+			Eventually(func() error {
+				speakerMetrics, err := metrics.ForPod(cs, promPod, advSpeaker, metallb.Namespace)
+				if err != nil {
+					return err
+				}
+				current, err := metrics.CounterValue("metallb_layer2_gratuitous_sent",
+					map[string]string{"ip": ingressIP}, speakerMetrics)
+				if err != nil {
+					return err
+				}
+				if current <= initialCount {
+					return fmt.Errorf("gratuitous_sent counter did not increase: initial=%.0f current=%.0f", initialCount, current)
+				}
+				return nil
+			}, 30*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
+		})
 	})
 
 	ginkgo.DescribeTable("validate requesting a specific address pool for Loadbalancer service", func(ipRange *string, autoAssign bool) {

--- a/e2etest/pkg/metrics/metrics.go
+++ b/e2etest/pkg/metrics/metrics.go
@@ -129,23 +129,13 @@ func ValidateGaugeValueCompare(check func(int) error, metricName string, labels 
 
 // ValidateCounterValue checks that the value related to the given metric is at most the expectedMax value.
 func ValidateCounterValue(check func(int) error, metricName string, labels map[string]string, allMetrics []map[string]*dto.MetricFamily) error {
-	var err error
-	var value int
-	found := false
-	for _, m := range allMetrics {
-		value, err = CounterForLabels(metricName, labels, m)
-		if err != nil {
-			continue
-		}
-		found = true
-		err := check(value)
-		if err != nil {
-			return fmt.Errorf("invalid value %d for %s, %w", value, metricName, err)
-		}
+	value, err := CounterValue(metricName, labels, allMetrics)
+	if err != nil {
+		return err
 	}
-
-	if !found {
-		return fmt.Errorf("metric %s not found", metricName)
+	v := int(value)
+	if err := check(v); err != nil {
+		return fmt.Errorf("invalid value %d for %s, %w", v, metricName, err)
 	}
 	return nil
 }
@@ -155,6 +145,44 @@ func CounterForLabels(metricName string, labels map[string]string, metrics map[s
 	return metricForLabels(metricName, labels, metrics, func(m *dto.Metric) int {
 		return int(m.GetCounter().GetValue())
 	})
+}
+
+// CounterValue returns the raw counter value for the given metric across all scraped pods.
+func CounterValue(metricName string, labels map[string]string, allMetrics []map[string]*dto.MetricFamily) (float64, error) {
+	for _, m := range allMetrics {
+		v, err := counterValueForLabels(metricName, labels, m)
+		if err != nil {
+			continue
+		}
+		return v, nil
+	}
+	return 0, fmt.Errorf("metric %s not found", metricName)
+}
+
+// counterValueForLabels retrieves the counter value as float64, preserving fractional
+// values and avoiding truncation from int conversion.
+func counterValueForLabels(metricName string, labels map[string]string, metrics map[string]*dto.MetricFamily) (float64, error) {
+	mf, ok := metrics[metricName]
+	if !ok {
+		return 0, fmt.Errorf("metric %s not in metrics", metricName)
+	}
+	for _, m := range mf.GetMetric() {
+		toMatch := len(labels)
+		for _, l := range m.GetLabel() {
+			v, ok := labels[l.GetName()]
+			if !ok {
+				continue
+			}
+			if v != l.GetValue() {
+				continue
+			}
+			toMatch--
+		}
+		if toMatch == 0 {
+			return m.GetCounter().GetValue(), nil
+		}
+	}
+	return 0, fmt.Errorf("label %s not found in metrics for %s", labels, metricName)
 }
 
 func GreaterOrEqualThan(min int) func(value int) error {

--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -3,9 +3,11 @@
 package layer2
 
 import (
+	"maps"
 	"net"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -15,14 +17,32 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// arpResponder is the subset of *arpClient behavior the Announce
+// uses. It exists so the ARP responders can be replaced with fakes in tests.
+type arpResponder interface {
+	Interface() string
+	Gratuitous(ip net.IP) error
+	Close() error
+}
+
+// ndpResponder is the subset of *ndpClient behavior the Announce
+// uses. It exists so the NDP responders can be replaced with fakes in tests.
+type ndpResponder interface {
+	Interface() string
+	Gratuitous(ip net.IP) error
+	Watch(ip net.IP) error
+	Unwatch(ip net.IP) error
+	Close() error
+}
+
 // Announce is used to "announce" new IPs mapped to the node's MAC address.
 type Announce struct {
 	logger log.Logger
 
 	sync.RWMutex
 	nodeInterfaces []string // current local interfaces' name list
-	arps           map[int]*arpResponder
-	ndps           map[int]*ndpResponder
+	arps           map[int]arpResponder
+	ndps           map[int]ndpResponder
 	ips            map[string][]IPAdvertisement // svcName -> IPAdvertisements
 	ipRefcnt       map[string]int               // ip.String() -> number of uses
 
@@ -32,13 +52,15 @@ type Announce struct {
 	excludeRegexp *regexp.Regexp
 }
 
-// New returns an initialized Announce.
-func New(l log.Logger, excludeRegexp *regexp.Regexp) (*Announce, error) {
+// New returns an initialized Announce. If gratuitousARPInterval is positive,
+// a background goroutine periodically sends gratuitous ARP/NDP for all
+// announced IPs at that interval.
+func New(l log.Logger, excludeRegexp *regexp.Regexp, gratuitousARPInterval time.Duration) (*Announce, error) {
 	ret := &Announce{
 		logger:         l,
 		nodeInterfaces: []string{},
-		arps:           map[int]*arpResponder{},
-		ndps:           map[int]*ndpResponder{},
+		arps:           map[int]arpResponder{},
+		ndps:           map[int]ndpResponder{},
 		ips:            map[string][]IPAdvertisement{},
 		ipRefcnt:       map[string]int{},
 		spamCh:         make(chan IPAdvertisement, 1024),
@@ -47,6 +69,10 @@ func New(l log.Logger, excludeRegexp *regexp.Regexp) (*Announce, error) {
 
 	go ret.interfaceScan()
 	go ret.spamLoop()
+	if gratuitousARPInterval > 0 {
+		level.Info(l).Log("op", "periodicGARP", "msg", "periodic gratuitous ARP enabled", "interval", gratuitousARPInterval)
+		go ret.periodicGARPLoop(gratuitousARPInterval)
+	}
 
 	return ret, nil
 }
@@ -117,7 +143,7 @@ func (a *Announce) updateInterfaces() {
 		}
 
 		if keepARP[ifi.Index] && a.arps[ifi.Index] == nil {
-			resp, err := newARPResponder(a.logger, &ifi, a.shouldAnnounce)
+			resp, err := newARPClient(a.logger, &ifi, a.shouldAnnounce)
 			if err != nil {
 				level.Error(l).Log("op", "createARPResponder", "error", err, "msg", "failed to create ARP responder")
 				continue
@@ -126,7 +152,7 @@ func (a *Announce) updateInterfaces() {
 			level.Info(l).Log("event", "createARPResponder", "msg", "created ARP responder for interface")
 		}
 		if keepNDP[ifi.Index] && a.ndps[ifi.Index] == nil {
-			resp, err := newNDPResponder(a.logger, &ifi, a.shouldAnnounce)
+			resp, err := newNDPClient(a.logger, &ifi, a.shouldAnnounce)
 			if err != nil {
 				level.Error(l).Log("op", "createNDPResponder", "error", err, "msg", "failed to create NDP responder")
 				continue
@@ -200,6 +226,58 @@ func (a *Announce) doSpam(adv IPAdvertisement) {
 	a.spamCh <- adv
 }
 
+func (a *Announce) periodicGARPLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		a.sendPeriodicGratuitous()
+	}
+}
+
+func (a *Announce) sendPeriodicGratuitous() {
+	for _, adv := range a.mergedAdvertisementsPerIP() {
+		a.gratuitous(adv)
+	}
+}
+
+// mergedAdvertisementsPerIP returns one IPAdvertisement per unique IP,
+// merging interface constraints across all advertisements for that IP:
+// allInterfaces=true if any source advertisement has it, otherwise the
+// union of interface sets. This ensures periodic gratuitous announcements
+// reach every interface where the IP is being advertised.
+func (a *Announce) mergedAdvertisementsPerIP() []IPAdvertisement {
+	a.RLock()
+	defer a.RUnlock()
+
+	merged := map[string]IPAdvertisement{}
+	for _, ipAdvs := range a.ips {
+		for _, adv := range ipAdvs {
+			ipStr := adv.ip.String()
+			existing, ok := merged[ipStr]
+			if !ok {
+				m := adv
+				if !m.allInterfaces {
+					m.interfaces = m.interfaces.Clone()
+				}
+				merged[ipStr] = m
+				continue
+			}
+			if existing.allInterfaces {
+				continue
+			}
+			if adv.allInterfaces {
+				existing.allInterfaces = true
+				existing.interfaces = nil
+			} else {
+				existing.interfaces = existing.interfaces.Union(adv.interfaces)
+			}
+			merged[ipStr] = existing
+		}
+	}
+
+	return slices.Collect(maps.Values(merged))
+}
+
 func (a *Announce) gratuitous(adv IPAdvertisement) {
 	a.RLock()
 	defer a.RUnlock()
@@ -213,8 +291,8 @@ func (a *Announce) gratuitous(adv IPAdvertisement) {
 
 	if ip.To4() != nil {
 		for _, client := range a.arps {
-			if !adv.matchInterface(client.intf) {
-				level.Debug(a.logger).Log("op", "gratuitousAnnounce", "skip interfaces", client.intf)
+			if !adv.matchInterface(client.Interface()) {
+				level.Debug(a.logger).Log("op", "gratuitousAnnounce", "skip interfaces", client.Interface())
 				continue
 			}
 			if err := client.Gratuitous(ip); err != nil {
@@ -223,8 +301,8 @@ func (a *Announce) gratuitous(adv IPAdvertisement) {
 		}
 	} else {
 		for _, client := range a.ndps {
-			if !adv.matchInterface(client.intf) {
-				level.Debug(a.logger).Log("op", "gratuitousAnnounce", "skip interfaces", client.intf)
+			if !adv.matchInterface(client.Interface()) {
+				level.Debug(a.logger).Log("op", "gratuitousAnnounce", "skip interfaces", client.Interface())
 				continue
 			}
 			if err := client.Gratuitous(ip); err != nil {
@@ -282,7 +360,7 @@ func (a *Announce) SetBalancer(name string, adv IPAdvertisement) {
 
 	for _, client := range a.ndps {
 		if err := client.Watch(adv.ip); err != nil {
-			level.Error(a.logger).Log("op", "watchMulticastGroup", "error", err, "ip", adv.ip, "interface", client.intf, "msg", "failed to watch NDP multicast group for IP, NDP responder will not respond to requests for this address")
+			level.Error(a.logger).Log("op", "watchMulticastGroup", "error", err, "ip", adv.ip, "interface", client.Interface(), "msg", "failed to watch NDP multicast group for IP, NDP responder will not respond to requests for this address")
 		}
 	}
 }
@@ -308,7 +386,7 @@ func (a *Announce) DeleteBalancer(name string) {
 
 		for _, client := range a.ndps {
 			if err := client.Unwatch(cur.ip); err != nil {
-				level.Error(a.logger).Log("op", "unwatchMulticastGroup", "error", err, "ip", cur.ip, "interface", client.intf, "msg", "failed to unwatch NDP multicast group for IP")
+				level.Error(a.logger).Log("op", "unwatchMulticastGroup", "error", err, "ip", cur.ip, "interface", client.Interface(), "msg", "failed to unwatch NDP multicast group for IP")
 			}
 		}
 	}

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -62,3 +62,204 @@ func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
 		t.Fatalf("ip 192.168.1.20 has not 2 refcnt: %d", announce.ipRefcnt["192.168.1.20"])
 	}
 }
+
+func Test_MergedAdvertisementsPerIP(t *testing.T) {
+	ipA := net.IPv4(192, 168, 1, 100)
+	ipB := net.IPv4(192, 168, 1, 101)
+
+	tests := []struct {
+		name string
+		ips  map[string][]IPAdvertisement
+		want map[string]IPAdvertisement
+	}{
+		{
+			name: "allInterfaces wins over interface set",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, allInterfaces: true}},
+				"svc2": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+			},
+			want: map[string]IPAdvertisement{
+				ipA.String(): {ip: ipA, allInterfaces: true},
+			},
+		},
+		{
+			name: "allInterfaces wins over interface set (reversed order)",
+			ips: map[string][]IPAdvertisement{
+				"svc2": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+				"svc1": {{ip: ipA, allInterfaces: true}},
+			},
+			want: map[string]IPAdvertisement{
+				ipA.String(): {ip: ipA, allInterfaces: true},
+			},
+		},
+		{
+			name: "interface sets are unioned",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+				"svc2": {{ip: ipA, interfaces: sets.New("eth1"), allInterfaces: false}},
+			},
+			want: map[string]IPAdvertisement{
+				ipA.String(): {ip: ipA, interfaces: sets.New("eth0", "eth1"), allInterfaces: false},
+			},
+		},
+		{
+			name: "distinct IPs produce distinct entries",
+			ips: map[string][]IPAdvertisement{
+				"svc1": {{ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false}},
+				"svc2": {{ip: ipB, allInterfaces: true}},
+			},
+			want: map[string]IPAdvertisement{
+				ipA.String(): {ip: ipA, interfaces: sets.New("eth0"), allInterfaces: false},
+				ipB.String(): {ip: ipB, allInterfaces: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			announce := &Announce{
+				ips: tt.ips,
+			}
+			merged := announce.mergedAdvertisementsPerIP()
+			if len(merged) != len(tt.want) {
+				t.Fatalf("got %d merged advs, want %d", len(merged), len(tt.want))
+			}
+			byIP := map[string]IPAdvertisement{}
+			for _, adv := range merged {
+				key := adv.ip.String()
+				if _, dup := byIP[key]; dup {
+					t.Fatalf("duplicate merged advertisement for %s", key)
+				}
+				byIP[key] = adv
+			}
+			for ip, want := range tt.want {
+				adv, ok := byIP[ip]
+				if !ok {
+					t.Fatalf("missing merged advertisement for %s", ip)
+				}
+				if adv.allInterfaces != want.allInterfaces {
+					t.Errorf("ip %s: allInterfaces=%v, want %v", ip, adv.allInterfaces, want.allInterfaces)
+				}
+				if !want.allInterfaces && !adv.interfaces.Equal(want.interfaces) {
+					t.Errorf("ip %s: interfaces=%v, want %v", ip, adv.interfaces, want.interfaces)
+				}
+			}
+		})
+	}
+}
+
+func Test_SendPeriodicGratuitous_IteratesEveryAnnouncedIP(t *testing.T) {
+	// Positive control for the empty-case test: with IPs announced,
+	// sendPeriodicGratuitous must call Gratuitous() once per unique announced
+	// IP on the matching responder, routing by address family (IPv4 -> ARP,
+	// IPv6 -> NDP). Fakes record the calls so we assert on the real gratuitous()
+	// path instead of only the merge helper.
+	arp := newFakeARPResponder("eth0")
+	ndp := newFakeNDPResponder("eth0")
+	ipV4 := net.IPv4(192, 168, 1, 20)
+	ipV6a := net.ParseIP("1000::1")
+	ipV6b := net.ParseIP("1000::2")
+	announce := &Announce{
+		arps: map[int]arpResponder{0: arp},
+		ndps: map[int]ndpResponder{0: ndp},
+		ips: map[string][]IPAdvertisement{
+			// Same IPv6 announced by two services: still one Gratuitous call.
+			"foo": {{ip: ipV6a, allInterfaces: true}},
+			"bar": {{ip: ipV6a, allInterfaces: true}},
+			"baz": {{ip: ipV6b, allInterfaces: true}},
+			"qux": {{ip: ipV4, allInterfaces: true}},
+		},
+		ipRefcnt: map[string]int{
+			ipV4.String():  1,
+			ipV6a.String(): 2,
+			ipV6b.String(): 1,
+		},
+		spamCh: make(chan IPAdvertisement, 1024),
+	}
+
+	announce.sendPeriodicGratuitous()
+
+	gotNDP := ndp.gratuitousCalls()
+	wantNDP := map[string]int{ipV6a.String(): 1, ipV6b.String(): 1}
+	assertGratuitousCounts(t, "NDP", gotNDP, wantNDP)
+	gotARP := arp.gratuitousCalls()
+	wantARP := map[string]int{ipV4.String(): 1}
+	assertGratuitousCounts(t, "ARP", gotARP, wantARP)
+}
+
+// assertGratuitousCounts checks that each expected IP was pinged exactly the
+// wanted number of times (and no unexpected IPs were pinged), so we can catch
+// both missing announcements and accidental duplicates.
+func assertGratuitousCounts(t *testing.T, proto string, got, want map[string]int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s Gratuitous called for IPs %v, want %v", proto, got, want)
+	}
+	for ip, wantN := range want {
+		gotN, ok := got[ip]
+		if !ok {
+			t.Fatalf("%s Gratuitous not called for %s (got %v)", proto, ip, got)
+		}
+		if gotN != wantN {
+			t.Fatalf("%s Gratuitous called %d times for %s, want %d", proto, gotN, ip, wantN)
+		}
+	}
+}
+
+// fakeARPResponder is a test double for the arpResponder interface that records the IPs
+// passed to Gratuitous.
+type fakeARPResponder struct {
+	intf       string
+	gratuitous []net.IP
+}
+
+func newFakeARPResponder(intf string) *fakeARPResponder {
+	return &fakeARPResponder{intf: intf}
+}
+
+func (f *fakeARPResponder) Interface() string { return f.intf }
+
+func (f *fakeARPResponder) Gratuitous(ip net.IP) error {
+	f.gratuitous = append(f.gratuitous, ip)
+	return nil
+}
+
+func (f *fakeARPResponder) Close() error { return nil }
+
+func (f *fakeARPResponder) gratuitousCalls() map[string]int {
+	m := map[string]int{}
+	for _, ip := range f.gratuitous {
+		m[ip.String()]++
+	}
+	return m
+}
+
+// fakeNDPResponder is a test double for the ndpResponder interface that records the IPs
+// passed to Gratuitous.
+type fakeNDPResponder struct {
+	intf       string
+	gratuitous []net.IP
+}
+
+func newFakeNDPResponder(intf string) *fakeNDPResponder {
+	return &fakeNDPResponder{intf: intf}
+}
+
+func (f *fakeNDPResponder) Interface() string { return f.intf }
+
+func (f *fakeNDPResponder) Gratuitous(ip net.IP) error {
+	f.gratuitous = append(f.gratuitous, ip)
+	return nil
+}
+
+func (f *fakeNDPResponder) Watch(net.IP) error   { return nil }
+func (f *fakeNDPResponder) Unwatch(net.IP) error { return nil }
+func (f *fakeNDPResponder) Close() error         { return nil }
+
+func (f *fakeNDPResponder) gratuitousCalls() map[string]int {
+	m := map[string]int{}
+	for _, ip := range f.gratuitous {
+		m[ip.String()]++
+	}
+	return m
+}

--- a/internal/layer2/arp.go
+++ b/internal/layer2/arp.go
@@ -17,7 +17,7 @@ import (
 
 type announceFunc func(net.IP, string) dropReason
 
-type arpResponder struct {
+type arpClient struct {
 	logger       log.Logger
 	intf         string
 	hardwareAddr net.HardwareAddr
@@ -26,13 +26,13 @@ type arpResponder struct {
 	announce     announceFunc
 }
 
-func newARPResponder(logger log.Logger, ifi *net.Interface, ann announceFunc) (*arpResponder, error) {
+func newARPClient(logger log.Logger, ifi *net.Interface, ann announceFunc) (*arpClient, error) {
 	client, err := arp.Dial(ifi)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARP responder for %q: %s", ifi.Name, err)
 	}
 
-	ret := &arpResponder{
+	ret := &arpClient{
 		logger:       logger,
 		intf:         ifi.Name,
 		hardwareAddr: ifi.HardwareAddr,
@@ -44,14 +44,14 @@ func newARPResponder(logger log.Logger, ifi *net.Interface, ann announceFunc) (*
 	return ret, nil
 }
 
-func (a *arpResponder) Interface() string { return a.intf }
+func (a *arpClient) Interface() string { return a.intf }
 
-func (a *arpResponder) Close() error {
+func (a *arpClient) Close() error {
 	close(a.closed)
 	return a.conn.Close()
 }
 
-func (a *arpResponder) Gratuitous(ip net.IP) error {
+func (a *arpClient) Gratuitous(ip net.IP) error {
 	for _, op := range []arp.Operation{arp.OperationRequest, arp.OperationReply} {
 		pkt, err := arp.NewPacket(op, a.hardwareAddr, ip, ethernet.Broadcast, ip)
 		if err != nil {
@@ -65,16 +65,16 @@ func (a *arpResponder) Gratuitous(ip net.IP) error {
 	return nil
 }
 
-func (a *arpResponder) run() {
+func (a *arpClient) run() {
 	for a.processRequest() != dropReasonClosed {
 	}
 }
 
-func (a *arpResponder) processRequest() dropReason {
+func (a *arpClient) processRequest() dropReason {
 	pkt, eth, err := a.conn.Read()
 	if err != nil {
 		// ARP listener doesn't cleanly return EOF when closed, so we
-		// need to hook into the call to arpResponder.Close()
+		// need to hook into the call to arpClient.Close()
 		// independently.
 		select {
 		case <-a.closed:

--- a/internal/layer2/arp_test.go
+++ b/internal/layer2/arp_test.go
@@ -127,7 +127,7 @@ func mustMarshal(m encoding.BinaryMarshaler) []byte {
 	return b
 }
 
-func newTestARP(t *testing.T, shouldAnnounce announceFunc) (*arpResponder, *net.UDPConn, func()) {
+func newTestARP(t *testing.T, shouldAnnounce announceFunc) (*arpClient, *net.UDPConn, func()) {
 	pc, err := net.ListenPacket("udp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen UDP: %s", err)
@@ -145,7 +145,7 @@ func newTestARP(t *testing.T, shouldAnnounce announceFunc) (*arpResponder, *net.
 	// Find any interface that has a hardware address. We don't care
 	// which one, we just need something to satisfy the various
 	// interfaces.
-	var a *arpResponder
+	var a *arpClient
 	for _, intf := range intfs {
 		if intf.HardwareAddr == nil {
 			continue
@@ -157,7 +157,7 @@ func newTestARP(t *testing.T, shouldAnnounce announceFunc) (*arpResponder, *net.
 			t.Fatalf("failed to create ARP client: %s", err)
 		}
 
-		a = &arpResponder{
+		a = &arpClient{
 			logger:       log.NewNopLogger(),
 			hardwareAddr: intf.HardwareAddr,
 			conn:         c,

--- a/internal/layer2/ndp.go
+++ b/internal/layer2/ndp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mdlayher/ndp"
 )
 
-type ndpResponder struct {
+type ndpClient struct {
 	logger       log.Logger
 	intf         string
 	hardwareAddr net.HardwareAddr
@@ -25,14 +25,14 @@ type ndpResponder struct {
 	solicitedNodeGroups map[string]int64
 }
 
-func newNDPResponder(logger log.Logger, ifi *net.Interface, ann announceFunc) (*ndpResponder, error) {
+func newNDPClient(logger log.Logger, ifi *net.Interface, ann announceFunc) (*ndpClient, error) {
 	// Use link-local address as the source IPv6 address for NDP communications.
 	conn, _, err := ndp.Dial(ifi, ndp.LinkLocal)
 	if err != nil {
 		return nil, fmt.Errorf("creating NDP responder for %q: %s", ifi.Name, err)
 	}
 
-	ret := &ndpResponder{
+	ret := &ndpClient{
 		logger:              logger,
 		intf:                ifi.Name,
 		hardwareAddr:        ifi.HardwareAddr,
@@ -45,20 +45,20 @@ func newNDPResponder(logger log.Logger, ifi *net.Interface, ann announceFunc) (*
 	return ret, nil
 }
 
-func (n *ndpResponder) Interface() string { return n.intf }
+func (n *ndpClient) Interface() string { return n.intf }
 
-func (n *ndpResponder) Close() error {
+func (n *ndpClient) Close() error {
 	close(n.closed)
 	return n.conn.Close()
 }
 
-func (n *ndpResponder) Gratuitous(ip net.IP) error {
+func (n *ndpClient) Gratuitous(ip net.IP) error {
 	err := n.advertise(net.IPv6linklocalallnodes, ip, true)
 	stats.SentGratuitous(ip.String())
 	return err
 }
 
-func (n *ndpResponder) Watch(ip net.IP) error {
+func (n *ndpClient) Watch(ip net.IP) error {
 	if ip.To4() != nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (n *ndpResponder) Watch(ip net.IP) error {
 	return nil
 }
 
-func (n *ndpResponder) Unwatch(ip net.IP) error {
+func (n *ndpClient) Unwatch(ip net.IP) error {
 	if ip.To4() != nil {
 		return nil
 	}
@@ -92,12 +92,12 @@ func (n *ndpResponder) Unwatch(ip net.IP) error {
 	return nil
 }
 
-func (n *ndpResponder) run() {
+func (n *ndpClient) run() {
 	for n.processRequest() != dropReasonClosed {
 	}
 }
 
-func (n *ndpResponder) processRequest() dropReason {
+func (n *ndpClient) processRequest() dropReason {
 	msg, _, src, err := n.conn.ReadFrom()
 	if err != nil {
 		select {
@@ -155,7 +155,7 @@ func (n *ndpResponder) processRequest() dropReason {
 	return dropReasonNone
 }
 
-func (n *ndpResponder) advertise(dst, target net.IP, gratuitous bool) error {
+func (n *ndpClient) advertise(dst, target net.IP, gratuitous bool) error {
 	m := &ndp.NeighborAdvertisement{
 		Solicited:     !gratuitous, // <Adam Jensen> I never asked for this...
 		Override:      gratuitous,  // Should clients replace existing cache entries

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"os/signal"
@@ -66,6 +67,10 @@ var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 const (
 	excludeL2ConfigPath    = "/etc/metallb/excludel2.yaml"
 	defaultDebounceTimeout = 3 * time.Second
+	// Cap the gratuitous ARP interval well below the time.Duration overflow
+	// point (max ~9.2e9 seconds for an int64 ns duration) while still
+	// allowing any sensible value.
+	maxGratuitousARPInterval = math.MaxInt32
 )
 
 // Service offers methods to mutate a Kubernetes service object.
@@ -103,6 +108,8 @@ func main() {
 		tlsCipherSuites         = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS cipher suites. Only applies to TLS 1.2. If empty, uses Go defaults.")
 		tlsCurvePreferences     = flag.String("tls-curve-preferences", "", "Comma-separated list of numeric CurveID values (see https://pkg.go.dev/crypto/tls#CurveID). If empty, uses Go defaults.")
 		metricsCertDir          = flag.String("metrics-cert-dir", "", "Directory containing tls.crt and tls.key for metrics TLS. If empty, auto-generated self-signed cert is used.")
+		gratuitousARPInterval   = flag.Int("gratuitous-arp-interval", 0, "Interval in seconds for periodic gratuitous ARP/NDP announcements. "+
+			"0 disables periodic announcements.")
 	)
 
 	flag.Parse()
@@ -140,6 +147,12 @@ func main() {
 		bgpDebounceTimeout = time.Duration(parsed) * time.Millisecond
 	}
 	level.Debug(logger).Log("msg", "using BGP debounce timeout", "milliseconds", bgpDebounceTimeout.Milliseconds())
+
+	if *gratuitousARPInterval < 0 || *gratuitousARPInterval > maxGratuitousARPInterval {
+		level.Error(logger).Log("msg", "invalid --gratuitous-arp-interval value, must be a non-negative integer number of seconds within bound", "provided", *gratuitousARPInterval, "max", maxGratuitousARPInterval)
+		os.Exit(1)
+	}
+	garpInterval := time.Duration(*gratuitousARPInterval) * time.Second
 
 	if bgpType == "frr" {
 		level.Warn(logger).Log("op", "startup", "msg", "The FRR mode is deprecated and will be removed in a future release. Please migrate to the frr-k8s mode, which is now the default BGP backend. See https://metallb.io/concepts/bgp/#frr-k8s-mode for details.")
@@ -224,6 +237,7 @@ func main() {
 		InterfaceExcludeRegexp:  interfacesToExclude,
 		IgnoreExcludeLB:         *ignoreLBExclude,
 		BGPDebounceTimeout:      bgpDebounceTimeout,
+		GratuitousARPInterval:   garpInterval,
 		Layer2StatusChange: func(namespacedName types.NamespacedName) {
 			l2StatusChan <- controllers.NewL2StatusEvent(namespacedName.Namespace, namespacedName.Name)
 		},
@@ -332,6 +346,7 @@ type controllerConfig struct {
 	InterfaceExcludeRegexp       *regexp.Regexp
 	IgnoreExcludeLB              bool
 	BGPDebounceTimeout           time.Duration
+	GratuitousARPInterval        time.Duration
 	Layer2StatusChange           func(types.NamespacedName)
 	BGPAdsChangedCallback        func(string)
 }
@@ -364,7 +379,7 @@ func newController(cfg controllerConfig) (*controller, error) {
 
 	layer2StatusFetcher := func(types.NamespacedName) []layer2.IPAdvertisement { return nil }
 	if !cfg.DisableLayer2 {
-		a, err := layer2.New(cfg.Logger, cfg.InterfaceExcludeRegexp)
+		a, err := layer2.New(cfg.Logger, cfg.InterfaceExcludeRegexp, cfg.GratuitousARPInterval)
 		layer2StatusFetcher = a.GetStatus
 		if err != nil {
 			return nil, fmt.Errorf("making layer2 announcer: %s", err)

--- a/tasks.py
+++ b/tasks.py
@@ -618,7 +618,7 @@ apiServer:
             "helm install metallb charts/metallb/ --set controller.image.tag=dev-{} "
             "--set speaker.image.tag=dev-{} --set speaker.logLevel=debug "
             "--set networkpolicies.enabled=true --set networkpolicies.defaultDeny=true --set prometheus.secureMetricsPort=9120 "
-            "--set controller.logLevel=debug {} {} --namespace metallb-system".format(
+            "--set controller.logLevel=debug --set speaker.gratuitousARPInterval=5 {} {} --namespace metallb-system".format(
                 architecture, architecture, prometheus_values, frr_values
             ),
             echo=True,

--- a/website/content/concepts/layer2.md
+++ b/website/content/concepts/layer2.md
@@ -67,6 +67,26 @@ about 10s), please [file a bug](https://github.com/metallb/metallb/issues/new)!
 We can help you investigate and determine if the issue is with the client, or a
 bug in MetalLB.
 
+## Periodic gratuitous announcements
+
+By default MetalLB only sends gratuitous ARP/NDP packets on failover. MetalLB
+does reply to ARP requests and NDP Neighbor Solicitations for announced service
+VIPs. In some environments — for example, switches that age FDB
+entries faster than upstream gateways age their ARP cache — this can result
+in periodic packet loss for service IPs even without a leadership change,
+because nothing refreshes the switch's forwarding tables between failovers.
+To work around this, the speaker
+can be configured to re-emit gratuitous ARP/NDP packets for every announced IP
+on a fixed interval, via the `--gratuitous-arp-interval` flag (or the
+`speaker.gratuitousARPInterval` Helm value). The value is in
+seconds; `0` (the default) keeps the original failover-only behaviour.
+
+The interval applies speaker-wide to every L2-announced IP on the node, so
+very short intervals on speakers announcing many IPs across many interfaces
+can produce a noticeable amount of broadcast traffic and slow down the
+speaker's handling of service updates. As a rule of thumb, pick the largest
+interval that is still shorter than your switch's FDB aging time.
+
 ## How the L2 leader election works
 
 The election of the "leader" (the node which is going to advertise the IP) of a


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Allow to set sending periodic gratuitous ARP / NDP messages. Follow up of https://github.com/metallb/metallb/pull/2981
Fixes https://github.com/metallb/metallb/issues/2910 and potentially remediates https://github.com/metallb/metallb/issues/2920

When the parameter is set, MetalLB periodically sends out ARP and NDP messages.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Optionally send periodic ARP / NDP messages to refresh the neighbor cache of clients.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for periodic gratuitous ARP/NDP announcements in Layer 2 mode.
  - Configure the announcement interval in seconds using the speaker command-line option or Helm values.
  - Announcements are disabled by default and can help refresh network switch forwarding information.
  - Invalid or excessively large interval values are rejected.

- **Documentation**
  - Added guidance covering configuration, defaults, traffic considerations, and recommendations related to switch forwarding database aging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->