### PR TITLE
fix(speaker): make exclusion ConfigMap readable

### DIFF
--- a/charts/metallb/policy/speaker.rego
+++ b/charts/metallb/policy/speaker.rego
@@ -32,3 +32,12 @@ deny[msg] {
   not input.spec.template.spec.tolerations[0] == { "key": "node-role.kubernetes.io/master", "effect": "NoSchedule", "operator": "Exists" }
   msg = "controller tolerations does not include node-role.kubernetes.io/master:NoSchedule"
 }
+# validate exclude-L2 config is readable by a non-root speaker
+deny[msg] {
+  input.kind == "DaemonSet"
+  endswith(input.metadata.name, "-speaker")
+  volume := input.spec.template.spec.volumes[_]
+  volume.name == "metallb-excludel2"
+  not volume.configMap.defaultMode == 292
+  msg = "speaker metallb-excludel2 ConfigMap defaultMode must be 292"
+}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -194,7 +194,7 @@ spec:
       {{- if .Values.speaker.excludeInterfaces.enabled }}
         - name: metallb-excludel2
           configMap:
-            defaultMode: 256
+            defaultMode: 292
             name: metallb-excludel2
       {{- end }}
         - name: memberlist-config

--- a/config/controllers/speaker.yaml
+++ b/config/controllers/speaker.yaml
@@ -116,7 +116,7 @@ spec:
           defaultMode: 420
       - name: metallb-excludel2
         configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
       - name: memberlist-config
         configMap:

--- a/config/manifests/metallb-frr-k8s-prometheus.yaml
+++ b/config/manifests/metallb-frr-k8s-prometheus.yaml
@@ -3958,7 +3958,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:

--- a/config/manifests/metallb-frr-k8s.yaml
+++ b/config/manifests/metallb-frr-k8s.yaml
@@ -3863,7 +3863,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2708,7 +2708,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2610,7 +2610,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -2470,7 +2470,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -2375,7 +2375,7 @@ spec:
           defaultMode: 420
           secretName: memberlist
       - configMap:
-          defaultMode: 256
+          defaultMode: 292
           name: metallb-excludel2
         name: metallb-excludel2
       - configMap:


### PR DESCRIPTION
/kind bug

Fixed #2960

**What this PR does / why we need it**:

The speaker mounts the non-secret `metallb-excludel2` ConfigMap with mode `0400`. A non-root speaker cannot read that file, so startup fails with a permission error. Set the mode to `0444` in both the bundled manifest source and Helm chart, regenerate the six derived manifests, and add a Helm policy that prevents either rendered path from regressing.

**Special notes for your reviewer**:

- `memberlist` remains a Secret with its existing `0644` mode; this change only affects the non-secret exclusion ConfigMap.
- Validation included `inv generatemanifests`, `helm lint charts/metallb`, Helm Conftest (42/42), and native plus hardened Helm renders that each produce `defaultMode: 292`.
- A deliberately reverted `256` mode fails the new policy. A rootless Podman check running as UID 65532 was denied at `0400` and read the same config successfully at `0444`.

**Release note**:

```release-note
Fix speaker startup when running as non-root by making the exclude-L2 ConfigMap readable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MetalLB speaker configuration permissions so the exclude-interfaces configuration can be read by all required processes.
  * Added validation to ensure the configuration volume uses the expected read-only permission mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->